### PR TITLE
feat: Add official GitHub Action and CI integration guide

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,11 @@ jobs:
       - name: Run swift-complexity action
         id: analysis
         uses: ./
+        env:
+          # TEMPORARY, tied to the container above: the v1.1.0 binary embeds a
+          # runpath from its build machine, so point the loader at the
+          # container's Swift runtime. Harmless on macOS (dyld ignores it).
+          LD_LIBRARY_PATH: /usr/lib/swift/linux
         with:
           # Pinned to a published release so the download path is deterministic;
           # fail-on-threshold is off because this job verifies the action

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,9 @@ jobs:
           ls ${TOOLCHAIN_USR}/lib/swift || (echo "Swift lib directory not found!" && exit 1)
           test -d ${TOOLCHAIN_USR}/lib/swift/Block || (echo "Block header not found!" && exit 1)
           # --- end debug ---
-          swift build --configuration release \
+          # --static-swift-stdlib matches the release build so static linking
+          # breakage is caught on every PR, not at release time
+          swift build --configuration release --static-swift-stdlib \
             -Xcxx -I${TOOLCHAIN_USR}/lib/swift \
             -Xcxx -I${TOOLCHAIN_USR}/lib/swift/Block
 
@@ -128,13 +130,27 @@ jobs:
   action-test:
     name: Action Test
     strategy:
+      fail-fast: false
       matrix:
-        os: [macos-15, ubuntu-22.04]
+        include:
+          - os: macos-15
+            container: ""
+          # TEMPORARY container: v1.1.0 Linux binaries are dynamically linked
+          # against the Swift runtime, so the test runs in a Swift image. Once
+          # a release built with --static-swift-stdlib ships (v1.2.0+), pin
+          # `version` to it and drop the container to prove runtime-free use.
+          - os: ubuntu-22.04
+            container: "swift:6.2-jammy"
     runs-on: ${{ matrix.os }}
+    container: ${{ matrix.container }}
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
+
+      - name: Install prerequisites (container)
+        if: matrix.container != ''
+        run: apt-get update && apt-get install -y jq curl
 
       - name: Run swift-complexity action
         id: analysis

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,34 @@ jobs:
             --toolchain-path "${TOOLCHAIN}" \
             --format json --recursive
 
+  action-test:
+    name: Action Test
+    strategy:
+      matrix:
+        os: [macos-15, ubuntu-22.04]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Run swift-complexity action
+        id: analysis
+        uses: ./
+        with:
+          # Pinned to a published release so the download path is deterministic;
+          # fail-on-threshold is off because this job verifies the action
+          # mechanics, not this repository's complexity.
+          version: "1.1.0"
+          fail-on-threshold: "false"
+
+      - name: Verify SARIF report structure
+        run: |
+          REPORT="${{ steps.analysis.outputs.report-file }}"
+          test -s "$REPORT" || { echo "Report is missing or empty: $REPORT"; exit 1; }
+          jq -e '.runs[0].tool.driver.name == "swift-complexity"' "$REPORT" > /dev/null
+          echo "SARIF report OK: $REPORT ($(jq '.runs[0].results | length' "$REPORT") results)"
+
   lint:
     name: Code Quality
     runs-on: macos-15

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,16 +148,21 @@ jobs:
               --arch ${{ matrix.arch }} \
               --product SwiftComplexityMCP
           else
