### PR TITLE
feat: Add inline suppression for LCOM4 class cohesion

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A command-line tool to analyze Swift code complexity and quality metrics using s
 - **Xcode Diagnostics**: Display complexity warnings and errors directly in Xcode editor with accurate line numbers
 - **Configurable Thresholds**: Set custom complexity thresholds via Xcode Build Settings or environment variables
 - **Per-Type Thresholds**: Assign different thresholds to types by name (prefix/suffix) via a `.swift-complexity.yml` config — e.g. stricter limits for `*Repository`, looser for `*UseCase`
-- **Inline Suppression**: Exempt a specific function from threshold checks with a `// swift-complexity:disable` comment, optionally scoped to just `cyclomatic` or `cognitive`
+- **Inline Suppression**: Exempt a specific function or type from threshold checks with a `// swift-complexity:disable` comment, optionally scoped to `cyclomatic`, `cognitive`, or `lcom4`
 - **Exit Code Integration**: Returns exit code 1 when complexity thresholds are exceeded, perfect for CI/CD pipelines
 - **Multiple Output Formats**: Text, JSON, XML, Xcode diagnostics, and SARIF output for different use cases
 - **Flexible Analysis**: Single files, directories, or recursive directory analysis
@@ -117,9 +117,10 @@ swift run SwiftComplexityCLI Sources --recursive --config config/complexity.yml
 
 ### Inline Suppression
 
-Exempt a single, reviewed function from threshold checks with a comment directly
-above its declaration. There is no "next line" form and no "enable" comment —
-the directive always applies to exactly the one declaration it precedes.
+Exempt a single, reviewed function or type from threshold checks with a comment
+directly above its declaration. There is no "next line" form and no "enable"
+comment — the directive always applies to exactly the one declaration it
+precedes, so a suppressed type never cascades to its member functions.
 
 ```swift
 // swift-complexity:disable
@@ -127,12 +128,15 @@ func parseLegacyFormat(_ input: String) -> Document { ... }
 
 // swift-complexity:disable cognitive
 func stateMachine(_ event: Event) { ... }  // cyclomatic is still checked
+
+// swift-complexity:disable lcom4
+class LegacyOrderManager { ... }  // member functions are still checked
 ```
 
 Suppressed values are still computed and shown in every output format — only the
 threshold judgment is skipped. Run with `--report-suppressions` to print every
