### PR TITLE
chore: Bump version to 1.1.0

### DIFF
--- a/Sources/SwiftComplexityCore/Version.swift
+++ b/Sources/SwiftComplexityCore/Version.swift
@@ -3,5 +3,5 @@
 /// Referenced by the CLI (`--version`), the MCP server handshake, and the
 /// SARIF `tool.driver.version` field so a release bump happens in one place.
 public enum SwiftComplexityVersion {
-    public static let current = "1.0.0"
+    public static let current = "1.1.0"
 }


### PR DESCRIPTION
## Summary

Bumps `SwiftComplexityVersion.current` (the single version constant referenced by the CLI `--version`, the MCP server handshake, and SARIF's `tool.driver.version`) from `1.0.0` to `1.1.0` ahead of tagging the release.

This release includes:
- SARIF output format for GitHub Code Scanning (#33)
- Inline suppression comments for complexity thresholds (#35)

## Verification

- `swift build` and `swift test`: 102 tests pass

https://claude.ai/code/session_01GaTHVDhSAx76RbLmVziLQu