-            # Linux: Get toolchain path for libdispatch headers
+            # Linux: Get toolchain path for libdispatch headers.
+            # --static-swift-stdlib makes the binaries self-contained so they
+            # run on machines without a Swift runtime (GitHub Action runners,
+            # bare containers, etc.).
             SWIFTLY_HOME="${HOME}/.local/share/swiftly"
             TOOLCHAIN_USR=$(ls -d ${SWIFTLY_HOME}/toolchains/*/usr 2>/dev/null | head -1)
             swift build \
               --configuration release \
+              --static-swift-stdlib \
               --product SwiftComplexityCLI \
               -Xcxx -I${TOOLCHAIN_USR}/lib/swift \
               -Xcxx -I${TOOLCHAIN_USR}/lib/swift/Block
             swift build \
               --configuration release \
+              --static-swift-stdlib \
               --product SwiftComplexityMCP \
               -Xcxx -I${TOOLCHAIN_USR}/lib/swift \
               -Xcxx -I${TOOLCHAIN_USR}/lib/swift/Block

--- a/README.md
+++ b/README.md
@@ -85,6 +85,35 @@ swift run SwiftComplexityCLI Sources --threshold 15 --recursive
 # Exit code 1: One or more functions exceed threshold
 ```
 
+### GitHub Action
+
+Add a complexity gate with inline PR annotations in one step (requires
+`v1.2.0` or later):
+
+```yaml
+permissions:
+  contents: read
+  security-events: write
+
+steps:
+  - uses: actions/checkout@v5
+
+  - name: Analyze complexity
+    id: analysis
+    uses: fummicc1/swift-complexity@v1.2.0
+    with:
+      paths: Sources
+      threshold: "10"
+
+  - uses: github/codeql-action/upload-sarif@v3
+    if: always()
+    with:
+      sarif_file: ${{ steps.analysis.outputs.report-file }}
+```
+
+See the [CI Integration guide](docs/user-guide/ci-integration.md) for all
+inputs, report-only setups, and a plain-CLI alternative.
+
 ### Per-Type Thresholds
 
 Assign different thresholds per nominal type (class/struct/enum/actor and extensions)
@@ -163,6 +192,7 @@ See the [Usage Guide](docs/user-guide/usage.md#per-type-complexity-thresholds) f
 - **[User Guide](docs/user-guide/)**: Installation, usage, and examples
 - **[Complexity Metrics](docs/user-guide/complexity-metrics.md)**: Detailed metric explanations and examples
 - **[Output Formats](docs/user-guide/output-formats.md)**: Text, JSON, XML, Xcode diagnostics, and SARIF format specifications
+- **[CI Integration](docs/user-guide/ci-integration.md)**: GitHub Action and Code Scanning setup
 - **[Development Guide](docs/development/DEVELOPMENT.md)**: Setup for contributors
 - **[Debug Website](debug-website/)**: Web-based interactive analyzer documentation
 

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,191 @@
+name: "Swift Complexity Analysis"
+description: >-
+  Analyze Swift code complexity (cyclomatic, cognitive, LCOM4) with
+  swift-complexity and enforce thresholds in CI. Generates SARIF for
+  GitHub Code Scanning by default.
+author: "fummicc1"
+
+branding:
+  icon: "bar-chart-2"
+  color: "orange"
+
+inputs:
+  version:
+    description: >-
+      swift-complexity release version to use (e.g. "1.1.0"), or "latest"
+      to resolve the most recent release.
+    required: false
+    default: "latest"
+  paths:
+    description: >-
+      Space-separated files or directories to analyze, relative to the
+      workspace.
+    required: false
+    default: "Sources"
+  format:
+    description: "Output format: text, json, xml, xcode, or sarif."
+    required: false
+    default: "sarif"
+  output-file:
+    description: "File the report is written to."
+    required: false
+    default: "swift-complexity.sarif"
+  threshold:
+    description: >-
+      Complexity threshold passed as --threshold. Set to an empty string
+      to omit it (e.g. when thresholds come from a config file). Without
+      any threshold the SARIF report contains no results.
+    required: false
+    default: "10"
+  config:
+    description: "Path to a .swift-complexity.yml threshold config file."
+    required: false
+    default: ""
+  fail-on-threshold:
+    description: >-
+      Fail the step when the analysis exits with code 1 (threshold
+      exceeded). Set to "false" to continue anyway; exit codes other
+      than 0 and 1 always fail.
+    required: false
+    default: "true"
+  extra-args:
+    description: 'Additional CLI arguments (e.g. "--exclude Tests").'
+    required: false
+    default: ""
+  github-token:
+    description: "Token used to resolve the latest release via the GitHub API."
+    required: false
+    default: ${{ github.token }}
+
+outputs:
+  report-file:
+    description: "Path to the generated report file."
+    value: ${{ steps.run-analysis.outputs.report-file }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Resolve version
+      id: resolve-version
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        REQUESTED_VERSION: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+        if [[ "$REQUESTED_VERSION" == "latest" ]]; then
+          TAG=$(curl -fsSL \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/fummicc1/swift-complexity/releases/latest" \
+            | grep -m1 '"tag_name"' | sed -E 's/.*"tag_name": *"v?([^"]+)".*/\1/')
+          if [[ -z "$TAG" ]]; then
+            echo "::error::Failed to resolve the latest swift-complexity release."
+            exit 1
+          fi
+          VERSION="$TAG"
+        else
+          VERSION="${REQUESTED_VERSION#v}"
+        fi
+        echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+        echo "Using swift-complexity $VERSION"
+
+    - name: Detect platform
+      id: detect-platform
+      shell: bash
+      run: |
+        set -euo pipefail
+        ARCH=$(uname -m)
+        case "$RUNNER_OS" in
+          macOS)
+            PLATFORM="macos"
+            [[ "$ARCH" == "x86_64" || "$ARCH" == "arm64" ]] || {
+              echo "::error::Unsupported macOS architecture: $ARCH"; exit 1;
+            }
+            ;;
+          Linux)
+            PLATFORM="linux"
+            if [[ "$ARCH" != "x86_64" ]]; then
+              echo "::error::Linux $ARCH is not supported; only x86_64 binaries are published."
+              exit 1
+            fi
+            ;;
+          *)
+            echo "::error::Unsupported runner OS: $RUNNER_OS"; exit 1
+            ;;
+        esac
+        echo "platform=$PLATFORM" >> "$GITHUB_OUTPUT"
+        echo "arch=$ARCH" >> "$GITHUB_OUTPUT"
+
+    - name: Download and verify binary
+      id: download
+      shell: bash
+      env:
+        VERSION: ${{ steps.resolve-version.outputs.version }}
+        PLATFORM: ${{ steps.detect-platform.outputs.platform }}
+        ARCH: ${{ steps.detect-platform.outputs.arch }}
+      run: |
+        set -euo pipefail
+        ASSET="SwiftComplexityCLI-${VERSION}-${PLATFORM}-${ARCH}.tar.gz"
+        BASE_URL="https://github.com/fummicc1/swift-complexity/releases/download/v${VERSION}"
+        WORK_DIR="${RUNNER_TEMP}/swift-complexity-action"
+        mkdir -p "$WORK_DIR"
+        cd "$WORK_DIR"
+
+        curl -fsSL -o "$ASSET" "${BASE_URL}/${ASSET}"
+        curl -fsSL -o "${ASSET}.sha256" "${BASE_URL}/${ASSET}.sha256"
+
+        if [[ "$RUNNER_OS" == "macOS" ]]; then
+          shasum -a 256 -c "${ASSET}.sha256"
+        else
+          sha256sum -c "${ASSET}.sha256"
+        fi
+
+        tar -xzf "$ASSET"
+        BINARY="${WORK_DIR}/SwiftComplexityCLI-${VERSION}-${PLATFORM}-${ARCH}/SwiftComplexityCLI"
+        if [[ ! -x "$BINARY" ]]; then
+          echo "::error::Binary not found at expected path inside the archive: $BINARY"
+          exit 1
+        fi
+        echo "binary=$BINARY" >> "$GITHUB_OUTPUT"
+
+    - name: Run analysis
+      id: run-analysis
+      shell: bash
+      env:
+        BINARY: ${{ steps.download.outputs.binary }}
+        PATHS: ${{ inputs.paths }}
+        FORMAT: ${{ inputs.format }}
+        OUTPUT_FILE: ${{ inputs.output-file }}
+        THRESHOLD: ${{ inputs.threshold }}
+        CONFIG: ${{ inputs.config }}
+        FAIL_ON_THRESHOLD: ${{ inputs.fail-on-threshold }}
+        EXTRA_ARGS: ${{ inputs.extra-args }}
+      run: |
+        set -uo pipefail
+        ARGS=()
+        # Intentionally unquoted expansions: paths and extra-args are
+        # space-separated lists by contract.
+        for p in $PATHS; do ARGS+=("$p"); done
+        ARGS+=(--recursive --format "$FORMAT")
+        [[ -n "$THRESHOLD" ]] && ARGS+=(--threshold "$THRESHOLD")
+        [[ -n "$CONFIG" ]] && ARGS+=(--config "$CONFIG")
+        for a in $EXTRA_ARGS; do ARGS+=("$a"); done
+
+        set +e
+        "$BINARY" "${ARGS[@]}" > "$OUTPUT_FILE"
+        EXIT_CODE=$?
+        set -e
+
+        echo "report-file=$OUTPUT_FILE" >> "$GITHUB_OUTPUT"
+
+        if [[ $EXIT_CODE -eq 1 ]]; then
+          if [[ "$FAIL_ON_THRESHOLD" == "true" ]]; then
+            echo "::error::Complexity threshold exceeded (see $OUTPUT_FILE)."
+            exit 1
+          fi
+          echo "Complexity threshold exceeded, continuing because fail-on-threshold is false."
+        elif [[ $EXIT_CODE -ne 0 ]]; then
+          echo "::error::swift-complexity failed with exit code $EXIT_CODE."
+          exit "$EXIT_CODE"
+        fi

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -8,6 +8,7 @@ This directory contains user-facing documentation for swift-complexity.
 - [Usage Guide](usage.md) - Basic usage examples and CLI options
 - [Output Formats](output-formats.md) - Detailed explanation of output formats
 - [Complexity Metrics](complexity-metrics.md) - Understanding cyclomatic and cognitive complexity
