### PR TITLE
docs: Update stale SARIF example version to 1.1.0

### DIFF
--- a/docs/user-guide/output-formats.md
+++ b/docs/user-guide/output-formats.md
@@ -295,7 +295,7 @@ tool from your repository root for GitHub-compatible URIs.
       "tool" : {
         "driver" : {
           "name" : "swift-complexity",
-          "version" : "1.0.0",
+          "version" : "1.1.0",
           "informationUri" : "https://github.com/fummicc1/swift-complexity",
           "rules" : [...]
         }


### PR DESCRIPTION
## Summary

The SARIF example output in `docs/user-guide/output-formats.md` still showed `"version": "1.0.0"` for `tool.driver.version` after the v1.1.0 release. Verified against the actual built CLI that this field now reports `1.1.0` (via `SwiftComplexityVersion.current`), so the doc example was out of date.

Docs-only change; no release needed for this on its own.

## Verification

- `swift-complexity ... -f sarif` output inspected directly; `tool.driver.version` is `1.1.0`

https://claude.ai/code/session_01GaTHVDhSAx76RbLmVziLQu