-suppressed function and its current values to stderr, so suppressions stay
-visible instead of silently hiding violations. See the
+suppressed function and type with its current values to stderr, so suppressions
+stay visible instead of silently hiding violations. See the
 [usage guide](docs/user-guide/usage.md#suppressing-specific-violations) for the
 full syntax, including why an unrecognized metric name suppresses nothing
 rather than everything.

--- a/Sources/SwiftComplexityCLI/ComplexityCommand.swift
+++ b/Sources/SwiftComplexityCLI/ComplexityCommand.swift
@@ -121,7 +121,7 @@ public struct ComplexityCommand: AsyncParsableCommand {
     @Flag(
         name: .long,
         help:
-            "Print every function with a // swift-complexity:disable comment, and its current metric values, to stderr"
+            "Print every function or type with a // swift-complexity:disable comment, and its current metric values, to stderr"
     )
     public var reportSuppressions: Bool = false
 
@@ -279,9 +279,9 @@ public struct ComplexityCommand: AsyncParsableCommand {
 
     // MARK: - Private Methods
 
-    /// Prints every suppressed function with its current metric values to
-    /// stderr, so `// swift-complexity:disable` comments stay visible instead
-    /// of silently hiding violations.
+    /// Prints every suppressed function and type with its current metric
+    /// values to stderr, so `// swift-complexity:disable` comments stay
+    /// visible instead of silently hiding violations.
     private func printSuppressionsReport(results: [ComplexityResult]) {
         var lines: [String] = []
         for result in results {
@@ -289,17 +289,25 @@ public struct ComplexityCommand: AsyncParsableCommand {
                 guard let suppressed = function.suppressedMetrics, !suppressed.isEmpty else {
                     continue
                 }
-                let metricValues = suppressed.sorted { $0.rawValue < $1.rawValue }.map {
-                    metric -> String in
+                let metricValues = suppressed.sorted { $0.rawValue < $1.rawValue }.compactMap {
+                    metric -> String? in
                     switch metric {
                     case .cyclomatic:
                         return "cyclomatic (\(function.cyclomaticComplexity))"
                     case .cognitive:
                         return "cognitive (\(function.cognitiveComplexity))"
+                    case .lcom4:
+                        return nil  // type-level metric, never present on a function
                     }
                 }
                 lines.append(
                     "\(result.filePath):\(function.location.line): \(function.name) — \(metricValues.joined(separator: ", "))"
+                )
+            }
+            for cohesion in result.classCohesions ?? [] {
+                guard cohesion.isSuppressed(.lcom4) else { continue }
+                lines.append(
+                    "\(result.filePath):\(cohesion.location.line): \(cohesion.name) — lcom4 (\(cohesion.lcom4))"
                 )
             }
         }
@@ -325,9 +333,10 @@ public struct ComplexityCommand: AsyncParsableCommand {
                 configuration.isExceeded(function, fallback: threshold)
             }
 
-            // For LCOM4, filter classes with low cohesion (LCOM4 >= 3)
+            // For LCOM4, filter classes with low cohesion (LCOM4 >= 3),
+            // excluding types whose cohesion check is suppressed inline
             let filteredCohesions = result.classCohesions?.filter { cohesion in
-                cohesion.lcom4 >= 3
+                cohesion.lcom4 >= 3 && !cohesion.isSuppressed(.lcom4)
             }
 
             // Keep result if either functions or cohesions pass threshold

--- a/Sources/SwiftComplexityCore/Analysis/ComplexityAnalyzer.swift
+++ b/Sources/SwiftComplexityCore/Analysis/ComplexityAnalyzer.swift
@@ -92,7 +92,9 @@ public actor ComplexityAnalyzer: ComplexityAnalyzing {
                     lcom4: lcom4Value,
                     methodCount: methods,
                     propertyCount: properties,
-                    location: detectedType.location
+                    location: detectedType.location,
+                    suppressedMetrics: detectedType.suppressedMetrics.isEmpty
+                        ? nil : detectedType.suppressedMetrics
                 )
 
                 cohesions.append(cohesion)

--- a/Sources/SwiftComplexityCore/Analysis/FunctionDetector.swift
+++ b/Sources/SwiftComplexityCore/Analysis/FunctionDetector.swift
@@ -55,7 +55,8 @@ class FunctionDetector: SyntaxVisitor {
             body: node.body,
             location: location,
             enclosingTypeName: enclosingTypeName(of: node),
-            suppressedMetrics: SuppressionParser.suppressedMetrics(in: node.leadingTrivia)
+            suppressedMetrics: SuppressionParser.suppressedMetrics(
+                in: node.leadingTrivia, applicableTo: SuppressedMetric.functionLevel)
         )
 
         detectedFunctions.append(detectedFunction)
@@ -74,7 +75,8 @@ class FunctionDetector: SyntaxVisitor {
             body: node.body,
             location: location,
             enclosingTypeName: enclosingTypeName(of: node),
-            suppressedMetrics: SuppressionParser.suppressedMetrics(in: node.leadingTrivia)
+            suppressedMetrics: SuppressionParser.suppressedMetrics(
+                in: node.leadingTrivia, applicableTo: SuppressedMetric.functionLevel)
         )
 
         detectedFunctions.append(detectedFunction)
@@ -93,7 +95,8 @@ class FunctionDetector: SyntaxVisitor {
             body: node.body,
             location: location,
             enclosingTypeName: enclosingTypeName(of: node),
-            suppressedMetrics: SuppressionParser.suppressedMetrics(in: node.leadingTrivia)
+            suppressedMetrics: SuppressionParser.suppressedMetrics(
+                in: node.leadingTrivia, applicableTo: SuppressedMetric.functionLevel)
         )
 
         detectedFunctions.append(detectedFunction)
@@ -138,7 +141,8 @@ class FunctionDetector: SyntaxVisitor {
             body: node.body,
             location: location,
             enclosingTypeName: enclosingTypeName(of: node),
-            suppressedMetrics: SuppressionParser.suppressedMetrics(in: node.leadingTrivia)
+            suppressedMetrics: SuppressionParser.suppressedMetrics(
+                in: node.leadingTrivia, applicableTo: SuppressedMetric.functionLevel)
         )
 
         detectedFunctions.append(detectedFunction)
@@ -230,7 +234,8 @@ class FunctionDetector: SyntaxVisitor {
             body: codeBlock,
             location: location,
             enclosingTypeName: enclosingTypeName(of: variable),
-            suppressedMetrics: SuppressionParser.suppressedMetrics(in: variable.leadingTrivia)
+            suppressedMetrics: SuppressionParser.suppressedMetrics(
+                in: variable.leadingTrivia, applicableTo: SuppressedMetric.functionLevel)
         )
 
         detectedFunctions.append(detectedFunction)

--- a/Sources/SwiftComplexityCore/Analysis/NominalTypeDetector.swift
+++ b/Sources/SwiftComplexityCore/Analysis/NominalTypeDetector.swift
@@ -28,17 +28,23 @@ struct DetectedNominal {
     let type: NominalTypeKind
     let members: MemberBlockItemListSyntax
     let location: SourceLocation
+    /// Type-level metrics suppressed via a `// swift-complexity:disable`
+    /// comment directly above this type declaration. Never cascades to the
+    /// type's member functions.
+    let suppressedMetrics: Set<SuppressedMetric>
 
     init(
         name: String,
         type: NominalTypeKind,
         members: MemberBlockItemListSyntax,
-        location: SourceLocation
+        location: SourceLocation,
+        suppressedMetrics: Set<SuppressedMetric> = []
     ) {
         self.name = name
         self.type = type
         self.members = members
         self.location = location
+        self.suppressedMetrics = suppressedMetrics
     }
 }
 
@@ -67,7 +73,9 @@ class NominalTypeDetector: SyntaxVisitor {
             name: name,
             type: .class,
             members: node.memberBlock.members,
-            location: location
+            location: location,
+            suppressedMetrics: SuppressionParser.suppressedMetrics(
+                in: node.leadingTrivia, applicableTo: SuppressedMetric.typeLevel)
         )
 
         detectedTypes.append(detectedNominal)
@@ -83,7 +91,9 @@ class NominalTypeDetector: SyntaxVisitor {
             name: name,
             type: .struct,
             members: node.memberBlock.members,
-            location: location
+            location: location,
+            suppressedMetrics: SuppressionParser.suppressedMetrics(
+                in: node.leadingTrivia, applicableTo: SuppressedMetric.typeLevel)
         )
 
         detectedTypes.append(detectedNominal)
@@ -99,7 +109,9 @@ class NominalTypeDetector: SyntaxVisitor {
             name: name,
             type: .actor,
             members: node.memberBlock.members,
-            location: location
+            location: location,
+            suppressedMetrics: SuppressionParser.suppressedMetrics(
+                in: node.leadingTrivia, applicableTo: SuppressedMetric.typeLevel)
         )
 
         detectedTypes.append(detectedNominal)

--- a/Sources/SwiftComplexityCore/Analysis/SuppressionParser.swift
+++ b/Sources/SwiftComplexityCore/Analysis/SuppressionParser.swift
@@ -13,7 +13,18 @@ enum SuppressionParser {
 
     /// Returns the set of metrics suppressed by any `swift-complexity:disable`
     /// comment found in `trivia`. Empty when no such comment is present.
-    static func suppressedMetrics(in trivia: Trivia) -> Set<SuppressedMetric> {
+    ///
+    /// The parsed metrics are intersected with `scope` — the metrics that
+    /// apply to the declaration kind the trivia precedes. This keeps a bare
+    /// disable meaning "every metric of this declaration itself" (a bare
+    /// disable above a type suppresses only the type-level metric, never its
+    /// member functions), and makes naming a metric of the wrong level (e.g.
+    /// `lcom4` above a function) suppress nothing rather than something
+    /// surprising.
+    static func suppressedMetrics(
+        in trivia: Trivia,
+        applicableTo scope: Set<SuppressedMetric>
+    ) -> Set<SuppressedMetric> {
         var result: Set<SuppressedMetric> = []
         for piece in trivia {
             guard case .lineComment(let text) = piece,
@@ -21,7 +32,7 @@ enum SuppressionParser {
             else { continue }
             result.formUnion(metrics)
         }
-        return result
+        return result.intersection(scope)
     }
 
     /// Parses a single `//`-prefixed comment. Returns `nil` when the comment

--- a/Sources/SwiftComplexityCore/Models/ClassCohesion.swift
+++ b/Sources/SwiftComplexityCore/Models/ClassCohesion.swift
@@ -34,6 +34,12 @@ public struct ClassCohesion: Codable, Hashable, Sendable {
     /// Source code location
     public let location: SourceLocation
 
+    /// Type-level metrics excluded from cohesion judgments by a
+    /// `// swift-complexity:disable` comment directly above this type
+    /// declaration. `nil` when nothing is suppressed; the LCOM4 value is
+    /// still reported even when suppressed, only the judgment is skipped.
+    public let suppressedMetrics: Set<SuppressedMetric>?
+
     /// Cohesion level (computed property)
     public var cohesionLevel: CohesionLevel {
         switch lcom4 {
@@ -52,7 +58,8 @@ public struct ClassCohesion: Codable, Hashable, Sendable {
         lcom4: Int,
         methodCount: Int,
         propertyCount: Int,
-        location: SourceLocation
+        location: SourceLocation,
+        suppressedMetrics: Set<SuppressedMetric>? = nil
     ) {
         self.name = name
         self.type = type
@@ -60,6 +67,12 @@ public struct ClassCohesion: Codable, Hashable, Sendable {
         self.methodCount = methodCount
         self.propertyCount = propertyCount
         self.location = location
+        self.suppressedMetrics = suppressedMetrics
+    }
+
+    /// Whether `metric` is suppressed for this type.
+    public func isSuppressed(_ metric: SuppressedMetric) -> Bool {
+        suppressedMetrics?.contains(metric) ?? false
     }
 }
 

--- a/Sources/SwiftComplexityCore/Models/FunctionComplexity.swift
+++ b/Sources/SwiftComplexityCore/Models/FunctionComplexity.swift
@@ -1,10 +1,24 @@
 import Foundation
 
-/// A per-function metric that can be excluded from threshold checks via a
+/// A metric that can be excluded from threshold checks via a
 /// `// swift-complexity:disable` comment.
+///
+/// `cyclomatic`/`cognitive` apply to function-level declarations,
+/// `lcom4` to type declarations (class/struct/actor). Which subset a
+/// directive can actually suppress is decided by the declaration it
+/// precedes — see `SuppressedMetric.functionLevel`/`typeLevel`.
 public enum SuppressedMetric: String, Codable, Hashable, Sendable, CaseIterable {
     case cyclomatic
     case cognitive
+    case lcom4
+}
+
+extension SuppressedMetric {
+    /// Metrics a directive above a function-level declaration can suppress.
+    public static let functionLevel: Set<SuppressedMetric> = [.cyclomatic, .cognitive]
+
+    /// Metrics a directive above a type declaration can suppress.
+    public static let typeLevel: Set<SuppressedMetric> = [.lcom4]
 }
 
 /// Represents complexity metrics for a single function or method

--- a/Sources/SwiftComplexityCore/Output/OutputFormatter.swift
+++ b/Sources/SwiftComplexityCore/Output/OutputFormatter.swift
@@ -367,11 +367,14 @@ public class OutputFormatter {
     }
 
     /// Creates a cohesion diagnostic message
+    ///
+    /// A type suppressed via `// swift-complexity:disable` emits no
+    /// diagnostic; its LCOM4 value stays visible in the other output formats.
     private func createCohesionDiagnostic(
         for cohesion: ClassCohesion,
         in filePath: String
     ) -> String? {
-        guard cohesion.cohesionLevel == .low else { return nil }
+        guard !cohesion.isSuppressed(.lcom4), cohesion.cohesionLevel == .low else { return nil }
 
         let severity = cohesion.lcom4 >= 5 ? "error" : "warning"
         let message =

--- a/Sources/SwiftComplexityCore/Output/SARIFReport.swift
+++ b/Sources/SwiftComplexityCore/Output/SARIFReport.swift
@@ -186,7 +186,7 @@ extension OutputFormatter {
         let uri = relativizedURI(for: result.filePath)
 
         return cohesions.compactMap { cohesion in
-            guard cohesion.cohesionLevel == .low else { return nil }
+            guard !cohesion.isSuppressed(.lcom4), cohesion.cohesionLevel == .low else { return nil }
             let message =
                 "\(cohesion.type.rawValue.capitalized) '\(cohesion.name)' has low cohesion (LCOM4: \(cohesion.lcom4))"
             return SARIFResult(

--- a/Tests/SwiftComplexityCoreTests/Fixtures/suppressed_types.swift
+++ b/Tests/SwiftComplexityCoreTests/Fixtures/suppressed_types.swift
@@ -1,0 +1,45 @@
+// Fixtures for type-level suppression comment detection (LCOM4).
+// Suppression is parsed from the type declaration's leading trivia by
+// NominalTypeDetector; the LCOM4 value itself is computed elsewhere.
+
+// swift-complexity:disable
+class BareSuppressedClass {
+    var a: Int = 0
+    var b: Int = 0
+    func useA() { a += 1 }
+    func useB() { b += 1 }
+}
+
+// swift-complexity:disable lcom4
+struct Lcom4SuppressedStruct {
+    var a: Int
+    var b: Int
+    func useA() -> Int { a }
+    func useB() -> Int { b }
+}
+
+// A regular comment above a type must not trigger suppression.
+actor NotSuppressedActor {
+    var a: Int = 0
+    var b: Int = 0
+    func useA() { a += 1 }
+    func useB() { b += 1 }
+}
+
+// A function-level metric name above a type suppresses nothing (fails closed).
+// swift-complexity:disable cyclomatic
+class WrongLevelMetricClass {
+    var a: Int = 0
+    var b: Int = 0
+    func useA() { a += 1 }
+    func useB() { b += 1 }
+}
+
+// A typo'd metric name suppresses nothing, unlike a bare disable.
+// swift-complexity:disable lcom44
+class TypoedMetricClass {
+    var a: Int = 0
+    var b: Int = 0
+    func useA() { a += 1 }
+    func useB() { b += 1 }
+}

--- a/Tests/SwiftComplexityCoreTests/SwiftComplexityTests.swift
+++ b/Tests/SwiftComplexityCoreTests/SwiftComplexityTests.swift
@@ -427,7 +427,9 @@ struct FunctionDetectionTests {
         }
 
         // Then
-        #expect(suppressed("fullySuppressed") == Set(SuppressedMetric.allCases))
+        // Bare disable on a function yields only function-level metrics —
+        // lcom4 must never leak into a function's suppression set.
+        #expect(suppressed("fullySuppressed") == SuppressedMetric.functionLevel)
         #expect(suppressed("cyclomaticOnlySuppressed") == [.cyclomatic])
         #expect(suppressed("cognitiveOnlySuppressed") == [.cognitive])
         // An unrelated preceding comment must not trigger suppression.
@@ -435,7 +437,7 @@ struct FunctionDetectionTests {
         // A typo'd metric name fails closed: nothing is suppressed.
         #expect(suppressed("typoedMetricNotSuppressed") == nil)
         // Suppression scopes to a computed property's own declaration too.
-        #expect(suppressed("isValid") == Set(SuppressedMetric.allCases))
+        #expect(suppressed("isValid") == SuppressedMetric.functionLevel)
     }
 }
 
@@ -444,10 +446,17 @@ struct FunctionDetectionTests {
 @Suite("Suppression parsing", .tags(.unit, .detectors))
 struct SuppressionParserTests {
 
-    @Test("Bare disable suppresses all metrics")
+    @Test("Bare disable suppresses every metric applicable to the declaration")
     func bareDisable() {
         let trivia: Trivia = [.lineComment("// swift-complexity:disable"), .newlines(1)]
-        #expect(SuppressionParser.suppressedMetrics(in: trivia) == Set(SuppressedMetric.allCases))
+        #expect(
+            SuppressionParser.suppressedMetrics(
+                in: trivia, applicableTo: SuppressedMetric.functionLevel)
+                == SuppressedMetric.functionLevel)
+        #expect(
+            SuppressionParser.suppressedMetrics(
+                in: trivia, applicableTo: SuppressedMetric.typeLevel)
+                == SuppressedMetric.typeLevel)
     }
 
     @Test("Specific metric name suppresses only that metric")
@@ -455,7 +464,9 @@ struct SuppressionParserTests {
         let trivia: Trivia = [
             .lineComment("// swift-complexity:disable cyclomatic"), .newlines(1),
         ]
-        #expect(SuppressionParser.suppressedMetrics(in: trivia) == [.cyclomatic])
+        #expect(
+            SuppressionParser.suppressedMetrics(
+                in: trivia, applicableTo: SuppressedMetric.functionLevel) == [.cyclomatic])
     }
 
     @Test("Comma-separated metric names are all recognized")
@@ -463,7 +474,10 @@ struct SuppressionParserTests {
         let trivia: Trivia = [
             .lineComment("// swift-complexity:disable cyclomatic, cognitive"), .newlines(1),
         ]
-        #expect(SuppressionParser.suppressedMetrics(in: trivia) == Set(SuppressedMetric.allCases))
+        #expect(
+            SuppressionParser.suppressedMetrics(
+                in: trivia, applicableTo: SuppressedMetric.functionLevel)
+                == [.cyclomatic, .cognitive])
     }
 
     @Test("Unrecognized metric name suppresses nothing (fails closed on a typo)")
@@ -471,25 +485,115 @@ struct SuppressionParserTests {
         let trivia: Trivia = [
             .lineComment("// swift-complexity:disable cyclomattic"), .newlines(1),
         ]
-        #expect(SuppressionParser.suppressedMetrics(in: trivia).isEmpty)
+        #expect(
+            SuppressionParser.suppressedMetrics(
+                in: trivia, applicableTo: SuppressedMetric.functionLevel
+            ).isEmpty)
+    }
+
+    @Test("Metric of the wrong declaration level suppresses nothing")
+    func wrongLevelMetricSuppressesNothing() {
+        // lcom4 above a function-level declaration
+        let lcom4Trivia: Trivia = [
+            .lineComment("// swift-complexity:disable lcom4"), .newlines(1),
+        ]
+        #expect(
+            SuppressionParser.suppressedMetrics(
+                in: lcom4Trivia, applicableTo: SuppressedMetric.functionLevel
+            ).isEmpty)
+
+        // cyclomatic above a type declaration
+        let cyclomaticTrivia: Trivia = [
+            .lineComment("// swift-complexity:disable cyclomatic"), .newlines(1),
+        ]
+        #expect(
+            SuppressionParser.suppressedMetrics(
+                in: cyclomaticTrivia, applicableTo: SuppressedMetric.typeLevel
+            ).isEmpty)
+    }
+
+    @Test("lcom4 token is recognized for type declarations")
+    func lcom4Token() {
+        let trivia: Trivia = [.lineComment("// swift-complexity:disable lcom4"), .newlines(1)]
+        #expect(
+            SuppressionParser.suppressedMetrics(
+                in: trivia, applicableTo: SuppressedMetric.typeLevel) == [.lcom4])
     }
 
     @Test("Unrelated comment is not treated as a directive")
     func unrelatedCommentIgnored() {
         let trivia: Trivia = [.lineComment("// just a regular comment"), .newlines(1)]
-        #expect(SuppressionParser.suppressedMetrics(in: trivia).isEmpty)
+        #expect(
+            SuppressionParser.suppressedMetrics(
+                in: trivia, applicableTo: SuppressedMetric.functionLevel
+            ).isEmpty)
     }
 
     @Test("Doc comments are never treated as a directive")
     func docCommentIgnored() {
         let trivia: Trivia = [.docLineComment("/// swift-complexity:disable"), .newlines(1)]
-        #expect(SuppressionParser.suppressedMetrics(in: trivia).isEmpty)
+        #expect(
+            SuppressionParser.suppressedMetrics(
+                in: trivia, applicableTo: SuppressedMetric.functionLevel
+            ).isEmpty)
     }
 
     @Test("A false-prefix match like disableFoo is not our directive")
     func falsePrefixNotMatched() {
         let trivia: Trivia = [.lineComment("// swift-complexity:disableFoo"), .newlines(1)]
-        #expect(SuppressionParser.suppressedMetrics(in: trivia).isEmpty)
+        #expect(
+            SuppressionParser.suppressedMetrics(
+                in: trivia, applicableTo: SuppressedMetric.functionLevel
+            ).isEmpty)
+    }
+}
+
+// MARK: - Nominal Type Detection Tests
+
+@Suite("Nominal type detection", .tags(.unit, .detectors))
+struct NominalTypeDetectorTests {
+
+    @Test("Type-level suppression comments are scoped to their own declaration")
+    func typeSuppressionScoping() throws {
+        // Given
+        let code = try loadFixture("suppressed_types")
+        let sourceFile = Parser.parse(source: code)
+        let detector = NominalTypeDetector(viewMode: .sourceAccurate)
+
+        // When
+        let types = detector.detectTypes(in: sourceFile)
+        func suppressed(_ name: String) -> Set<SuppressedMetric>? {
+            types.first { $0.name == name }?.suppressedMetrics
+        }
+
+        // Then
+        #expect(types.count == 5)
+        // A bare disable above a type suppresses only the type's own metrics,
+        // never its member functions.
+        #expect(suppressed("BareSuppressedClass") == SuppressedMetric.typeLevel)
+        #expect(suppressed("Lcom4SuppressedStruct") == [.lcom4])
+        #expect(suppressed("NotSuppressedActor") == [])
+        // A function-level metric name above a type fails closed.
+        #expect(suppressed("WrongLevelMetricClass") == [])
+        #expect(suppressed("TypoedMetricClass") == [])
+    }
+
+    @Test("Member functions of a bare-suppressed type stay checked")
+    func noCascadeToMemberFunctions() throws {
+        // Given
+        let code = try loadFixture("suppressed_types")
+        let sourceFile = Parser.parse(source: code)
+        let detector = FunctionDetector(viewMode: .sourceAccurate)
+
+        // When
+        let functions = detector.detectFunctions(in: sourceFile)
+
+        // Then - no function inherits suppression from its enclosing type
+        for function in functions {
+            #expect(
+                function.suppressedMetrics.isEmpty,
+                "\(function.name) must not inherit type-level suppression")
+        }
     }
 }
 
@@ -577,7 +681,7 @@ struct OutputFormatterTests {
                 name: "fullySuppressed", signature: "func fullySuppressed()",
                 cyclomaticComplexity: 20, cognitiveComplexity: 20,
                 location: SourceLocation(line: 3, column: 1),
-                suppressedMetrics: Set(SuppressedMetric.allCases))
+                suppressedMetrics: SuppressedMetric.functionLevel)
         ]
         let result = ComplexityResult(filePath: "test.swift", functions: functions)
         let formatter = OutputFormatter()
@@ -716,6 +820,35 @@ struct OutputFormatterTests {
         #expect(results.first?["level"] as? String == "error")
         #expect(output.contains("GodClass"))
         #expect(!output.contains("FocusedClass"))
+    }
+
+    @Test("SARIF and Xcode formats skip a suppressed low-cohesion type")
+    func cohesionSuppressionSkipsJudgments() throws {
+        // Given - low cohesion (lcom4 5 would normally be an error), suppressed
+        let cohesions = [
+            ClassCohesion(
+                name: "SuppressedGodClass", type: .class, lcom4: 5, methodCount: 10,
+                propertyCount: 8, location: SourceLocation(line: 3, column: 1),
+                suppressedMetrics: [.lcom4])
+        ]
+        let result = ComplexityResult(
+            filePath: "test.swift", functions: [], classCohesions: cohesions)
+        let formatter = OutputFormatter()
+
+        // When
+        let sarif = formatter.format(results: [result], format: .sarif, options: OutputOptions())
+        let xcode = formatter.format(results: [result], format: .xcode, options: OutputOptions())
+        let json = formatter.format(results: [result], format: .json, options: OutputOptions())
+
+        // Then - no judgment in sarif/xcode, but the value stays visible in json
+        let parsed =
+            try JSONSerialization.jsonObject(with: Data(sarif.utf8)) as? [String: Any] ?? [:]
+        let runs = parsed["runs"] as? [[String: Any]] ?? []
+        let sarifResults = runs.first?["results"] as? [[String: Any]] ?? []
+        #expect(sarifResults.isEmpty)
+        #expect(xcode.isEmpty)
+        #expect(json.contains("SuppressedGodClass"))
+        #expect(json.contains("\"lcom4\":5"))
     }
 }
 

