### PR TITLE
feat: Add inline suppression comments for complexity thresholds

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A command-line tool to analyze Swift code complexity and quality metrics using s
 - **Xcode Diagnostics**: Display complexity warnings and errors directly in Xcode editor with accurate line numbers
 - **Configurable Thresholds**: Set custom complexity thresholds via Xcode Build Settings or environment variables
 - **Per-Type Thresholds**: Assign different thresholds to types by name (prefix/suffix) via a `.swift-complexity.yml` config — e.g. stricter limits for `*Repository`, looser for `*UseCase`
+- **Inline Suppression**: Exempt a specific function from threshold checks with a `// swift-complexity:disable` comment, optionally scoped to just `cyclomatic` or `cognitive`
 - **Exit Code Integration**: Returns exit code 1 when complexity thresholds are exceeded, perfect for CI/CD pipelines
 - **Multiple Output Formats**: Text, JSON, XML, Xcode diagnostics, and SARIF output for different use cases
 - **Flexible Analysis**: Single files, directories, or recursive directory analysis
@@ -113,6 +114,28 @@ swift run SwiftComplexityCLI Sources --recursive
 # Explicit config path
 swift run SwiftComplexityCLI Sources --recursive --config config/complexity.yml
 ```
+
+### Inline Suppression
+
+Exempt a single, reviewed function from threshold checks with a comment directly
+above its declaration. There is no "next line" form and no "enable" comment —
+the directive always applies to exactly the one declaration it precedes.
+
+```swift
+// swift-complexity:disable
+func parseLegacyFormat(_ input: String) -> Document { ... }
+
+// swift-complexity:disable cognitive
+func stateMachine(_ event: Event) { ... }  // cyclomatic is still checked
+```
+
+Suppressed values are still computed and shown in every output format — only the
+threshold judgment is skipped. Run with `--report-suppressions` to print every
+suppressed function and its current values to stderr, so suppressions stay
+visible instead of silently hiding violations. See the
+[usage guide](docs/user-guide/usage.md#suppressing-specific-violations) for the
+full syntax, including why an unrecognized metric name suppresses nothing
+rather than everything.
 
 See the [Usage Guide](docs/user-guide/usage.md#per-type-complexity-thresholds) for full resolution rules.
 

--- a/Sources/SwiftComplexityCLI/ComplexityCommand.swift
+++ b/Sources/SwiftComplexityCLI/ComplexityCommand.swift
@@ -118,6 +118,13 @@ public struct ComplexityCommand: AsyncParsableCommand {
     )
     public var verbose: Bool = false
 
+    @Flag(
+        name: .long,
+        help:
+            "Print every function with a // swift-complexity:disable comment, and its current metric values, to stderr"
+    )
+    public var reportSuppressions: Bool = false
+
     // MARK: - Execution
 
     public init() {}
@@ -149,6 +156,10 @@ public struct ComplexityCommand: AsyncParsableCommand {
 
             let results = try await fileProcessor.processFiles(
                 at: paths, options: processingOptions)
+
+            if reportSuppressions {
+                printSuppressionsReport(results: results)
+            }
 
             let filteredResults = filterByThreshold(
                 results: results, threshold: threshold, configuration: configuration)
@@ -267,6 +278,39 @@ public struct ComplexityCommand: AsyncParsableCommand {
     }
 
     // MARK: - Private Methods
+
+    /// Prints every suppressed function with its current metric values to
+    /// stderr, so `// swift-complexity:disable` comments stay visible instead
+    /// of silently hiding violations.
+    private func printSuppressionsReport(results: [ComplexityResult]) {
+        var lines: [String] = []
+        for result in results {
+            for function in result.functions {
+                guard let suppressed = function.suppressedMetrics, !suppressed.isEmpty else {
+                    continue
+                }
+                let metricValues = suppressed.sorted { $0.rawValue < $1.rawValue }.map {
+                    metric -> String in
+                    switch metric {
+                    case .cyclomatic:
+                        return "cyclomatic (\(function.cyclomaticComplexity))"
+                    case .cognitive:
+                        return "cognitive (\(function.cognitiveComplexity))"
+                    }
+                }
+                lines.append(
+                    "\(result.filePath):\(function.location.line): \(function.name) — \(metricValues.joined(separator: ", "))"
+                )
+            }
+        }
+
+        let header =
+            lines.isEmpty
+            ? "No suppressed complexity checks found.\n"
+            : "Suppressed complexity checks:\n" + lines.map { "  \($0)" }.joined(separator: "\n")
+                + "\n"
+        FileHandle.standardError.write(Data(header.utf8))
+    }
 
     private func filterByThreshold(
         results: [ComplexityResult],

--- a/Sources/SwiftComplexityCore/Analysis/ComplexityAnalyzer.swift
+++ b/Sources/SwiftComplexityCore/Analysis/ComplexityAnalyzer.swift
@@ -54,7 +54,9 @@ public actor ComplexityAnalyzer: ComplexityAnalyzing {
                 cyclomaticComplexity: cyclomaticComplexity,
                 cognitiveComplexity: cognitiveComplexity,
                 location: function.location,
-                enclosingTypeName: function.enclosingTypeName
+                enclosingTypeName: function.enclosingTypeName,
+                suppressedMetrics: function.suppressedMetrics.isEmpty
+                    ? nil : function.suppressedMetrics
             )
 
             functionComplexities.append(functionComplexity)

--- a/Sources/SwiftComplexityCore/Analysis/FunctionDetector.swift
+++ b/Sources/SwiftComplexityCore/Analysis/FunctionDetector.swift
@@ -8,19 +8,24 @@ struct DetectedFunction {
     let location: SourceLocation
     /// Nearest enclosing nominal type name (or extended type for extensions); nil for free functions.
     let enclosingTypeName: String?
+    /// Metrics suppressed via a `// swift-complexity:disable` comment directly
+    /// above this declaration.
+    let suppressedMetrics: Set<SuppressedMetric>
 
     init(
         name: String,
         signature: String,
         body: CodeBlockSyntax?,
         location: SourceLocation,
-        enclosingTypeName: String? = nil
+        enclosingTypeName: String? = nil,
+        suppressedMetrics: Set<SuppressedMetric> = []
     ) {
         self.name = name
         self.signature = signature
         self.body = body
         self.location = location
         self.enclosingTypeName = enclosingTypeName
+        self.suppressedMetrics = suppressedMetrics
     }
 }
 
@@ -49,7 +54,8 @@ class FunctionDetector: SyntaxVisitor {
             signature: signature,
             body: node.body,
             location: location,
-            enclosingTypeName: enclosingTypeName(of: node)
+            enclosingTypeName: enclosingTypeName(of: node),
+            suppressedMetrics: SuppressionParser.suppressedMetrics(in: node.leadingTrivia)
         )
 
         detectedFunctions.append(detectedFunction)
@@ -67,7 +73,8 @@ class FunctionDetector: SyntaxVisitor {
             signature: signature,
             body: node.body,
             location: location,
-            enclosingTypeName: enclosingTypeName(of: node)
+            enclosingTypeName: enclosingTypeName(of: node),
+            suppressedMetrics: SuppressionParser.suppressedMetrics(in: node.leadingTrivia)
         )
 
         detectedFunctions.append(detectedFunction)
@@ -85,7 +92,8 @@ class FunctionDetector: SyntaxVisitor {
             signature: signature,
             body: node.body,
             location: location,
-            enclosingTypeName: enclosingTypeName(of: node)
+            enclosingTypeName: enclosingTypeName(of: node),
+            suppressedMetrics: SuppressionParser.suppressedMetrics(in: node.leadingTrivia)
         )
 
         detectedFunctions.append(detectedFunction)
@@ -129,7 +137,8 @@ class FunctionDetector: SyntaxVisitor {
             signature: signature,
             body: node.body,
             location: location,
-            enclosingTypeName: enclosingTypeName(of: node)
+            enclosingTypeName: enclosingTypeName(of: node),
+            suppressedMetrics: SuppressionParser.suppressedMetrics(in: node.leadingTrivia)
         )
 
         detectedFunctions.append(detectedFunction)
@@ -220,7 +229,8 @@ class FunctionDetector: SyntaxVisitor {
             signature: signature,
             body: codeBlock,
             location: location,
-            enclosingTypeName: enclosingTypeName(of: variable)
+            enclosingTypeName: enclosingTypeName(of: variable),
+            suppressedMetrics: SuppressionParser.suppressedMetrics(in: variable.leadingTrivia)
         )
 
         detectedFunctions.append(detectedFunction)

--- a/Sources/SwiftComplexityCore/Analysis/SuppressionParser.swift
+++ b/Sources/SwiftComplexityCore/Analysis/SuppressionParser.swift
@@ -1,0 +1,55 @@
+import SwiftSyntax
+
+/// Scans a declaration's leading trivia for `// swift-complexity:disable` comments.
+///
+/// The comment must be the closest leading `//` comment directly above the
+/// declaration it suppresses; there is no separate "next line" form and no
+/// "enable" counterpart, because suppression always applies to exactly the
+/// one declaration whose leading trivia contains the comment. Only plain
+/// `//` line comments are recognized; `///` doc comments are ignored so
+/// documentation is never mistaken for a directive.
+enum SuppressionParser {
+    private static let marker = "swift-complexity:disable"
+
+    /// Returns the set of metrics suppressed by any `swift-complexity:disable`
+    /// comment found in `trivia`. Empty when no such comment is present.
+    static func suppressedMetrics(in trivia: Trivia) -> Set<SuppressedMetric> {
+        var result: Set<SuppressedMetric> = []
+        for piece in trivia {
+            guard case .lineComment(let text) = piece,
+                let metrics = parseDirective(from: text)
+            else { continue }
+            result.formUnion(metrics)
+        }
+        return result
+    }
+
+    /// Parses a single `//`-prefixed comment. Returns `nil` when the comment
+    /// is not a swift-complexity directive at all.
+    ///
+    /// - A bare directive (nothing but whitespace after the marker) suppresses
+    ///   every metric.
+    /// - A directive followed by metric names suppresses exactly the
+    ///   recognized ones. Unrecognized tokens are ignored, and if none of them
+    ///   are recognized, nothing is suppressed — suppression fails closed on a
+    ///   typo rather than silently disabling every metric.
+    private static func parseDirective(from commentText: String) -> Set<SuppressedMetric>? {
+        guard commentText.hasPrefix("//") else { return nil }
+        let content = commentText.dropFirst(2).trimmingCharacters(in: .whitespaces)
+
+        guard content.hasPrefix(marker) else { return nil }
+        let afterMarker = content.dropFirst(marker.count)
+
+        // Reject a false-prefix match like "disableFoo", which is a different
+        // (unsupported) directive, not a typo'd form of "disable".
+        if let firstChar = afterMarker.first, firstChar.isLetter || firstChar.isNumber {
+            return nil
+        }
+
+        let remainder = afterMarker.trimmingCharacters(in: .whitespaces)
+        guard !remainder.isEmpty else { return Set(SuppressedMetric.allCases) }
+
+        let tokens = remainder.split(whereSeparator: { $0 == " " || $0 == "," || $0 == "\t" })
+        return Set(tokens.compactMap { SuppressedMetric(rawValue: String($0)) })
+    }
+}

--- a/Sources/SwiftComplexityCore/Models/FunctionComplexity.swift
+++ b/Sources/SwiftComplexityCore/Models/FunctionComplexity.swift
@@ -1,5 +1,12 @@
 import Foundation
 
+/// A per-function metric that can be excluded from threshold checks via a
+/// `// swift-complexity:disable` comment.
+public enum SuppressedMetric: String, Codable, Hashable, Sendable, CaseIterable {
+    case cyclomatic
+    case cognitive
+}
+
 /// Represents complexity metrics for a single function or method
 public struct FunctionComplexity: Codable, Hashable, Sendable {
     /// Function or method name
@@ -24,13 +31,20 @@ public struct FunctionComplexity: Codable, Hashable, Sendable {
     /// compatibility with previously encoded results.
     public let enclosingTypeName: String?
 
+    /// Metrics excluded from threshold checks by a `// swift-complexity:disable`
+    /// comment directly above this declaration. `nil` when nothing is
+    /// suppressed; values are still reported even when suppressed, only the
+    /// threshold judgment is skipped.
+    public let suppressedMetrics: Set<SuppressedMetric>?
+
     public init(
         name: String,
         signature: String,
         cyclomaticComplexity: Int,
         cognitiveComplexity: Int,
         location: SourceLocation,
-        enclosingTypeName: String? = nil
+        enclosingTypeName: String? = nil,
+        suppressedMetrics: Set<SuppressedMetric>? = nil
     ) {
         self.name = name
         self.signature = signature
@@ -38,6 +52,12 @@ public struct FunctionComplexity: Codable, Hashable, Sendable {
         self.cognitiveComplexity = cognitiveComplexity
         self.location = location
         self.enclosingTypeName = enclosingTypeName
+        self.suppressedMetrics = suppressedMetrics
+    }
+
+    /// Whether `metric` is suppressed for this function.
+    public func isSuppressed(_ metric: SuppressedMetric) -> Bool {
+        suppressedMetrics?.contains(metric) ?? false
     }
 }
 

--- a/Sources/SwiftComplexityCore/Models/ThresholdConfiguration.swift
+++ b/Sources/SwiftComplexityCore/Models/ThresholdConfiguration.swift
@@ -87,15 +87,18 @@ public struct ThresholdConfiguration: Codable, Sendable, Equatable {
     /// Whether the given function exceeds its effective threshold.
     ///
     /// Mirrors the legacy semantics: a function is flagged when either its
-    /// cyclomatic or cognitive complexity reaches the threshold.
+    /// cyclomatic or cognitive complexity reaches the threshold. A metric
+    /// suppressed via `// swift-complexity:disable` is excluded from this
+    /// check; its value is still reported elsewhere, only the judgment is
+    /// skipped.
     public func isExceeded(_ function: FunctionComplexity, fallback: Int?) -> Bool {
         guard
             let threshold = threshold(forTypeName: function.enclosingTypeName, fallback: fallback)
         else {
             return false
         }
-        return function.cyclomaticComplexity >= threshold
-            || function.cognitiveComplexity >= threshold
+        return (!function.isSuppressed(.cyclomatic) && function.cyclomaticComplexity >= threshold)
+            || (!function.isSuppressed(.cognitive) && function.cognitiveComplexity >= threshold)
     }
 
     // MARK: - Loading

--- a/Sources/SwiftComplexityCore/Output/OutputFormatter.swift
+++ b/Sources/SwiftComplexityCore/Output/OutputFormatter.swift
@@ -337,6 +337,11 @@ public class OutputFormatter {
     }
 
     /// Creates a complexity diagnostic message
+    ///
+    /// A metric suppressed via `// swift-complexity:disable` is excluded from
+    /// the exceedance and severity checks below, but both raw values are
+    /// always shown in the message — suppression only skips the judgment, it
+    /// never hides the underlying numbers.
     private func createComplexityDiagnostic(
         for function: FunctionComplexity,
         in filePath: String,
@@ -345,10 +350,15 @@ public class OutputFormatter {
         let cyclomatic = function.cyclomaticComplexity
         let cognitive = function.cognitiveComplexity
 
-        guard cyclomatic > threshold || cognitive > threshold else { return nil }
+        let cyclomaticExceeds = !function.isSuppressed(.cyclomatic) && cyclomatic > threshold
+        let cognitiveExceeds = !function.isSuppressed(.cognitive) && cognitive > threshold
+
+        guard cyclomaticExceeds || cognitiveExceeds else { return nil }
 
         let severity =
-            (cyclomatic > threshold * 2 || cognitive > threshold * 2) ? "error" : "warning"
+            (cyclomaticExceeds && cyclomatic > threshold * 2)
+                || (cognitiveExceeds && cognitive > threshold * 2)
+            ? "error" : "warning"
         let message =
             "Function '\(function.name)' has high complexity (Cyclomatic: \(cyclomatic), Cognitive: \(cognitive), Threshold: \(threshold))"
 

--- a/Sources/SwiftComplexityCore/Output/SARIFReport.swift
+++ b/Sources/SwiftComplexityCore/Output/SARIFReport.swift
@@ -137,7 +137,9 @@ extension OutputFormatter {
 
     /// Builds one SARIF result per metric that reaches its effective threshold,
     /// using the same `>=` semantics as the CLI exit-code check so annotations
-    /// and CI failures always agree.
+    /// and CI failures always agree. A metric suppressed via
+    /// `// swift-complexity:disable` never produces a result, even if the
+    /// overall function still exceeds the threshold on its other metric.
     private func complexityResults(
         for result: ComplexityResult,
         options: OutputOptions
@@ -151,13 +153,21 @@ extension OutputFormatter {
                 ?? options.threshold
             guard let threshold = resolved else { return [] }
 
-            let metrics: [(ruleId: String, label: String, value: Int)] = [
-                (SARIFConstants.cyclomaticRuleId, "cyclomatic", function.cyclomaticComplexity),
-                (SARIFConstants.cognitiveRuleId, "cognitive", function.cognitiveComplexity),
+            let metrics: [(ruleId: String, label: String, metric: SuppressedMetric, value: Int)] = [
+                (
+                    SARIFConstants.cyclomaticRuleId, "cyclomatic", .cyclomatic,
+                    function.cyclomaticComplexity
+                ),
+                (
+                    SARIFConstants.cognitiveRuleId, "cognitive", .cognitive,
+                    function.cognitiveComplexity
+                ),
             ]
 
             return metrics.compactMap { metric in
-                guard metric.value >= threshold else { return nil }
+                guard !function.isSuppressed(metric.metric), metric.value >= threshold else {
+                    return nil
+                }
                 let message =
                     "Function '\(function.name)' has \(metric.label) complexity \(metric.value) (threshold: \(threshold))"
                 return SARIFResult(

--- a/Tests/SwiftComplexityCLITests/SwiftComplexityCLITests.swift
+++ b/Tests/SwiftComplexityCLITests/SwiftComplexityCLITests.swift
@@ -181,4 +181,16 @@ struct CLIConfigOptionTests {
         #expect(command.config == "rules.yml")
         #expect(command.threshold == 10)
     }
+
+    @Test("--report-suppressions defaults to false")
+    func reportSuppressionsDefaultsToFalse() throws {
+        let command = try ComplexityCommand.parse(["Sources"])
+        #expect(command.reportSuppressions == false)
+    }
+
+    @Test("--report-suppressions is parsed")
+    func reportSuppressionsParsed() throws {
+        let command = try ComplexityCommand.parse(["Sources", "--report-suppressions"])
+        #expect(command.reportSuppressions == true)
+    }
 }

--- a/Tests/SwiftComplexityCoreTests/Fixtures/suppressed_functions.swift
+++ b/Tests/SwiftComplexityCoreTests/Fixtures/suppressed_functions.swift
@@ -1,0 +1,69 @@
+// Fixtures for inline suppression comment detection.
+// Every function below has cyclomatic complexity 3 (base 1 + 2 sibling if
+// statements) and cognitive complexity 2 (2 sibling ifs, no nesting bonus).
+
+// swift-complexity:disable
+func fullySuppressed(a: Int, b: Int) {
+    if a > 0 {
+        print("a")
+    }
+    if b > 0 {
+        print("b")
+    }
+}
+
+// swift-complexity:disable cyclomatic
+func cyclomaticOnlySuppressed(a: Int, b: Int) {
+    if a > 0 {
+        print("a")
+    }
+    if b > 0 {
+        print("b")
+    }
+}
+
+/// Doc comments are never mistaken for a directive, even when phrased
+/// similarly and placed directly above the declaration.
+// swift-complexity:disable cognitive
+func cognitiveOnlySuppressed(a: Int, b: Int) {
+    if a > 0 {
+        print("a")
+    }
+    if b > 0 {
+        print("b")
+    }
+}
+
+// This is an unrelated comment that happens to precede a complex function.
+func notSuppressed(a: Int, b: Int) {
+    if a > 0 {
+        print("a")
+    }
+    if b > 0 {
+        print("b")
+    }
+}
+
+// A typo'd metric name suppresses nothing (fails closed), unlike a bare
+// disable which would suppress everything.
+// swift-complexity:disable cyclomattic
+func typoedMetricNotSuppressed(a: Int, b: Int) {
+    if a > 0 {
+        print("a")
+    }
+    if b > 0 {
+        print("b")
+    }
+}
+
+struct SuppressedComputedProperty {
+    // swift-complexity:disable
+    var isValid: Bool {
+        if true {
+            if true {
+                return true
+            }
+        }
+        return false
+    }
+}

--- a/Tests/SwiftComplexityCoreTests/SwiftComplexityTests.swift
+++ b/Tests/SwiftComplexityCoreTests/SwiftComplexityTests.swift
@@ -412,6 +412,85 @@ struct FunctionDetectionTests {
         #expect(setter?.cyclomaticComplexity == 1)
         #expect(setter?.cognitiveComplexity == 0)
     }
+
+    @Test("Suppression comments are scoped to their own declaration")
+    func suppressionCommentsScoping() async throws {
+        // Given
+        let code = try loadFixture("suppressed_functions")
+        let sourceFile = Parser.parse(source: code)
+        let analyzer = try ComplexityAnalyzer()
+
+        // When
+        let result = try await analyzer.analyze(sourceFile: sourceFile, filePath: "test.swift")
+        func suppressed(_ name: String) -> Set<SuppressedMetric>? {
+            result.functions.first { $0.name == name }?.suppressedMetrics
+        }
+
+        // Then
+        #expect(suppressed("fullySuppressed") == Set(SuppressedMetric.allCases))
+        #expect(suppressed("cyclomaticOnlySuppressed") == [.cyclomatic])
+        #expect(suppressed("cognitiveOnlySuppressed") == [.cognitive])
+        // An unrelated preceding comment must not trigger suppression.
+        #expect(suppressed("notSuppressed") == nil)
+        // A typo'd metric name fails closed: nothing is suppressed.
+        #expect(suppressed("typoedMetricNotSuppressed") == nil)
+        // Suppression scopes to a computed property's own declaration too.
+        #expect(suppressed("isValid") == Set(SuppressedMetric.allCases))
+    }
+}
+
+// MARK: - Suppression Parsing Tests
+
+@Suite("Suppression parsing", .tags(.unit, .detectors))
+struct SuppressionParserTests {
+
+    @Test("Bare disable suppresses all metrics")
+    func bareDisable() {
+        let trivia: Trivia = [.lineComment("// swift-complexity:disable"), .newlines(1)]
+        #expect(SuppressionParser.suppressedMetrics(in: trivia) == Set(SuppressedMetric.allCases))
+    }
+
+    @Test("Specific metric name suppresses only that metric")
+    func specificMetric() {
+        let trivia: Trivia = [
+            .lineComment("// swift-complexity:disable cyclomatic"), .newlines(1),
+        ]
+        #expect(SuppressionParser.suppressedMetrics(in: trivia) == [.cyclomatic])
+    }
+
+    @Test("Comma-separated metric names are all recognized")
+    func commaSeparatedMetrics() {
+        let trivia: Trivia = [
+            .lineComment("// swift-complexity:disable cyclomatic, cognitive"), .newlines(1),
+        ]
+        #expect(SuppressionParser.suppressedMetrics(in: trivia) == Set(SuppressedMetric.allCases))
+    }
+
+    @Test("Unrecognized metric name suppresses nothing (fails closed on a typo)")
+    func typoedMetricSuppressesNothing() {
+        let trivia: Trivia = [
+            .lineComment("// swift-complexity:disable cyclomattic"), .newlines(1),
+        ]
+        #expect(SuppressionParser.suppressedMetrics(in: trivia).isEmpty)
+    }
+
+    @Test("Unrelated comment is not treated as a directive")
+    func unrelatedCommentIgnored() {
+        let trivia: Trivia = [.lineComment("// just a regular comment"), .newlines(1)]
+        #expect(SuppressionParser.suppressedMetrics(in: trivia).isEmpty)
+    }
+
+    @Test("Doc comments are never treated as a directive")
+    func docCommentIgnored() {
+        let trivia: Trivia = [.docLineComment("/// swift-complexity:disable"), .newlines(1)]
+        #expect(SuppressionParser.suppressedMetrics(in: trivia).isEmpty)
+    }
+
+    @Test("A false-prefix match like disableFoo is not our directive")
+    func falsePrefixNotMatched() {
+        let trivia: Trivia = [.lineComment("// swift-complexity:disableFoo"), .newlines(1)]
+        #expect(SuppressionParser.suppressedMetrics(in: trivia).isEmpty)
+    }
 }
 
 // MARK: - Output Formatter Tests
@@ -466,6 +545,49 @@ struct OutputFormatterTests {
         #expect(output.contains("\"testFunc\""))
         #expect(output.contains("\"cyclomaticComplexity\":1"))
         #expect(output.contains("\"cognitiveComplexity\":0"))
+    }
+
+    @Test("Xcode diagnostics still flag a function via its non-suppressed metric")
+    func xcodeDiagnosticsPartiallySuppressed() {
+        // Given - both metrics exceed the threshold, but only cyclomatic is suppressed
+        let functions = [
+            FunctionComplexity(
+                name: "partiallySuppressed", signature: "func partiallySuppressed()",
+                cyclomaticComplexity: 20, cognitiveComplexity: 20,
+                location: SourceLocation(line: 3, column: 1),
+                suppressedMetrics: [.cyclomatic])
+        ]
+        let result = ComplexityResult(filePath: "test.swift", functions: functions)
+        let formatter = OutputFormatter()
+        let options = OutputOptions(threshold: 10)
+
+        // When
+        let output = formatter.format(results: [result], format: .xcode, options: options)
+
+        // Then - still reported (cognitive is not suppressed), values remain visible
+        #expect(output.contains("test.swift:3:1"))
+        #expect(output.contains("Cyclomatic: 20, Cognitive: 20"))
+    }
+
+    @Test("Xcode diagnostics stay silent when every offending metric is suppressed")
+    func xcodeDiagnosticsFullySuppressed() {
+        // Given
+        let functions = [
+            FunctionComplexity(
+                name: "fullySuppressed", signature: "func fullySuppressed()",
+                cyclomaticComplexity: 20, cognitiveComplexity: 20,
+                location: SourceLocation(line: 3, column: 1),
+                suppressedMetrics: Set(SuppressedMetric.allCases))
+        ]
+        let result = ComplexityResult(filePath: "test.swift", functions: functions)
+        let formatter = OutputFormatter()
+        let options = OutputOptions(threshold: 10)
+
+        // When
+        let output = formatter.format(results: [result], format: .xcode, options: options)
+
+        // Then
+        #expect(output.isEmpty)
     }
 
     @Test("SARIF format reports one result per violated metric")
@@ -536,6 +658,32 @@ struct OutputFormatterTests {
         let runs = json["runs"] as? [[String: Any]] ?? []
         let results = runs.first?["results"] as? [[String: Any]] ?? []
         #expect(results.isEmpty)
+    }
+
+    @Test("SARIF format skips a metric suppressed via // swift-complexity:disable")
+    func sarifFormatWithSuppression() throws {
+        // Given - both metrics exceed the threshold, but only cyclomatic is suppressed
+        let functions = [
+            FunctionComplexity(
+                name: "partiallySuppressed", signature: "func partiallySuppressed()",
+                cyclomaticComplexity: 20, cognitiveComplexity: 20,
+                location: SourceLocation(line: 1, column: 1),
+                suppressedMetrics: [.cyclomatic])
+        ]
+        let result = ComplexityResult(filePath: "test.swift", functions: functions)
+        let formatter = OutputFormatter()
+        let options = OutputOptions(threshold: 10)
+
+        // When
+        let output = formatter.format(results: [result], format: .sarif, options: options)
+
+        // Then - only the non-suppressed metric produces a result
+        let json =
+            try JSONSerialization.jsonObject(with: Data(output.utf8)) as? [String: Any] ?? [:]
+        let runs = json["runs"] as? [[String: Any]] ?? []
+        let results = runs.first?["results"] as? [[String: Any]] ?? []
+        #expect(results.count == 1)
+        #expect(results.first?["ruleId"] as? String == "cognitive_complexity")
     }
 
     @Test("SARIF format reports low cohesion classes")

--- a/Tests/SwiftComplexityCoreTests/ThresholdConfigurationTests.swift
+++ b/Tests/SwiftComplexityCoreTests/ThresholdConfigurationTests.swift
@@ -104,13 +104,16 @@ struct ThresholdConfigurationTests {
 
     @Suite("isExceeded")
     struct IsExceededTests {
-        private func function(type: String?, cyclomatic: Int, cognitive: Int) -> FunctionComplexity
-        {
+        private func function(
+            type: String?, cyclomatic: Int, cognitive: Int,
+            suppressed: Set<SuppressedMetric>? = nil
+        ) -> FunctionComplexity {
             FunctionComplexity(
                 name: "f", signature: "func f()",
                 cyclomaticComplexity: cyclomatic, cognitiveComplexity: cognitive,
                 location: SourceLocation(line: 1, column: 1),
-                enclosingTypeName: type
+                enclosingTypeName: type,
+                suppressedMetrics: suppressed
             )
         }
 
@@ -143,6 +146,31 @@ struct ThresholdConfigurationTests {
             let config = ThresholdConfiguration.empty
             let fn = function(type: nil, cyclomatic: 99, cognitive: 99)
             #expect(!config.isExceeded(fn, fallback: nil))
+        }
+
+        @Test("Suppressing every metric clears the flag entirely")
+        func suppressingAllMetricsClearsFlag() {
+            let config = ThresholdConfiguration.empty
+            let fn = function(
+                type: nil, cyclomatic: 20, cognitive: 20,
+                suppressed: Set(SuppressedMetric.allCases))
+            #expect(!config.isExceeded(fn, fallback: 5))
+        }
+
+        @Test("Suppressing one metric still lets the other metric flag it")
+        func suppressingOneMetricLeavesTheOtherActive() {
+            let config = ThresholdConfiguration.empty
+            let fn = function(
+                type: nil, cyclomatic: 20, cognitive: 20, suppressed: [.cyclomatic])
+            #expect(config.isExceeded(fn, fallback: 5))
+        }
+
+        @Test("Suppressing the only metric that would have exceeded clears the flag")
+        func suppressingTheOnlyOffendingMetricClearsFlag() {
+            let config = ThresholdConfiguration.empty
+            let fn = function(
+                type: nil, cyclomatic: 20, cognitive: 1, suppressed: [.cyclomatic])
+            #expect(!config.isExceeded(fn, fallback: 5))
         }
     }
 

--- a/docs/user-guide/usage.md
+++ b/docs/user-guide/usage.md
@@ -38,6 +38,7 @@ swift run SwiftComplexity path/to/directory --recursive
 - `--cyclomatic-only` - Show only cyclomatic complexity metrics
 - `--cognitive-only` - Show only cognitive complexity metrics
 - `--recursive` - Recursively analyze subdirectories
+- `--report-suppressions` - Print every function with a `// swift-complexity:disable` comment, and its current metric values, to stderr
 
 ### Filtering Options
 
@@ -133,6 +134,50 @@ swift run swift-complexity Sources --recursive
 
 # Or point at a specific config file
 swift run swift-complexity Sources --recursive --config config/complexity.yml
+```
+
+## Suppressing Specific Violations
+
+When a function's complexity is unavoidable and reviewed on purpose, add a
+`// swift-complexity:disable` comment directly above its declaration (function,
+initializer, deinitializer, or computed property). There is no separate
+"disable next line" form and no matching "enable" comment — the comment always
+applies to exactly the one declaration it immediately precedes.
+
+```swift
+// swift-complexity:disable
+func parseLegacyFormat(_ input: String) -> Document {
+    // A large switch statement kept for backward compatibility.
+    ...
+}
+
+// swift-complexity:disable cognitive
+func stateMachine(_ event: Event) {
+    // Only cognitive complexity is suppressed; cyclomatic is still checked.
+    ...
+}
+```
+
+- A bare `// swift-complexity:disable` suppresses every metric for that
+  declaration.
+- Naming specific metrics (`cyclomatic`, `cognitive`, space- or comma-separated)
+  suppresses only those, leaving the others checked as usual.
+- An unrecognized metric name suppresses nothing for that comment — suppression
+  fails closed on a typo instead of silently disabling every metric.
+- `///` documentation comments are never treated as a directive, so a doc
+  comment above a suppressed declaration is unaffected.
+- Suppressed values are still computed and shown in every output format; only
+  the threshold judgment (and therefore exit code 1, and any warning in
+  `xcode`/`sarif` output) is skipped for the suppressed metric.
+- LCOM4 class cohesion has no suppression mechanism yet, since it is a
+  type-level metric rather than a per-function one.
+
+Run with `--report-suppressions` to print every suppressed function and its
+current metric values to stderr, so suppression comments stay visible instead
+of silently hiding violations:
+
+```bash
+swift run swift-complexity Sources --recursive --threshold 10 --report-suppressions
 ```
 
 ### Complex Examples


### PR DESCRIPTION
## Summary

Adds `// swift-complexity:disable` so a single, reviewed function can be exempted from threshold checks without raising the threshold globally or abandoning enforcement. This closes a real gap left by the per-type threshold work (#32): today, one legitimately complex function forces a choice between fixing it or weakening the check for the whole type.

Second step of the "Now" roadmap, after SARIF output (#33).

## Syntax

```swift
// swift-complexity:disable
func parseLegacyFormat(_ input: String) -> Document { ... }

// swift-complexity:disable cognitive
func stateMachine(_ event: Event) { ... }  // cyclomatic is still checked
```

- The comment must be the closest leading comment directly above the declaration it suppresses (function, initializer, deinitializer, or computed property/accessor).
- A bare disable suppresses every metric; naming specific metrics (`cyclomatic`/`cognitive`, space- or comma-separated) suppresses only those.
- **Deliberately no "next line" form and no "enable" counterpart** — suppression always scopes to exactly one declaration, so unlike range-based disable/enable there's nothing to forget to re-enable.
- **Fails closed on a typo**: an unrecognized metric name suppresses nothing for that comment, rather than falling back to "suppress everything." A typo should not silently widen what a complexity tool hides.
- `///` doc comments are never mistaken for a directive.

## Design notes

- Suppressed values are still computed and shown in every output format — only the threshold *judgment* is skipped. This meant updating all three places that independently decide "does this function violate its threshold" so a suppressed metric can't leak through one of them: `ThresholdConfiguration.isExceeded` (feeds the exit code and the upstream filter shared by text/json/xml/xcode/sarif), the Xcode diagnostic (which reports both metrics in one combined message and keeps doing so — only the gating changes), and SARIF's per-metric result generation (which computes its own `>=` check independent of `isExceeded`).
- LCOM4 class cohesion has no suppression yet — it's a type-level metric, not a per-function one, so it needs its own design. Left as a follow-up.
- New `--report-suppressions` flag prints every suppressed function and its current metric values to stderr, so suppressions stay visible instead of silently accumulating.

## Verification

- `swift test`: 102 tests pass, including new coverage for `SuppressionParser` (bare disable, specific metrics, comma-separated, typo'd metric, unrelated comment, doc comment, false-prefix match like `disableFoo`), `ThresholdConfiguration.isExceeded` with suppression, Xcode diagnostics with partial/full suppression, and SARIF with partial suppression
- E2E against a real fixture (`Tests/SwiftComplexityCoreTests/Fixtures/suppressed_functions.swift`) confirmed with the built CLI across `text`, `xcode`, and `sarif` formats at multiple thresholds, and `--report-suppressions` output
- `swift-format` clean via lefthook pre-commit; no new markdownlint errors introduced (verified by diffing lint output against `main`)

https://claude.ai/code/session_01GaTHVDhSAx76RbLmVziLQu