### PR TITLE
docs: Add MIT LICENSE file (closes #29)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Fumiya Tanaka
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary

Adds a standard MIT `LICENSE` file at the repository root, resolving #29.

The README already declared the project as MIT-licensed, but no `LICENSE` file existed. Without one, redistribution of released binaries defaults to "all rights reserved" under copyright, creating legal ambiguity for downstream users (e.g. teams redistributing release binaries internally). This change makes the existing intent legally explicit.

## Changes

- Add `LICENSE` with the standard MIT text (`Copyright (c) 2025 Fumiya Tanaka`)

## Verification

- LICENSE text matches the canonical SPDX MIT template (only the copyright line is project-specific)
- No source changes; build/tests are unaffected
- After merge, GitHub should detect and display the repository as MIT-licensed

Closes #29

https://claude.ai/code/session_01QvZLELvJyEvSiR4SadiSt2