+- [CI Integration](ci-integration.md) - GitHub Action and Code Scanning setup
 
 ## Quick Start
 

--- a/docs/user-guide/ci-integration.md
+++ b/docs/user-guide/ci-integration.md
@@ -1,0 +1,113 @@
+# CI Integration
+
+Set up a complexity gate for your Swift project in about 5 minutes using the
+official GitHub Action, with violations shown as inline pull request
+annotations via GitHub Code Scanning.
+
+## Quick Start (GitHub Actions)
+
+Create `.github/workflows/complexity.yml` in your repository:
+
+```yaml
+name: Complexity
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  security-events: write  # required by upload-sarif
+
+jobs:
+  complexity:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Analyze complexity
+        id: analysis
+        uses: fummicc1/swift-complexity@v1.2.0
+        with:
+          paths: Sources
+          threshold: "10"
+
+      - name: Upload SARIF to Code Scanning
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()  # upload even when the threshold gate fails the job
+        with:
+          sarif_file: ${{ steps.analysis.outputs.report-file }}
+```
+
+That's it. Pull requests that introduce functions above the threshold now
+fail the check, and each violation appears as an inline annotation on the
+diff and in the repository's Security tab.
+
+> **Note**: The action requires tag `v1.2.0` or later — earlier releases do
+> not contain `action.yml`.
+
+## Action Inputs
+
+| Input | Default | Description |
+| ----- | ------- | ----------- |
+| `version` | `latest` | swift-complexity release to use (e.g. `1.2.0`), or `latest` |
+| `paths` | `Sources` | Space-separated files/directories to analyze |
+| `format` | `sarif` | Output format: `text`, `json`, `xml`, `xcode`, or `sarif` |
+| `output-file` | `swift-complexity.sarif` | File the report is written to |
+| `threshold` | `10` | Passed as `--threshold`; empty string omits it |
+| `config` | (none) | Path to a `.swift-complexity.yml` threshold config |
+| `fail-on-threshold` | `true` | Fail the step on exit code 1 (threshold exceeded) |
+| `extra-args` | (none) | Additional CLI arguments, e.g. `--exclude Tests` |
+| `github-token` | `${{ github.token }}` | Used to resolve `latest` via the GitHub API |
+
+### Outputs
+
+| Output | Description |
+| ------ | ----------- |
+| `report-file` | Path to the generated report |
+
+## Notes and Pitfalls
+
+- **A threshold is required for SARIF results.** Without `threshold` or a
+  config file, the SARIF report contains no results (this mirrors the CLI's
+  exit-code behavior). The action defaults to `10` so this works out of the
+  box; pass an empty `threshold` only when your thresholds come from a
+  `.swift-complexity.yml` config.
+- **`fail-on-threshold: "false"` ignores exit code 1** (threshold exceeded)
+  so the workflow can continue — useful for report-only setups. Exit codes
+  other than 0 and 1 (real errors) always fail the step.
+- **`if: always()` on the upload step** ensures the SARIF report reaches
+  Code Scanning even when the analysis step fails the build.
+- **Runner support**: macOS (arm64/x86_64) and Linux (x86_64). Linux arm64
+  runners are not supported because no binary is published for them.
+- Per-type thresholds, inline suppression comments, and LCOM4 analysis all
+  work in CI exactly as they do locally — see the
+  [Usage Guide](usage.md) for details.
+
+## Without the Action (plain CLI)
+
+If you prefer managing the binary yourself (or use a different CI system),
+install via Homebrew or download a release binary directly:
+
+```yaml
+jobs:
+  complexity:
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install swift-complexity
+        run: brew install fummicc1/tap/swift-complexity
+
+      - name: Analyze
+        run: |
+          swift-complexity Sources --recursive \
+            --format sarif --threshold 10 > swift-complexity.sarif
+
+      - uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: swift-complexity.sarif
+```
+
+The tool exits with code 1 when any function exceeds its threshold, which
+fails the job — the same gate the action provides.


