### PR TITLE
feat: Per-type complexity thresholds via YAML config (closes #19)

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "70e81fb720e913b0564eb8bf9ff69abd7176fc01244403dff00784da2ef14630",
+  "originHash" : "4f208c076367e5adc1699a6b28ed552dbc0543544bf0ac788ef8a5c910539317",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -107,6 +107,15 @@
       "state" : {
         "revision" : "7c6ad0fc39d0763e0b699210e4124afd5041c5df",
         "version" : "1.6.4"
+      }
+    },
+    {
+      "identity" : "yams",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/Yams.git",
+      "state" : {
+        "revision" : "3d6871d5b4a5cd519adf233fbb576e0a2af71c17",
+        "version" : "5.4.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -34,6 +34,8 @@ let package = Package(
     .package(url: "https://github.com/swiftlang/indexstore-db", branch: "main"),
     // MCP (Model Context Protocol) server SDK
     .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", from: "0.11.0"),
+    // YAML parser (for per-type complexity threshold configuration)
+    .package(url: "https://github.com/jpsim/Yams.git", from: "5.0.0"),
   ],
   targets: [
     .target(
@@ -43,6 +45,8 @@ let package = Package(
         .product(name: "SwiftParser", package: "swift-syntax"),
         // IndexStore-DB integration (for LCOM4 semantic analysis)
         .product(name: "IndexStoreDB", package: "indexstore-db"),
+        // YAML decoding for per-type threshold configuration
+        .product(name: "Yams", package: "Yams"),
       ],
       path: "Sources/SwiftComplexityCore",
     ),

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A command-line tool to analyze Swift code complexity and quality metrics using s
 - **Xcode Integration**: Seamless integration with Xcode via Build Tool Plugin for complexity feedback during build phase
 - **Xcode Diagnostics**: Display complexity warnings and errors directly in Xcode editor with accurate line numbers
 - **Configurable Thresholds**: Set custom complexity thresholds via Xcode Build Settings or environment variables
+- **Per-Type Thresholds**: Assign different thresholds to types by name (prefix/suffix) via a `.swift-complexity.yml` config — e.g. stricter limits for `*Repository`, looser for `*UseCase`
 - **Exit Code Integration**: Returns exit code 1 when complexity thresholds are exceeded, perfect for CI/CD pipelines
 - **Multiple Output Formats**: Text, JSON, XML, and Xcode diagnostics output for different use cases
 - **Flexible Analysis**: Single files, directories, or recursive directory analysis
@@ -79,6 +80,38 @@ swift run SwiftComplexityCLI Sources --threshold 15 --recursive
 # Exit code 0: All functions below threshold
 # Exit code 1: One or more functions exceed threshold
 ```
+
+### Per-Type Thresholds
+
+Assign different thresholds per nominal type (class/struct/enum/actor and extensions)
+so each layer or feature gets its own complexity budget. Create a
+`.swift-complexity.yml` (auto-discovered in the current directory, or pass `--config <path>`):
+
+```yaml
+# .swift-complexity.yml
+defaultThreshold: 10            # Fallback for types matching no rule (optional)
+rules:
+  - prefix: Toilet              # Feature grouping (type name prefix)
+    threshold: 12
+  - suffix: Repository          # Layer grouping (type name suffix)
+    threshold: 5
+  - suffix: UseCase
+    threshold: 15
+```
+
+A function's threshold is resolved from its enclosing type name: among all matching
+rules the **strictest (lowest)** wins (e.g. `ToiletRepository` matches `Toilet`=12 and
+`Repository`=5 → **5**). Unmatched types fall back to `--threshold` or `defaultThreshold`.
+
+```bash
+# Auto-discovers .swift-complexity.yml
+swift run SwiftComplexityCLI Sources --recursive
+
+# Explicit config path
+swift run SwiftComplexityCLI Sources --recursive --config config/complexity.yml
+```
+
+See the [Usage Guide](docs/user-guide/usage.md#per-type-complexity-thresholds) for full resolution rules.
 
 ## Supported Complexity Metrics
 
@@ -158,7 +191,7 @@ mint install fummicc1/swift-complexity
 
 | Tool | Description |
 |---|---|
-| `analyze_complexity` | Analyze Swift files/directories on disk (recursive, threshold, LCOM4 support) |
+| `analyze_complexity` | Analyze Swift files/directories on disk (recursive, threshold, per-type thresholds via `config_path`, LCOM4 support) |
 | `analyze_code_string` | Analyze a Swift code string directly without files on disk |
 
 ### Configuration

--- a/Sources/SwiftComplexityCLI/ComplexityCommand.swift
+++ b/Sources/SwiftComplexityCLI/ComplexityCommand.swift
@@ -60,6 +60,14 @@ public struct ComplexityCommand: AsyncParsableCommand {
     )
     public var threshold: Int?
 
+    @Option(
+        name: .long,
+        help:
+            "Path to a per-type threshold config file (YAML). Defaults to .swift-complexity.yml in the current directory if present.",
+        completion: .file(extensions: ["yml", "yaml"])
+    )
+    public var config: String?
+
     @Flag(
         name: .long,
         help: "Show only cyclomatic complexity"
@@ -117,7 +125,10 @@ public struct ComplexityCommand: AsyncParsableCommand {
     public func run() async throws {
         try validateFlags()
         try validateLCOM4Options()
-        logVerboseConfiguration()
+
+        let configuration = try loadConfiguration()
+
+        logVerboseConfiguration(configuration: configuration)
 
         do {
             let analyzer = try createAnalyzer()
@@ -132,13 +143,15 @@ public struct ComplexityCommand: AsyncParsableCommand {
             let results = try await fileProcessor.processFiles(
                 at: paths, options: processingOptions)
 
-            let filteredResults = filterByThreshold(results: results, threshold: threshold)
+            let filteredResults = filterByThreshold(
+                results: results, threshold: threshold, configuration: configuration)
 
             let outputOptions = OutputOptions(
                 showCyclomaticOnly: cyclomaticOnly,
                 showCognitiveOnly: cognitiveOnly,
                 showLCOM4: lcom4,
-                threshold: threshold
+                threshold: threshold,
+                thresholdConfiguration: configuration
             )
 
             let formatter = OutputFormatter()
@@ -147,12 +160,17 @@ public struct ComplexityCommand: AsyncParsableCommand {
 
             print(output)
 
-            if let threshold = threshold,
-                hasExceededThreshold(results: results, threshold: threshold)
+            if threshold != nil || !configuration.isEmpty,
+                hasExceededThreshold(
+                    results: results, threshold: threshold, configuration: configuration)
             {
                 throw ExitCode(1)
             }
 
+        } catch let exitCode as ExitCode {
+            // Re-throw threshold/exit signals so ArgumentParser sets the exit code
+            // without wrapping them into an "unexpected error" message.
+            throw exitCode
         } catch let error as FileProcessorError {
             throw CLIError.processingFailed(error.localizedDescription)
         } catch let error as CLIError {
@@ -160,6 +178,20 @@ public struct ComplexityCommand: AsyncParsableCommand {
             throw ExitCode.failure
         } catch {
             throw CLIError.unexpectedError(error.localizedDescription)
+        }
+    }
+
+    /// Loads per-type threshold configuration from `--config` if provided,
+    /// otherwise auto-discovers `.swift-complexity.yml` in the current directory.
+    private func loadConfiguration() throws -> ThresholdConfiguration {
+        do {
+            if let config {
+                return try ThresholdConfiguration.load(fromFileAtPath: config)
+            }
+            return try ThresholdConfiguration.discover() ?? .empty
+        } catch let error as ThresholdConfiguration.LoadError {
+            print("Error: \(error.localizedDescription)")
+            throw ExitCode.failure
         }
     }
 
@@ -193,7 +225,7 @@ public struct ComplexityCommand: AsyncParsableCommand {
     }
 
     /// Logs verbose configuration
-    private func logVerboseConfiguration() {
+    private func logVerboseConfiguration(configuration: ThresholdConfiguration) {
         guard verbose else { return }
 
         print("swift-complexity v\(Self.configuration.version)")
@@ -207,6 +239,12 @@ public struct ComplexityCommand: AsyncParsableCommand {
         }
         if !exclude.isEmpty { print("Exclude patterns: \(exclude.joined(separator: ", "))") }
         if let t = threshold { print("Complexity threshold: \(t)") }
+        if !configuration.isEmpty {
+            if let defaultThreshold = configuration.defaultThreshold {
+                print("Per-type config default threshold: \(defaultThreshold)")
+            }
+            print("Per-type config rules: \(configuration.rules.count)")
+        }
     }
 
     /// Creates a ComplexityAnalyzer instance
@@ -223,15 +261,17 @@ public struct ComplexityCommand: AsyncParsableCommand {
 
     // MARK: - Private Methods
 
-    private func filterByThreshold(results: [ComplexityResult], threshold: Int?)
-        -> [ComplexityResult]
-    {
-        guard let threshold = threshold else { return results }
+    private func filterByThreshold(
+        results: [ComplexityResult],
+        threshold: Int?,
+        configuration: ThresholdConfiguration
+    ) -> [ComplexityResult] {
+        // No filtering when neither a global threshold nor any config rule is set.
+        guard threshold != nil || !configuration.isEmpty else { return results }
 
         return results.compactMap { result in
             let filteredFunctions = result.functions.filter { function in
-                function.cyclomaticComplexity >= threshold
-                    || function.cognitiveComplexity >= threshold
+                configuration.isExceeded(function, fallback: threshold)
             }
 
             // For LCOM4, filter classes with low cohesion (LCOM4 >= 3)
@@ -252,12 +292,14 @@ public struct ComplexityCommand: AsyncParsableCommand {
         }
     }
 
-    private func hasExceededThreshold(results: [ComplexityResult], threshold: Int) -> Bool {
+    private func hasExceededThreshold(
+        results: [ComplexityResult],
+        threshold: Int?,
+        configuration: ThresholdConfiguration
+    ) -> Bool {
         for result in results {
             for function in result.functions {
-                if function.cyclomaticComplexity >= threshold
-                    || function.cognitiveComplexity >= threshold
-                {
+                if configuration.isExceeded(function, fallback: threshold) {
                     return true
                 }
             }

--- a/Sources/SwiftComplexityCore/Analysis/ComplexityAnalyzer.swift
+++ b/Sources/SwiftComplexityCore/Analysis/ComplexityAnalyzer.swift
@@ -53,7 +53,8 @@ public actor ComplexityAnalyzer: ComplexityAnalyzing {
                 signature: function.signature,
                 cyclomaticComplexity: cyclomaticComplexity,
                 cognitiveComplexity: cognitiveComplexity,
-                location: function.location
+                location: function.location,
+                enclosingTypeName: function.enclosingTypeName
             )
 
             functionComplexities.append(functionComplexity)

--- a/Sources/SwiftComplexityCore/Analysis/FunctionDetector.swift
+++ b/Sources/SwiftComplexityCore/Analysis/FunctionDetector.swift
@@ -6,12 +6,21 @@ struct DetectedFunction {
     let signature: String
     let body: CodeBlockSyntax?
     let location: SourceLocation
+    /// Nearest enclosing nominal type name (or extended type for extensions); nil for free functions.
+    let enclosingTypeName: String?
 
-    init(name: String, signature: String, body: CodeBlockSyntax?, location: SourceLocation) {
+    init(
+        name: String,
+        signature: String,
+        body: CodeBlockSyntax?,
+        location: SourceLocation,
+        enclosingTypeName: String? = nil
+    ) {
         self.name = name
         self.signature = signature
         self.body = body
         self.location = location
+        self.enclosingTypeName = enclosingTypeName
     }
 }
 
@@ -39,7 +48,8 @@ class FunctionDetector: SyntaxVisitor {
             name: name,
             signature: signature,
             body: node.body,
-            location: location
+            location: location,
+            enclosingTypeName: enclosingTypeName(of: node)
         )
 
         detectedFunctions.append(detectedFunction)
@@ -56,7 +66,8 @@ class FunctionDetector: SyntaxVisitor {
             name: name,
             signature: signature,
             body: node.body,
-            location: location
+            location: location,
+            enclosingTypeName: enclosingTypeName(of: node)
         )
 
         detectedFunctions.append(detectedFunction)
@@ -73,7 +84,8 @@ class FunctionDetector: SyntaxVisitor {
             name: name,
             signature: signature,
             body: node.body,
-            location: location
+            location: location,
+            enclosingTypeName: enclosingTypeName(of: node)
         )
 
         detectedFunctions.append(detectedFunction)
@@ -116,7 +128,8 @@ class FunctionDetector: SyntaxVisitor {
             name: name,
             signature: signature,
             body: node.body,
-            location: location
+            location: location,
+            enclosingTypeName: enclosingTypeName(of: node)
         )
 
         detectedFunctions.append(detectedFunction)
@@ -206,10 +219,39 @@ class FunctionDetector: SyntaxVisitor {
             name: propertyName,
             signature: signature,
             body: codeBlock,
-            location: location
+            location: location,
+            enclosingTypeName: enclosingTypeName(of: variable)
         )
 
         detectedFunctions.append(detectedFunction)
+    }
+
+    /// Walks up the parent chain to find the nearest enclosing nominal type name.
+    ///
+    /// Returns the type name for class/struct/enum/actor, the extended type for
+    /// extensions, or `nil` for free (top-level) functions. For nested types, the
+    /// nearest (innermost) enclosing type wins.
+    private func enclosingTypeName(of node: some SyntaxProtocol) -> String? {
+        var current = node.parent
+        while let parent = current {
+            if let decl = parent.as(ClassDeclSyntax.self) {
+                return decl.name.text
+            }
+            if let decl = parent.as(StructDeclSyntax.self) {
+                return decl.name.text
+            }
+            if let decl = parent.as(EnumDeclSyntax.self) {
+                return decl.name.text
+            }
+            if let decl = parent.as(ActorDeclSyntax.self) {
+                return decl.name.text
+            }
+            if let decl = parent.as(ExtensionDeclSyntax.self) {
+                return decl.extendedType.trimmedDescription
+            }
+            current = parent.parent
+        }
+        return nil
     }
 
     private func findParentPropertyName(from node: AccessorDeclSyntax) -> String? {

--- a/Sources/SwiftComplexityCore/Models/FunctionComplexity.swift
+++ b/Sources/SwiftComplexityCore/Models/FunctionComplexity.swift
@@ -17,18 +17,27 @@ public struct FunctionComplexity: Codable, Hashable, Sendable {
     /// Location in source code
     public let location: SourceLocation
 
+    /// Name of the nearest enclosing nominal type (class/struct/enum/actor) or the
+    /// extended type for extensions. `nil` for free (top-level) functions.
+    ///
+    /// Used to resolve per-type complexity thresholds. Optional for backward
+    /// compatibility with previously encoded results.
+    public let enclosingTypeName: String?
+
     public init(
         name: String,
         signature: String,
         cyclomaticComplexity: Int,
         cognitiveComplexity: Int,
-        location: SourceLocation
+        location: SourceLocation,
+        enclosingTypeName: String? = nil
     ) {
         self.name = name
         self.signature = signature
         self.cyclomaticComplexity = cyclomaticComplexity
         self.cognitiveComplexity = cognitiveComplexity
         self.location = location
+        self.enclosingTypeName = enclosingTypeName
     }
 }
 

--- a/Sources/SwiftComplexityCore/Models/ThresholdConfiguration.swift
+++ b/Sources/SwiftComplexityCore/Models/ThresholdConfiguration.swift
@@ -1,0 +1,155 @@
+import Foundation
+import Yams
+
+/// A single per-type complexity threshold rule.
+///
+/// A rule matches a nominal type by its name using an optional `prefix` and/or
+/// `suffix`. When both are specified, both must match. A rule with neither
+/// `prefix` nor `suffix` is considered invalid and never matches, because it
+/// would otherwise apply to every type and make the configuration ambiguous.
+public struct ThresholdRule: Codable, Sendable, Hashable {
+    /// Match types whose name starts with this string (e.g. `Toilet` → `ToiletRepository`).
+    public let prefix: String?
+
+    /// Match types whose name ends with this string (e.g. `Repository` → `UserRepository`).
+    public let suffix: String?
+
+    /// Complexity threshold applied to functions of the matched type.
+    public let threshold: Int
+
+    public init(prefix: String? = nil, suffix: String? = nil, threshold: Int) {
+        self.prefix = prefix
+        self.suffix = suffix
+        self.threshold = threshold
+    }
+
+    /// Returns whether this rule matches the given type name.
+    ///
+    /// A rule without any `prefix` or `suffix` never matches: such a rule has no
+    /// selector, so applying it to all types would be surprising.
+    public func matches(typeName: String) -> Bool {
+        guard prefix != nil || suffix != nil else { return false }
+
+        let prefixMatches = prefix.map { typeName.hasPrefix($0) } ?? true
+        let suffixMatches = suffix.map { typeName.hasSuffix($0) } ?? true
+        return prefixMatches && suffixMatches
+    }
+}
+
+/// Per-type complexity threshold configuration.
+///
+/// Loaded from a `.swift-complexity.yml` file. Functions are flagged using a
+/// threshold resolved from their enclosing type name: among all matching rules
+/// the strictest (lowest) threshold wins. Types matching no rule fall back to
+/// the caller-provided value (typically the CLI `--threshold`) or, failing that,
+/// `defaultThreshold`.
+public struct ThresholdConfiguration: Codable, Sendable, Equatable {
+    /// Fallback threshold for types/functions that match no rule. Optional.
+    public let defaultThreshold: Int?
+
+    /// Ordered list of per-type threshold rules.
+    public let rules: [ThresholdRule]
+
+    public init(defaultThreshold: Int? = nil, rules: [ThresholdRule] = []) {
+        self.defaultThreshold = defaultThreshold
+        self.rules = rules
+    }
+
+    /// An empty configuration that defines no rules. Resolution then depends
+    /// solely on the caller-provided fallback, preserving legacy behavior.
+    public static let empty = ThresholdConfiguration()
+
+    /// Whether this configuration carries no rules and no default threshold.
+    public var isEmpty: Bool {
+        defaultThreshold == nil && rules.isEmpty
+    }
+
+    /// Resolves the effective complexity threshold for a function whose
+    /// enclosing type is `typeName`.
+    ///
+    /// - Parameters:
+    ///   - typeName: The nearest enclosing nominal type name, or `nil` for a
+    ///     free (top-level) function.
+    ///   - fallback: A caller-supplied threshold (e.g. the CLI `--threshold`)
+    ///     that overrides `defaultThreshold` for unmatched types.
+    /// - Returns: The strictest matching rule threshold, otherwise
+    ///   `fallback ?? defaultThreshold`, otherwise `nil` (no threshold → never flagged).
+    public func threshold(forTypeName typeName: String?, fallback: Int?) -> Int? {
+        if let typeName {
+            let matched = rules.filter { $0.matches(typeName: typeName) }.map(\.threshold)
+            if let strictest = matched.min() {
+                return strictest
+            }
+        }
+        return fallback ?? defaultThreshold
+    }
+
+    /// Whether the given function exceeds its effective threshold.
+    ///
+    /// Mirrors the legacy semantics: a function is flagged when either its
+    /// cyclomatic or cognitive complexity reaches the threshold.
+    public func isExceeded(_ function: FunctionComplexity, fallback: Int?) -> Bool {
+        guard
+            let threshold = threshold(forTypeName: function.enclosingTypeName, fallback: fallback)
+        else {
+            return false
+        }
+        return function.cyclomaticComplexity >= threshold
+            || function.cognitiveComplexity >= threshold
+    }
+
+    // MARK: - Loading
+
+    /// Errors thrown while loading a threshold configuration.
+    public enum LoadError: Error, LocalizedError {
+        case fileNotFound(String)
+        case decodingFailed(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .fileNotFound(let path):
+                return "Configuration file not found: \(path)"
+            case .decodingFailed(let message):
+                return "Failed to decode configuration: \(message)"
+            }
+        }
+    }
+
+    /// Loads configuration from a YAML file at the given path.
+    public static func load(fromFileAtPath path: String) throws -> ThresholdConfiguration {
+        let url = URL(fileURLWithPath: path)
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            throw LoadError.fileNotFound(path)
+        }
+        return try load(from: url)
+    }
+
+    /// Loads configuration from a YAML file URL.
+    public static func load(from url: URL) throws -> ThresholdConfiguration {
+        let yaml = try String(contentsOf: url, encoding: .utf8)
+        do {
+            return try YAMLDecoder().decode(ThresholdConfiguration.self, from: yaml)
+        } catch {
+            throw LoadError.decodingFailed(error.localizedDescription)
+        }
+    }
+
+    /// Default configuration file name searched in the current working directory.
+    public static let defaultFileName = ".swift-complexity.yml"
+
+    /// Discovers a configuration file in `directory` (default: current directory),
+    /// trying `.swift-complexity.yml` then `.swift-complexity.yaml`. Returns `nil`
+    /// when no file is present.
+    public static func discover(in directory: String = FileManager.default.currentDirectoryPath)
+        throws -> ThresholdConfiguration?
+    {
+        let candidates = [".swift-complexity.yml", ".swift-complexity.yaml"]
+        for candidate in candidates {
+            let url = URL(fileURLWithPath: directory).appendingPathComponent(candidate)
+            if FileManager.default.fileExists(atPath: url.path) {
+                return try load(from: url)
+            }
+        }
+        return nil
+    }
+}

--- a/Sources/SwiftComplexityCore/Output/OutputFormatter.swift
+++ b/Sources/SwiftComplexityCore/Output/OutputFormatter.swift
@@ -5,17 +5,22 @@ public struct OutputOptions {
     public let showCognitiveOnly: Bool
     public let showLCOM4: Bool
     public let threshold: Int?
+    /// Per-type threshold configuration. When set, Xcode diagnostics resolve a
+    /// per-function threshold from the function's enclosing type.
+    public let thresholdConfiguration: ThresholdConfiguration?
 
     public init(
         showCyclomaticOnly: Bool = false,
         showCognitiveOnly: Bool = false,
         showLCOM4: Bool = false,
-        threshold: Int? = nil
+        threshold: Int? = nil,
+        thresholdConfiguration: ThresholdConfiguration? = nil
     ) {
         self.showCyclomaticOnly = showCyclomaticOnly
         self.showCognitiveOnly = showCognitiveOnly
         self.showLCOM4 = showLCOM4
         self.threshold = threshold
+        self.thresholdConfiguration = thresholdConfiguration
     }
 }
 
@@ -210,6 +215,9 @@ public class OutputFormatter {
                 for function in result.functions {
                     xml += "    <function name=\"\(xmlEscape(function.name))\" "
                     xml += "signature=\"\(xmlEscape(function.signature))\" "
+                    if let enclosingTypeName = function.enclosingTypeName {
+                        xml += "enclosing-type=\"\(xmlEscape(enclosingTypeName))\" "
+                    }
                     xml += "line=\"\(function.location.line)\" "
                     xml += "column=\"\(function.location.column)\">\n"
                     xml +=
@@ -281,11 +289,19 @@ public class OutputFormatter {
     private func formatAsXcodeDiagnostics(results: [ComplexityResult], options: OutputOptions)
         -> String
     {
-        let threshold = options.threshold ?? 10
+        let configuration = options.thresholdConfiguration
 
         let complexityDiagnostics = results.flatMap { result in
-            result.functions.compactMap { function in
-                createComplexityDiagnostic(for: function, in: result.filePath, threshold: threshold)
+            result.functions.compactMap { function -> String? in
+                // Resolve a per-function threshold from the enclosing type, falling
+                // back to --threshold and finally the Xcode default of 10.
+                let resolved =
+                    configuration?.threshold(
+                        forTypeName: function.enclosingTypeName, fallback: options.threshold)
+                    ?? options.threshold
+                let threshold = resolved ?? 10
+                return createComplexityDiagnostic(
+                    for: function, in: result.filePath, threshold: threshold)
             }
         }
 

--- a/Sources/SwiftComplexityCore/Output/OutputFormatter.swift
+++ b/Sources/SwiftComplexityCore/Output/OutputFormatter.swift
@@ -206,71 +206,90 @@ public class OutputFormatter {
     private func formatAsXML(results: [ComplexityResult], options: OutputOptions) -> String {
         var xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
         xml += "<complexity-report>\n"
-
         for result in results {
-            xml += "  <file path=\"\(xmlEscape(result.filePath))\">\n"
+            xml += xmlFileElement(result)
+        }
+        xml += "</complexity-report>\n"
+        return xml
+    }
 
-            // Function complexity
-            if !result.functions.isEmpty {
-                for function in result.functions {
-                    xml += "    <function name=\"\(xmlEscape(function.name))\" "
-                    xml += "signature=\"\(xmlEscape(function.signature))\" "
-                    if let enclosingTypeName = function.enclosingTypeName {
-                        xml += "enclosing-type=\"\(xmlEscape(enclosingTypeName))\" "
-                    }
-                    xml += "line=\"\(function.location.line)\" "
-                    xml += "column=\"\(function.location.column)\">\n"
-                    xml +=
-                        "      <cyclomatic-complexity>\(function.cyclomaticComplexity)</cyclomatic-complexity>\n"
-                    xml +=
-                        "      <cognitive-complexity>\(function.cognitiveComplexity)</cognitive-complexity>\n"
-                    xml += "    </function>\n"
-                }
+    private func xmlFileElement(_ result: ComplexityResult) -> String {
+        var xml = "  <file path=\"\(xmlEscape(result.filePath))\">\n"
 
-                xml += "    <summary>\n"
-                xml += "      <total-functions>\(result.summary.totalFunctions)</total-functions>\n"
-                xml +=
-                    "      <average-cyclomatic-complexity>\(result.summary.averageCyclomaticComplexity)</average-cyclomatic-complexity>\n"
-                xml +=
-                    "      <average-cognitive-complexity>\(result.summary.averageCognitiveComplexity)</average-cognitive-complexity>\n"
-                xml +=
-                    "      <max-cyclomatic-complexity>\(result.summary.maxCyclomaticComplexity)</max-cyclomatic-complexity>\n"
-                xml +=
-                    "      <max-cognitive-complexity>\(result.summary.maxCognitiveComplexity)</max-cognitive-complexity>\n"
-                xml += "    </summary>\n"
+        // Function complexity
+        if !result.functions.isEmpty {
+            for function in result.functions {
+                xml += xmlFunctionElement(function)
             }
-
-            // Class cohesion (LCOM4)
-            if let classCohesions = result.classCohesions {
-                for cohesion in classCohesions {
-                    xml += "    <class name=\"\(xmlEscape(cohesion.name))\" "
-                    xml += "type=\"\(cohesion.type.rawValue)\" "
-                    xml += "line=\"\(cohesion.location.line)\" "
-                    xml += "column=\"\(cohesion.location.column)\">\n"
-                    xml += "      <lcom4>\(cohesion.lcom4)</lcom4>\n"
-                    xml += "      <method-count>\(cohesion.methodCount)</method-count>\n"
-                    xml += "      <property-count>\(cohesion.propertyCount)</property-count>\n"
-                    xml +=
-                        "      <cohesion-level>\(cohesion.cohesionLevel.rawValue)</cohesion-level>\n"
-                    xml += "    </class>\n"
-                }
-
-                if let cohesionSummary = result.cohesionSummary {
-                    xml += "    <cohesion-summary>\n"
-                    xml += "      <total-classes>\(cohesionSummary.totalClasses)</total-classes>\n"
-                    xml +=
-                        "      <average-lcom4>\(cohesionSummary.averageLCOM4)</average-lcom4>\n"
-                    xml += "      <max-lcom4>\(cohesionSummary.maxLCOM4)</max-lcom4>\n"
-                    xml +=
-                        "      <low-cohesion-classes>\(cohesionSummary.classesWithLowCohesion)</low-cohesion-classes>\n"
-                    xml += "    </cohesion-summary>\n"
-                }
-            }
-
-            xml += "  </file>\n"
+            xml += xmlFunctionSummary(result.summary)
         }
 
-        xml += "</complexity-report>\n"
+        // Class cohesion (LCOM4)
+        if let classCohesions = result.classCohesions {
+            for cohesion in classCohesions {
+                xml += xmlClassElement(cohesion)
+            }
+            if let cohesionSummary = result.cohesionSummary {
+                xml += xmlCohesionSummary(cohesionSummary)
+            }
+        }
+
+        xml += "  </file>\n"
+        return xml
+    }
+
+    private func xmlFunctionElement(_ function: FunctionComplexity) -> String {
+        var xml = "    <function name=\"\(xmlEscape(function.name))\" "
+        xml += "signature=\"\(xmlEscape(function.signature))\" "
+        if let enclosingTypeName = function.enclosingTypeName {
+            xml += "enclosing-type=\"\(xmlEscape(enclosingTypeName))\" "
+        }
+        xml += "line=\"\(function.location.line)\" "
+        xml += "column=\"\(function.location.column)\">\n"
+        xml +=
+            "      <cyclomatic-complexity>\(function.cyclomaticComplexity)</cyclomatic-complexity>\n"
+        xml +=
+            "      <cognitive-complexity>\(function.cognitiveComplexity)</cognitive-complexity>\n"
+        xml += "    </function>\n"
+        return xml
+    }
+
+    private func xmlFunctionSummary(_ summary: FileSummary) -> String {
+        var xml = "    <summary>\n"
+        xml += "      <total-functions>\(summary.totalFunctions)</total-functions>\n"
+        xml +=
+            "      <average-cyclomatic-complexity>\(summary.averageCyclomaticComplexity)</average-cyclomatic-complexity>\n"
+        xml +=
+            "      <average-cognitive-complexity>\(summary.averageCognitiveComplexity)</average-cognitive-complexity>\n"
+        xml +=
+            "      <max-cyclomatic-complexity>\(summary.maxCyclomaticComplexity)</max-cyclomatic-complexity>\n"
+        xml +=
+            "      <max-cognitive-complexity>\(summary.maxCognitiveComplexity)</max-cognitive-complexity>\n"
+        xml += "    </summary>\n"
+        return xml
+    }
+
+    private func xmlClassElement(_ cohesion: ClassCohesion) -> String {
+        var xml = "    <class name=\"\(xmlEscape(cohesion.name))\" "
+        xml += "type=\"\(cohesion.type.rawValue)\" "
+        xml += "line=\"\(cohesion.location.line)\" "
+        xml += "column=\"\(cohesion.location.column)\">\n"
+        xml += "      <lcom4>\(cohesion.lcom4)</lcom4>\n"
+        xml += "      <method-count>\(cohesion.methodCount)</method-count>\n"
+        xml += "      <property-count>\(cohesion.propertyCount)</property-count>\n"
+        xml += "      <cohesion-level>\(cohesion.cohesionLevel.rawValue)</cohesion-level>\n"
+        xml += "    </class>\n"
+        return xml
+    }
+
+    private func xmlCohesionSummary(_ summary: CohesionSummary) -> String {
+        var xml = "    <cohesion-summary>\n"
+        xml += "      <total-classes>\(summary.totalClasses)</total-classes>\n"
+        xml += "      <average-lcom4>\(summary.averageLCOM4)</average-lcom4>\n"
+        xml += "      <max-lcom4>\(summary.maxLCOM4)</max-lcom4>\n"
+        xml +=
+            "      <low-cohesion-classes>\(summary.classesWithLowCohesion)</low-cohesion-classes>\n"
+        xml += "    </cohesion-summary>\n"
         return xml
     }
 

--- a/Sources/SwiftComplexityMCP/Handlers/AnalyzeComplexityHandler.swift
+++ b/Sources/SwiftComplexityMCP/Handlers/AnalyzeComplexityHandler.swift
@@ -20,6 +20,7 @@ enum AnalyzeComplexityHandler {
         let recursive = ParamExtractor.bool("recursive", from: arguments)
         let exclude = ParamExtractor.stringArray("exclude", from: arguments) ?? []
         let threshold = ParamExtractor.int("threshold", from: arguments)
+        let configPath = ParamExtractor.string("config_path", from: arguments)
         let formatString = ParamExtractor.string("format", from: arguments) ?? "json"
         let cyclomaticOnly = ParamExtractor.bool("cyclomatic_only", from: arguments)
         let cognitiveOnly = ParamExtractor.bool("cognitive_only", from: arguments)
@@ -43,6 +44,19 @@ enum AnalyzeComplexityHandler {
                     .text("Error: 'index_store_path' is required when 'lcom4' is true")
                 ],
                 isError: true)
+        }
+
+        // Load per-type threshold configuration (if provided)
+        let configuration: ThresholdConfiguration
+        if let configPath {
+            do {
+                configuration = try ThresholdConfiguration.load(fromFileAtPath: configPath)
+            } catch {
+                return .init(
+                    content: [.text("Error: \(error.localizedDescription)")], isError: true)
+            }
+        } else {
+            configuration = .empty
         }
 
         let format: OutputFormat = formatString == "text" ? .text : .json
@@ -71,9 +85,10 @@ enum AnalyzeComplexityHandler {
             var results = try await fileProcessor.processFiles(
                 at: paths, options: processingOptions)
 
-            // Apply threshold filtering
-            if let threshold = threshold {
-                results = filterByThreshold(results: results, threshold: threshold)
+            // Apply threshold filtering (per-type config and/or global threshold)
+            if threshold != nil || !configuration.isEmpty {
+                results = filterByThreshold(
+                    results: results, threshold: threshold, configuration: configuration)
             }
 
             // Format output
@@ -81,7 +96,8 @@ enum AnalyzeComplexityHandler {
                 showCyclomaticOnly: cyclomaticOnly,
                 showCognitiveOnly: cognitiveOnly,
                 showLCOM4: lcom4,
-                threshold: threshold
+                threshold: threshold,
+                thresholdConfiguration: configuration
             )
 
             let formatter = OutputFormatter()
@@ -94,13 +110,14 @@ enum AnalyzeComplexityHandler {
         }
     }
 
-    private static func filterByThreshold(results: [ComplexityResult], threshold: Int)
-        -> [ComplexityResult]
-    {
+    private static func filterByThreshold(
+        results: [ComplexityResult],
+        threshold: Int?,
+        configuration: ThresholdConfiguration
+    ) -> [ComplexityResult] {
         results.compactMap { result in
             let filteredFunctions = result.functions.filter { function in
-                function.cyclomaticComplexity >= threshold
-                    || function.cognitiveComplexity >= threshold
+                configuration.isExceeded(function, fallback: threshold)
             }
 
             // Threshold only filters functions; cohesion data is always preserved

--- a/Sources/SwiftComplexityMCP/ToolDefinitions.swift
+++ b/Sources/SwiftComplexityMCP/ToolDefinitions.swift
@@ -34,7 +34,14 @@ enum ToolDefinitions {
                 "threshold": .object([
                     "type": .string("integer"),
                     "description": .string(
-                        "Complexity threshold — only return functions at or above this value"),
+                        "Complexity threshold — only return functions at or above this value. Used as the fallback for types that match no rule in config_path."
+                    ),
+                ]),
+                "config_path": .object([
+                    "type": .string("string"),
+                    "description": .string(
+                        "Path to a per-type threshold config file (YAML, e.g. .swift-complexity.yml). Resolves a per-function threshold from the enclosing type name; the strictest matching rule wins."
+                    ),
                 ]),
                 "format": .object([
                     "type": .string("string"),

--- a/Tests/SwiftComplexityCLITests/SwiftComplexityCLITests.swift
+++ b/Tests/SwiftComplexityCLITests/SwiftComplexityCLITests.swift
@@ -151,3 +151,31 @@ struct CLIValidationTests {
         }
     }
 }
+
+// MARK: - Config Option Tests
+
+@Suite("CLI Config Option", .tags(.cli))
+struct CLIConfigOptionTests {
+
+    @Test("--config option is parsed")
+    func configOptionParsed() throws {
+        let command = try ComplexityCommand.parse(["Sources", "--config", "rules.yml"])
+        #expect(command.config == "rules.yml")
+        #expect(command.paths == ["Sources"])
+    }
+
+    @Test("--config defaults to nil when absent")
+    func configDefaultsToNil() throws {
+        let command = try ComplexityCommand.parse(["Sources"])
+        #expect(command.config == nil)
+    }
+
+    @Test("--config and --threshold can be combined")
+    func configWithThreshold() throws {
+        let command = try ComplexityCommand.parse([
+            "Sources", "--config", "rules.yml", "--threshold", "10",
+        ])
+        #expect(command.config == "rules.yml")
+        #expect(command.threshold == 10)
+    }
+}

--- a/Tests/SwiftComplexityCoreTests/EnclosingTypeDetectionTests.swift
+++ b/Tests/SwiftComplexityCoreTests/EnclosingTypeDetectionTests.swift
@@ -1,0 +1,114 @@
+import SwiftParser
+import SwiftSyntax
+import Testing
+
+@testable import SwiftComplexityCore
+
+@Suite("Enclosing type detection")
+struct EnclosingTypeDetectionTests {
+
+    /// Parses `source` and returns detected functions keyed by name.
+    private func detect(_ source: String) -> [String: DetectedFunction] {
+        let sourceFile = Parser.parse(source: source)
+        let detector = FunctionDetector(viewMode: .sourceAccurate)
+        let functions = detector.detectFunctions(in: sourceFile)
+        return Dictionary(functions.map { ($0.name, $0) }, uniquingKeysWith: { first, _ in first })
+    }
+
+    @Test("Method in a class reports the class name")
+    func classMethod() {
+        let functions = detect(
+            """
+            class UserRepository {
+                func fetch() {}
+            }
+            """)
+        #expect(functions["fetch"]?.enclosingTypeName == "UserRepository")
+    }
+
+    @Test("Method in a struct reports the struct name")
+    func structMethod() {
+        let functions = detect(
+            """
+            struct ToiletUseCase {
+                func run() {}
+            }
+            """)
+        #expect(functions["run"]?.enclosingTypeName == "ToiletUseCase")
+    }
+
+    @Test("Method in an enum reports the enum name")
+    func enumMethod() {
+        let functions = detect(
+            """
+            enum Router {
+                func navigate() {}
+            }
+            """)
+        #expect(functions["navigate"]?.enclosingTypeName == "Router")
+    }
+
+    @Test("Method in an actor reports the actor name")
+    func actorMethod() {
+        let functions = detect(
+            """
+            actor SessionStore {
+                func save() {}
+            }
+            """)
+        #expect(functions["save"]?.enclosingTypeName == "SessionStore")
+    }
+
+    @Test("Method in an extension reports the extended type")
+    func extensionMethod() {
+        let functions = detect(
+            """
+            extension UserClient {
+                func login() {}
+            }
+            """)
+        #expect(functions["login"]?.enclosingTypeName == "UserClient")
+    }
+
+    @Test("Free function has no enclosing type")
+    func freeFunction() {
+        let functions = detect("func globalHelper() {}")
+        #expect(functions["globalHelper"] != nil)
+        #expect(functions["globalHelper"]?.enclosingTypeName == nil)
+    }
+
+    @Test("Nested type uses the nearest enclosing type")
+    func nestedType() {
+        let functions = detect(
+            """
+            struct Outer {
+                struct Inner {
+                    func work() {}
+                }
+            }
+            """)
+        #expect(functions["work"]?.enclosingTypeName == "Inner")
+    }
+
+    @Test("Initializer reports its enclosing type")
+    func initializer() {
+        let functions = detect(
+            """
+            class PaymentRepository {
+                init() {}
+            }
+            """)
+        #expect(functions["init"]?.enclosingTypeName == "PaymentRepository")
+    }
+
+    @Test("Computed property accessor reports its enclosing type")
+    func computedProperty() {
+        let functions = detect(
+            """
+            struct AccountRepository {
+                var balance: Int { 0 }
+            }
+            """)
+        #expect(functions["balance"]?.enclosingTypeName == "AccountRepository")
+    }
+}

--- a/Tests/SwiftComplexityCoreTests/ThresholdConfigurationTests.swift
+++ b/Tests/SwiftComplexityCoreTests/ThresholdConfigurationTests.swift
@@ -1,0 +1,207 @@
+import Foundation
+import Testing
+
+@testable import SwiftComplexityCore
+
+@Suite("ThresholdConfiguration")
+struct ThresholdConfigurationTests {
+
+    // MARK: - Rule Matching
+
+    @Suite("Rule matching")
+    struct RuleMatchingTests {
+        @Test("Prefix-only rule matches by prefix")
+        func prefixOnly() {
+            let rule = ThresholdRule(prefix: "Toilet", threshold: 12)
+            #expect(rule.matches(typeName: "ToiletRepository"))
+            #expect(rule.matches(typeName: "ToiletUseCase"))
+            #expect(!rule.matches(typeName: "UserRepository"))
+        }
+
+        @Test("Suffix-only rule matches by suffix")
+        func suffixOnly() {
+            let rule = ThresholdRule(suffix: "Repository", threshold: 5)
+            #expect(rule.matches(typeName: "ToiletRepository"))
+            #expect(rule.matches(typeName: "UserRepository"))
+            #expect(!rule.matches(typeName: "ToiletUseCase"))
+        }
+
+        @Test("Prefix + suffix rule requires both")
+        func prefixAndSuffix() {
+            let rule = ThresholdRule(prefix: "User", suffix: "UseCase", threshold: 7)
+            #expect(rule.matches(typeName: "UserUseCase"))
+            #expect(!rule.matches(typeName: "UserRepository"))
+            #expect(!rule.matches(typeName: "AdminUseCase"))
+        }
+
+        @Test("Rule without prefix or suffix never matches")
+        func emptyRuleNeverMatches() {
+            let rule = ThresholdRule(threshold: 3)
+            #expect(!rule.matches(typeName: "Anything"))
+            #expect(!rule.matches(typeName: ""))
+        }
+    }
+
+    // MARK: - Threshold Resolution
+
+    @Suite("Threshold resolution")
+    struct ResolutionTests {
+        private let config = ThresholdConfiguration(
+            defaultThreshold: 10,
+            rules: [
+                ThresholdRule(prefix: "Toilet", threshold: 12),
+                ThresholdRule(suffix: "Repository", threshold: 5),
+                ThresholdRule(suffix: "UseCase", threshold: 15),
+            ]
+        )
+
+        @Test("Multiple matches pick the strictest (lowest) threshold")
+        func strictestWins() {
+            // ToiletRepository matches prefix(Toilet=12) and suffix(Repository=5) → 5
+            #expect(config.threshold(forTypeName: "ToiletRepository", fallback: nil) == 5)
+        }
+
+        @Test("Single match uses that rule's threshold (can be looser than default)")
+        func singleMatchAllowsLooser() {
+            // ToiletUseCase matches prefix(Toilet=12) and suffix(UseCase=15) → 12
+            #expect(config.threshold(forTypeName: "ToiletUseCase", fallback: nil) == 12)
+            // PaymentUseCase matches only suffix(UseCase=15) → 15 (looser than default 10)
+            #expect(config.threshold(forTypeName: "PaymentUseCase", fallback: nil) == 15)
+        }
+
+        @Test("Unmatched type falls back to default when no CLI threshold")
+        func unmatchedUsesDefault() {
+            #expect(config.threshold(forTypeName: "SomeService", fallback: nil) == 10)
+        }
+
+        @Test("CLI threshold overrides config default for unmatched types")
+        func cliOverridesDefault() {
+            #expect(config.threshold(forTypeName: "SomeService", fallback: 3) == 3)
+        }
+
+        @Test("Matched rule is not capped by CLI threshold")
+        func matchedIgnoresFallback() {
+            // Even with a stricter CLI fallback, a matched rule wins (15 for UseCase).
+            #expect(config.threshold(forTypeName: "PaymentUseCase", fallback: 3) == 15)
+        }
+
+        @Test("Free function (nil type) uses fallback then default")
+        func freeFunction() {
+            #expect(config.threshold(forTypeName: nil, fallback: nil) == 10)
+            #expect(config.threshold(forTypeName: nil, fallback: 4) == 4)
+        }
+
+        @Test("Empty configuration relies solely on fallback")
+        func emptyConfig() {
+            let empty = ThresholdConfiguration.empty
+            #expect(empty.isEmpty)
+            #expect(empty.threshold(forTypeName: "AnyRepository", fallback: nil) == nil)
+            #expect(empty.threshold(forTypeName: "AnyRepository", fallback: 8) == 8)
+        }
+    }
+
+    // MARK: - isExceeded
+
+    @Suite("isExceeded")
+    struct IsExceededTests {
+        private func function(type: String?, cyclomatic: Int, cognitive: Int) -> FunctionComplexity
+        {
+            FunctionComplexity(
+                name: "f", signature: "func f()",
+                cyclomaticComplexity: cyclomatic, cognitiveComplexity: cognitive,
+                location: SourceLocation(line: 1, column: 1),
+                enclosingTypeName: type
+            )
+        }
+
+        @Test("Function in matched type is flagged at the rule threshold")
+        func flaggedByRule() {
+            let config = ThresholdConfiguration(
+                rules: [ThresholdRule(suffix: "Repository", threshold: 5)])
+            let fn = function(type: "UserRepository", cyclomatic: 5, cognitive: 0)
+            #expect(config.isExceeded(fn, fallback: nil))
+        }
+
+        @Test("Function below the rule threshold is not flagged")
+        func notFlaggedBelowRule() {
+            let config = ThresholdConfiguration(
+                rules: [ThresholdRule(suffix: "Repository", threshold: 8)])
+            let fn = function(type: "UserRepository", cyclomatic: 5, cognitive: 3)
+            #expect(!config.isExceeded(fn, fallback: nil))
+        }
+
+        @Test("Cognitive complexity alone can trigger the flag")
+        func cognitiveTriggers() {
+            let config = ThresholdConfiguration(
+                rules: [ThresholdRule(suffix: "Repository", threshold: 5)])
+            let fn = function(type: "UserRepository", cyclomatic: 1, cognitive: 6)
+            #expect(config.isExceeded(fn, fallback: nil))
+        }
+
+        @Test("No applicable threshold means never flagged")
+        func neverFlaggedWithoutThreshold() {
+            let config = ThresholdConfiguration.empty
+            let fn = function(type: nil, cyclomatic: 99, cognitive: 99)
+            #expect(!config.isExceeded(fn, fallback: nil))
+        }
+    }
+
+    // MARK: - YAML Loading
+
+    @Suite("YAML loading")
+    struct LoadingTests {
+        private func writeTempYAML(_ contents: String) throws -> String {
+            let dir = FileManager.default.temporaryDirectory
+            let url = dir.appendingPathComponent("swift-complexity-test-\(UUID().uuidString).yml")
+            try contents.write(to: url, atomically: true, encoding: .utf8)
+            return url.path
+        }
+
+        @Test("Decodes default threshold and rules from YAML")
+        func decodesYAML() throws {
+            let yaml = """
+                defaultThreshold: 10
+                rules:
+                  - prefix: Toilet
+                    threshold: 12
+                  - suffix: Repository
+                    threshold: 5
+                """
+            let path = try writeTempYAML(yaml)
+            defer { try? FileManager.default.removeItem(atPath: path) }
+
+            let config = try ThresholdConfiguration.load(fromFileAtPath: path)
+            #expect(config.defaultThreshold == 10)
+            #expect(config.rules.count == 2)
+            #expect(config.rules[0].prefix == "Toilet")
+            #expect(config.rules[0].suffix == nil)
+            #expect(config.rules[0].threshold == 12)
+            #expect(config.rules[1].suffix == "Repository")
+            #expect(config.rules[1].threshold == 5)
+        }
+
+        @Test("Decodes config without a default threshold")
+        func decodesWithoutDefault() throws {
+            let yaml = """
+                rules:
+                  - suffix: UseCase
+                    threshold: 15
+                """
+            let path = try writeTempYAML(yaml)
+            defer { try? FileManager.default.removeItem(atPath: path) }
+
+            let config = try ThresholdConfiguration.load(fromFileAtPath: path)
+            #expect(config.defaultThreshold == nil)
+            #expect(config.rules.count == 1)
+            #expect(config.rules[0].threshold == 15)
+        }
+
+        @Test("Missing file throws fileNotFound")
+        func missingFileThrows() {
+            #expect(throws: ThresholdConfiguration.LoadError.self) {
+                _ = try ThresholdConfiguration.load(
+                    fromFileAtPath: "/nonexistent/swift-complexity.yml")
+            }
+        }
+    }
+}

--- a/Tests/SwiftComplexityMCPTests/SwiftComplexityMCPTests.swift
+++ b/Tests/SwiftComplexityMCPTests/SwiftComplexityMCPTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import MCP
 import SwiftComplexityCore
 import Testing
@@ -320,6 +321,87 @@ struct ThresholdFilteringTests {
         #expect(output.contains("complex"))
         // Cohesion data must be preserved regardless of threshold
         #expect(output.contains("TestClass"))
+    }
+}
+
+// MARK: - Per-Type Threshold (config_path) Tests
+
+@Suite("AnalyzeComplexityHandler config_path")
+struct AnalyzeComplexityConfigPathTests {
+    private func textContent(_ result: CallTool.Result) -> String? {
+        result.content.first.flatMap {
+            if case .text(let t) = $0 { return t }
+            return nil
+        }
+    }
+
+    /// Writes `contents` to a uniquely named temp file with `ext` and returns its path.
+    private func writeTemp(_ contents: String, ext: String) throws -> String {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("swift-complexity-mcp-\(UUID().uuidString).\(ext)")
+        try contents.write(to: url, atomically: true, encoding: .utf8)
+        return url.path
+    }
+
+    @Test("config_path applies per-type thresholds while filtering")
+    func configPathFilters() async throws {
+        // UserRepository.fetch and BillingService.process both have cyclomatic complexity 3.
+        let swiftSource = """
+            class UserRepository {
+                func fetch(_ x: Int) -> Int {
+                    if x > 0 { return 1 }
+                    if x < 0 { return -1 }
+                    return 0
+                }
+            }
+            class BillingService {
+                func process(_ x: Int) -> Int {
+                    if x > 0 { return 1 }
+                    if x < 0 { return -1 }
+                    return 0
+                }
+            }
+            """
+        // Repository threshold 3 → flagged; Service threshold 100 → not flagged.
+        let yaml = """
+            rules:
+              - suffix: Repository
+                threshold: 3
+              - suffix: Service
+                threshold: 100
+            """
+        let swiftPath = try writeTemp(swiftSource, ext: "swift")
+        let configPath = try writeTemp(yaml, ext: "yml")
+        defer {
+            try? FileManager.default.removeItem(atPath: swiftPath)
+            try? FileManager.default.removeItem(atPath: configPath)
+        }
+
+        let args: [String: Value] = [
+            "paths": .array([.string(swiftPath)]),
+            "config_path": .string(configPath),
+        ]
+        let result = await AnalyzeComplexityHandler.handle(args)
+
+        #expect(result.isError != true)
+        let text = textContent(result)
+        #expect(text?.contains("fetch") == true)
+        #expect(text?.contains("UserRepository") == true)
+        // process() is under the lenient Service threshold (100) and must be filtered out.
+        #expect(text?.contains("process") == false)
+    }
+
+    @Test("Invalid config_path returns an error")
+    func invalidConfigPath() async throws {
+        let swiftPath = try writeTemp("func foo() {}", ext: "swift")
+        defer { try? FileManager.default.removeItem(atPath: swiftPath) }
+
+        let args: [String: Value] = [
+            "paths": .array([.string(swiftPath)]),
+            "config_path": .string("/nonexistent/rules.yml"),
+        ]
+        let result = await AnalyzeComplexityHandler.handle(args)
+        #expect(result.isError == true)
     }
 }
 

--- a/docs/user-guide/usage.md
+++ b/docs/user-guide/usage.md
@@ -34,6 +34,7 @@ swift run SwiftComplexity path/to/directory --recursive
 ### Analysis Options
 
 - `--threshold <number>` - Set complexity threshold for warnings
+- `--config <path>` - Path to a per-type threshold config file (YAML). Defaults to `.swift-complexity.yml` in the current directory if present
 - `--cyclomatic-only` - Show only cyclomatic complexity metrics
 - `--cognitive-only` - Show only cognitive complexity metrics
 - `--recursive` - Recursively analyze subdirectories
@@ -85,6 +86,53 @@ swift run swift-complexity Sources --cyclomatic-only
 
 # Only cognitive complexity
 swift run swift-complexity Sources --cognitive-only
+```
+
+## Per-Type Complexity Thresholds
+
+Different layers and features often warrant different complexity budgets. You can
+assign thresholds per nominal type (class/struct/enum/actor, and extensions) using
+a YAML configuration file. The tool reads `.swift-complexity.yml` from the current
+directory automatically, or you can pass an explicit path with `--config`.
+
+```yaml
+# .swift-complexity.yml
+defaultThreshold: 10            # Fallback for types that match no rule (optional)
+rules:
+  - prefix: Toilet              # Feature grouping (matches type name prefix)
+    threshold: 12
+  - prefix: User
+    threshold: 8
+  - suffix: Repository          # Layer grouping (matches type name suffix)
+    threshold: 5
+  - suffix: UseCase
+    threshold: 15
+```
+
+### How a threshold is resolved
+
+For each function, the effective threshold is resolved from its nearest enclosing
+type name:
+
+1. Collect every rule whose `prefix` and/or `suffix` matches the type name (a rule
+   with both must match both).
+2. If any rules match, the **strictest (lowest)** threshold wins. For example,
+   `ToiletRepository` matches `prefix: Toilet` (12) and `suffix: Repository` (5),
+   so its threshold is **5**.
+3. If no rule matches (or the function is a free/top-level function), fall back to
+   `--threshold` if provided, otherwise `defaultThreshold`. The CLI `--threshold`
+   overrides `defaultThreshold`.
+
+A function is flagged when either its cyclomatic or cognitive complexity reaches
+the effective threshold. When a config (or `--threshold`) is active, only flagged
+functions are shown and the tool exits with code `1` if any function is flagged.
+
+```bash
+# Auto-discovers .swift-complexity.yml in the current directory
+swift run swift-complexity Sources --recursive
+
+# Or point at a specific config file
+swift run swift-complexity Sources --recursive --config config/complexity.yml
 ```
 
 ### Complex Examples


### PR DESCRIPTION
## Summary

Closes #19. Adds **per-type complexity thresholds** so different layers/features can have different complexity budgets, configured via a `.swift-complexity.yml` file.

Responsibilities differ across nominal types, so a single global `--threshold` is often too coarse — e.g. a `repository` layer warrants a stricter limit than a `domain-services` layer. This change lets you express that.

## Configuration

Auto-discovered as `.swift-complexity.yml` in the current directory, or passed via `--config <path>`:

```yaml
defaultThreshold: 10            # Fallback for types matching no rule (optional)
rules:
  - prefix: Toilet              # Feature grouping (type-name prefix)
    threshold: 12
  - prefix: User
    threshold: 8
  - suffix: Repository          # Layer grouping (type-name suffix)
    threshold: 5
  - suffix: UseCase
    threshold: 15
```

## Resolution rules

For each function, the effective threshold is resolved from its **nearest enclosing type name** (class/struct/enum/actor, or the extended type for extensions):

1. A rule may specify `prefix` and/or `suffix`; when both are given, both must match. A rule with neither never matches.
2. Among all matching rules, the **strictest (lowest)** threshold wins. e.g. `ToiletRepository` matches `prefix: Toilet` (12) and `suffix: Repository` (5) → **5**.
3. If no rule matches (or it's a free/top-level function), fall back to `--threshold`, then `defaultThreshold`. The CLI `--threshold` overrides `defaultThreshold`. A matched rule is **not** capped by the fallback, so a layer can be intentionally looser (e.g. `UseCase`=15).

A function is flagged when either its cyclomatic or cognitive complexity reaches the effective threshold (same semantics as the existing global threshold).

## Surfaces covered

- **CLI**: filtering, exit code, and Xcode diagnostics (`--format xcode` shows the per-type `Threshold:` value).
- **MCP**: `analyze_complexity` gains a `config_path` parameter.
- **Output**: `enclosingTypeName` is now included in JSON, and `enclosing-type` as an XML attribute (omitted for free functions).

## Incidental fix

Re-throw `ExitCode` from the threshold check so ArgumentParser sets the exit code without wrapping it into a spurious `Error: Unexpected error: ... (ArgumentParser.ExitCode error 1.)` message (pre-existing behavior, reproducible with `--threshold` alone).

## Changes

- New `Sources/SwiftComplexityCore/Models/ThresholdConfiguration.swift` (model, prefix/suffix matching, strictest-wins resolution, YAML loading via Yams).
- `FunctionDetector` / `FunctionComplexity` / `ComplexityAnalyzer`: capture and carry `enclosingTypeName`.
- `OutputFormatter`, `ComplexityCommand` (`--config`), MCP `ToolDefinitions` / `AnalyzeComplexityHandler`.
- Adds `Yams` (`from: 5.0.0`) to `SwiftComplexityCore`.
- Tests (Core/CLI/MCP) + README and `docs/user-guide/usage.md`.

## Testing

- `swift test` — **all 83 tests pass**, including new suites: enclosing-type detection, rule matching / resolution, `isExceeded`, YAML decoding, `--config` parsing, and MCP `config_path` filtering.
- Manual E2E with the built binary: per-type filtering, `.swift-complexity.yml` auto-discovery, `--format xcode` per-type threshold, JSON `enclosingTypeName` / XML `enclosing-type`, clean exit code 1, and unchanged behavior when no config/threshold is present.

## Follow-ups (not in this PR)

- `analyze_code_string` does not take `config_path` (it has no threshold/filtering concept), but its JSON output now exposes `enclosingTypeName` so clients can resolve thresholds themselves.

https://claude.ai/code/session_01GaTHVDhSAx76RbLmVziLQu