--- a/Tests/SwiftComplexityCoreTests/ThresholdConfigurationTests.swift
+++ b/Tests/SwiftComplexityCoreTests/ThresholdConfigurationTests.swift
@@ -153,7 +153,7 @@ struct ThresholdConfigurationTests {
             let config = ThresholdConfiguration.empty
             let fn = function(
                 type: nil, cyclomatic: 20, cognitive: 20,
-                suppressed: Set(SuppressedMetric.allCases))
+                suppressed: SuppressedMetric.functionLevel)
             #expect(!config.isExceeded(fn, fallback: 5))
         }
 

--- a/docs/user-guide/usage.md
+++ b/docs/user-guide/usage.md
@@ -138,11 +138,13 @@ swift run swift-complexity Sources --recursive --config config/complexity.yml
 
 ## Suppressing Specific Violations
 
-When a function's complexity is unavoidable and reviewed on purpose, add a
-`// swift-complexity:disable` comment directly above its declaration (function,
-initializer, deinitializer, or computed property). There is no separate
-"disable next line" form and no matching "enable" comment — the comment always
-applies to exactly the one declaration it immediately precedes.
+When a declaration's complexity is unavoidable and reviewed on purpose, add a
+`// swift-complexity:disable` comment directly above it. The comment works on
+function-level declarations (function, initializer, deinitializer, or computed
+property) for `cyclomatic`/`cognitive`, and on type declarations
+(class/struct/actor) for `lcom4`. There is no separate "disable next line" form
+and no matching "enable" comment — the comment always applies to exactly the
+one declaration it immediately precedes.
 
 ```swift
 // swift-complexity:disable
@@ -156,12 +158,23 @@ func stateMachine(_ event: Event) {
     // Only cognitive complexity is suppressed; cyclomatic is still checked.
     ...
 }
+
+// swift-complexity:disable lcom4
+class LegacyOrderManager {
+    // Low cohesion is accepted while an incremental refactor is tracked
+    // elsewhere; member functions are still checked for complexity.
+    ...
+}
 ```
 
