### PR TITLE
feat: Auto-update Homebrew tap on release (closes #28)

### DIFF
--- a/.github/scripts/update_formula.py
+++ b/.github/scripts/update_formula.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Bump version and per-architecture sha256 values in a Homebrew formula.
+
+The swift-complexity tap formulae use multi-arch ``on_macos``/``on_linux`` blocks,
+so we cannot rely on a single ``url``/``sha256`` pair. Instead we anchor on each
+release ``url`` line (which encodes the product and platform variant) and rewrite
+the ``sha256`` line that immediately follows it, fetching the canonical checksum
+from the ``.sha256`` asset uploaded alongside every tarball.
+
+Usage: update_formula.py <version> <formula.rb>
+"""
+
+import re
+import sys
+import urllib.request
+
+RELEASE_BASE = "https://github.com/fummicc1/swift-complexity/releases/download"
+
+# Captures e.g. "SwiftComplexityCLI" and "macos-arm64" from a url line that uses
+# the formula's `#{version}` interpolation, so the regex is version-independent.
+URL_RE = re.compile(r"(SwiftComplexity\w+)-#\{version\}-([\w-]+)\.tar\.gz\"")
+VERSION_RE = re.compile(r'version "[^"]*"')
+SHA_RE = re.compile(r'sha256 "[^"]*"')
+
+
+def fetch_sha256(version: str, product: str, variant: str) -> str:
+    url = f"{RELEASE_BASE}/v{version}/{product}-{version}-{variant}.tar.gz.sha256"
+    with urllib.request.urlopen(url) as response:
+        # ".sha256" files are "<digest>  <filename>"; we only need the digest.
+        return response.read().decode().split()[0]
+
+
+def update(version: str, path: str) -> None:
+    with open(path, encoding="utf-8") as f:
+        lines = f.readlines()
+
+    pending: tuple[str, str] | None = None
+    out: list[str] = []
+    for line in lines:
+        if VERSION_RE.search(line) and line.lstrip().startswith("version "):
+            line = VERSION_RE.sub(f'version "{version}"', line)
+
+        match = URL_RE.search(line)
+        if match:
+            pending = (match.group(1), match.group(2))
+        elif pending is not None and "sha256" in line:
+            sha = fetch_sha256(version, *pending)
+            line = SHA_RE.sub(f'sha256 "{sha}"', line)
+            pending = None
+
+        out.append(line)
+
+    with open(path, "w", encoding="utf-8") as f:
+        f.writelines(out)
+
+
+def main() -> None:
+    if len(sys.argv) != 3:
+        sys.exit("Usage: update_formula.py <version> <formula.rb>")
+    update(sys.argv[1], sys.argv[2])
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -375,6 +375,51 @@ jobs:
             artifacts/*.artifactbundle.zip
           generate_release_notes: true
 
+  update-homebrew-tap:
+    name: Update Homebrew Tap
+    runs-on: ubuntu-latest
+    needs: [validate, create-release]
+    # Prereleases must not bump the user-facing tap formula.
+    if: needs.validate.outputs.is_prerelease == 'false'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Generate tap token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.HOMEBREW_TAP_APP_ID }}
+          private-key: ${{ secrets.HOMEBREW_TAP_APP_PRIVATE_KEY }}
+          owner: fummicc1
+          repositories: homebrew-tap
+
+      - name: Checkout tap
+        uses: actions/checkout@v5
+        with:
+          repository: fummicc1/homebrew-tap
+          token: ${{ steps.app-token.outputs.token }}
+          path: homebrew-tap
+
+      - name: Patch formulae
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          python3 .github/scripts/update_formula.py "$VERSION" homebrew-tap/Formula/swift-complexity.rb
+          python3 .github/scripts/update_formula.py "$VERSION" homebrew-tap/Formula/swift-complexity-mcp.rb
+
+      - name: Commit and push
+        working-directory: homebrew-tap
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Formula
+          git diff --staged --quiet || git commit -m "swift-complexity ${VERSION}"
+          git push
+
   notify:
     name: Notify Release
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -395,6 +395,16 @@ jobs:
           owner: fummicc1
           repositories: homebrew-tap
 
+      - name: Resolve bot user id
+        id: bot
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          BOT_NAME: ${{ steps.app-token.outputs.app-slug }}[bot]
+        run: |
+          BOT_ID=$(gh api "/users/${BOT_NAME}" --jq .id)
+          echo "name=${BOT_NAME}" >> "$GITHUB_OUTPUT"
+          echo "email=${BOT_ID}+${BOT_NAME}@users.noreply.github.com" >> "$GITHUB_OUTPUT"
+
       - name: Checkout tap
         uses: actions/checkout@v5
         with:
@@ -413,9 +423,11 @@ jobs:
         working-directory: homebrew-tap
         env:
           VERSION: ${{ needs.validate.outputs.version }}
+          GIT_AUTHOR_NAME: ${{ steps.bot.outputs.name }}
+          GIT_AUTHOR_EMAIL: ${{ steps.bot.outputs.email }}
+          GIT_COMMITTER_NAME: ${{ steps.bot.outputs.name }}
+          GIT_COMMITTER_EMAIL: ${{ steps.bot.outputs.email }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add Formula
           git diff --staged --quiet || git commit -m "swift-complexity ${VERSION}"
           git push

--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ Visit [swift-complexity.fummicc1.dev](https://swift-complexity.fummicc1.dev) to 
 
 ### Installation
 
+On macOS the recommended path is [Homebrew](https://brew.sh):
+
+```bash
+brew install fummicc1/tap/swift-complexity
+```
+
+Or build from source:
+
 ```bash
 git clone https://github.com/fummicc1/swift-complexity
 cd swift-complexity
@@ -136,10 +144,13 @@ The MCP (Model Context Protocol) server exposes complexity analysis as tools for
 ### Installation
 
 ```bash
-# Install MCP server only
+# Homebrew (macOS, recommended)
+brew install fummicc1/tap/swift-complexity-mcp
+
+# Mint: MCP server only
 mint install fummicc1/swift-complexity SwiftComplexityMCP
 
-# Or install both CLI and MCP server at once
+# Mint: both CLI and MCP server at once
 mint install fummicc1/swift-complexity
 ```
 


### PR DESCRIPTION
## Summary

Completes the `brew install fummicc1/tap/swift-complexity` distribution requested in #28.

The tap repository `fummicc1/homebrew-tap` and its formulae (`swift-complexity.rb` / `swift-complexity-mcp.rb`) were already bootstrapped manually for v0.1.0, but this repository was missing (1) a mechanism to keep the formulae in sync with every release, and (2) `brew install` instructions in the README. This PR fills both gaps.

## Changes

- **`.github/scripts/update_formula.py`** (new): Rewrites the `version` and per-architecture `sha256` fields by fetching the `.sha256` assets attached to the release. It anchors on each formula `url` line to map the immediately following `sha256` line, so it handles the multi-arch `on_macos`/`on_linux` block layout without positional fragility. Standard library only.
- **`.github/workflows/release.yml`**: Adds an `update-homebrew-tap` job. It runs after `create-release`, **only for non-prereleases**. It checks out the tap with a GitHub App token (not a PAT), updates both formulae via the script, then commits & pushes.
- **`README.md`**: Documents `brew install` in the CLI and MCP Installation sections.

## Prerequisites (post-merge user action ⚠️)

The auto-update job requires the following, which cannot be configured in code:

1. Create a **GitHub App** owned by fummicc1 with `Contents: Read and write` permission, installed on `fummicc1/homebrew-tap`.
2. Register the secrets **`HOMEBREW_TAP_APP_ID`** and **`HOMEBREW_TAP_APP_PRIVATE_KEY`** in this repository.

If unset, only this job fails; the release itself (`create-release`) is unaffected.

## Verification

- ✅ **Reproduction test**: Running `update_formula.py 0.1.0` against the current tap formulae reproduces the existing `version` and `sha256` values **exactly** (idempotency proves the substitution logic is correct).
- ✅ `python3 ast.parse` confirms valid syntax.
- ✅ `actionlint` parses `release.yml` successfully (warnings are limited to pre-existing steps; the new job is clean).
- ✅ Verified the `brew install` formatting in the README.

https://claude.ai/code/session_01QvZLELvJyEvSiR4SadiSt2