### PR DESCRIPTION
## Summary

Adds a composite GitHub Action at the repository root so CI adoption becomes a single `uses:` step, plus a "CI in 5 minutes" guide. This completes the CI adoption path started with SARIF output (#33): action → SARIF → `upload-sarif` → inline PR annotations.

Final item of the current roadmap's "Now" horizon.

## Usage (after the next release)

```yaml
permissions:
  contents: read
  security-events: write

steps:
  - uses: actions/checkout@v5

  - name: Analyze complexity
    id: analysis
    uses: fummicc1/swift-complexity@v1.2.0
    with:
      paths: Sources
      threshold: "10"

  - uses: github/codeql-action/upload-sarif@v3
    if: always()
    with:
      sarif_file: ${{ steps.analysis.outputs.report-file }}
```

## Design

- **Composite action, no toolchain needed**: downloads the prebuilt release binary for the runner platform (macOS arm64/x86_64, Linux x86_64), verifies the published sha256 checksum, and runs the analysis. `version: latest` resolves via the GitHub API using the workflow token (avoids rate limits); exact versions are also accepted.
- **SARIF by default with `threshold: 10`** — without any threshold the SARIF report is silently empty, so the default makes the quick-start work out of the box. An empty `threshold` supports config-file-driven setups.
- **`fail-on-threshold: "false"`** ignores exit code 1 (threshold exceeded) for report-only setups; other non-zero exit codes always fail the step.
- **SARIF upload stays in the caller's workflow** (`github/codeql-action/upload-sarif`), keeping `security-events: write` permission out of this action.
- **Docs pin to an exact tag, not a moving `v1` major tag**: `release.yml` triggers on any `v*` tag and derives the version from the tag name without validation, so pushing a bare `v1` tag would start a bogus release run. Major-tag automation needs a trigger guard first — left as a follow-up.
- Note: the action is usable from tag `v1.2.0` onward (earlier tags don't contain `action.yml`); docs say so explicitly.

## Found & fixed along the way: dynamically linked Linux binaries

The first `action-test` run exposed that **Linux release binaries fail with a `libswiftCore.so` loading error** on machines without a Swift toolchain — defeating the action's purpose on Linux, and equally affecting direct binary downloads and nest installs. Fixes in this PR:

- `release.yml` now builds Linux binaries with `--static-swift-stdlib`, so releases from v1.2.0 onward are self-contained
- The CI `test` job's Linux build uses the same flag, catching static-linking breakage on every PR instead of at release time
- The `action-test` Linux leg temporarily runs in a `swift:6.2-jammy` container with `LD_LIBRARY_PATH` pointing at the container's Swift runtime (the pinned v1.1.0 binaries are still dynamic and embed a build-machine runpath); comments mark both for removal once a static release ships. `fail-fast: false` keeps one platform's failure from cancelling the other

## Changes

- `action.yml` — composite action (9 inputs, `report-file` output, Marketplace branding)
- `.github/workflows/ci.yml` — new `action-test` job (macOS + Ubuntu-in-Swift-container matrix) running the action from the local checkout via `uses: ./` against the released v1.1.0 binaries, then validating the generated SARIF structure with `jq`; Linux test build gains `--static-swift-stdlib`
- `.github/workflows/release.yml` — Linux release builds gain `--static-swift-stdlib`
- `docs/user-guide/ci-integration.md` — quick start, full input reference, pitfalls (empty-SARIF, `if: always()`, runner support), and a plain-CLI alternative
- `README.md` / `docs/user-guide/README.md` — GitHub Action section and doc index entry

## Verification

- **The `action-test` CI job on this PR is the E2E test**: it exercises version pinning, platform detection, binary download, sha256 verification, analysis run with `fail-on-threshold: "false"` (this repo exceeds threshold 10, exercising the exit-code-1 path), and SARIF structural validation — on both macOS and Linux. The macOS leg already passed end-to-end on the first run (7 SARIF results validated)
- `actionlint` on both workflows: warning count identical to `main` (composite `action.yml` is outside actionlint's scope; validated via YAML parse + the CI job itself)
- `markdownlint`: new guide is clean; total error count unchanged vs `main`

## Post-merge follow-ups (not in this PR)

1. Cut **v1.2.0** (bundles LCOM4 suppression #39 + this action + static Linux binaries) so `@v1.2.0` in the docs resolves
2. After v1.2.0: pin `action-test` to `1.2.0` and drop the temporary Swift container from the Linux leg
3. Publish to GitHub Marketplace from the release UI (manual, owner-only)

https://claude.ai/code/session_01GaTHVDhSAx76RbLmVziLQu