-- A bare `// swift-complexity:disable` suppresses every metric for that
-  declaration.
-- Naming specific metrics (`cyclomatic`, `cognitive`, space- or comma-separated)
-  suppresses only those, leaving the others checked as usual.
+- A bare `// swift-complexity:disable` suppresses every metric **of that
+  declaration itself**: `cyclomatic` and `cognitive` on a function,
+  `lcom4` on a type. A bare disable above a type never cascades to its
+  member functions — suppress each function individually if needed.
+- Naming specific metrics (`cyclomatic`, `cognitive`, `lcom4`, space- or
+  comma-separated) suppresses only those, leaving the others checked as usual.
+- A metric name that does not apply to the declaration level (e.g. `lcom4`
+  above a function, or `cyclomatic` above a class) suppresses nothing.
 - An unrecognized metric name suppresses nothing for that comment — suppression
   fails closed on a typo instead of silently disabling every metric.
 - `///` documentation comments are never treated as a directive, so a doc
@@ -169,12 +182,10 @@ func stateMachine(_ event: Event) {
 - Suppressed values are still computed and shown in every output format; only
   the threshold judgment (and therefore exit code 1, and any warning in
   `xcode`/`sarif` output) is skipped for the suppressed metric.
-- LCOM4 class cohesion has no suppression mechanism yet, since it is a
-  type-level metric rather than a per-function one.
 
-Run with `--report-suppressions` to print every suppressed function and its
-current metric values to stderr, so suppression comments stay visible instead
-of silently hiding violations:
+Run with `--report-suppressions` to print every suppressed function and type
+with its current metric values to stderr, so suppression comments stay visible
+instead of silently hiding violations:
 
 ```bash
 swift run swift-complexity Sources --recursive --threshold 10 --report-suppressions


### PR DESCRIPTION
## Summary

Extends `// swift-complexity:disable` to type declarations (class/struct/actor) so a reviewed low-cohesion type can be exempted from LCOM4 judgments. Previously the only workaround was `--exclude`, which hides the whole file's complexity violations too.

Closes #36.

## Syntax

```swift
// swift-complexity:disable lcom4
class LegacyOrderManager { ... }  // member functions are still checked

// swift-complexity:disable
struct ScatteredHelper { ... }    // bare form: suppresses the type's own metrics (= lcom4)
```

## Design

- **Scope intersection**: `SuppressionParser` now takes an `applicableTo` scope and intersects parsed metrics with it — `FunctionDetector` passes `functionLevel` (cyclomatic/cognitive), `NominalTypeDetector` passes `typeLevel` (lcom4). This yields three properties at once:
  - A bare disable means "every metric of this declaration itself": above a type it suppresses only `lcom4` and **never cascades to member functions** (a dedicated test pins this).
  - A metric of the wrong level (`lcom4` above a function, `cyclomatic` above a class) suppresses nothing — the fail-closed contract from #35 extends naturally.
  - **JSON backward compatibility**: without the intersection, adding `lcom4` to `SuppressedMetric.allCases` would have leaked `"lcom4"` into the `suppressedMetrics` array of bare-disabled functions, changing v1.1.0 output. A test now pins the function set to `{cyclomatic, cognitive}`.
- **Values stay visible, judgments are skipped** (same contract as #35): `ClassCohesion` gains an optional `suppressedMetrics` set; the LCOM4 value is still computed and shown everywhere. All three cohesion judgment sites are gated — the Xcode diagnostic, SARIF's `lcom4_cohesion` results, and the CLI's threshold filtering. The exit code needs no change because LCOM4 never influenced it.
- `--report-suppressions` now also lists suppressed types with current LCOM4 values, and its help text mentions types.
- `CohesionSummary` statistics and `cohesionLevel` classification are deliberately unchanged — they are data, not judgments.

## Verification

- `swift test`: 107 tests pass, including the **first direct unit tests for `NominalTypeDetector`** (type-level scoping fixture: bare/`lcom4`-scoped/unsuppressed/wrong-level/typo cases), a no-cascade test over member functions, parser scope-intersection tests, and a formatter test asserting a suppressed LCOM4=5 class produces no SARIF result and no Xcode diagnostic while remaining visible in JSON
- E2E against the real LCOM4 path (`--lcom4 --index-store-path`): a suppressed LCOM4=3 class disappeared from `xcode`/`sarif` output while an identical unsuppressed twin still reported; `--report-suppressions` listed it; JSON kept both values
- Function-level JSON output verified unchanged against the v1.1.0 fixtures (no `lcom4` leakage)
- `swift-format` clean; markdownlint error count identical to `main`

https://claude.ai/code/session_01GaTHVDhSAx76RbLmVziLQu