### PR TITLE
feat: Maintain a moving major version tag on stable releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,9 @@ name: Release
 on:
   push:
     tags:
-      - "v*"
+      # Full semver tags only: the moving major tag (e.g. v1) is force-pushed
+      # by the update-major-tag job below and must not start a release run.
+      - "v*.*.*"
   workflow_dispatch:
     inputs:
       version:
@@ -379,6 +381,30 @@ jobs:
             artifacts/*.sha256
             artifacts/*.artifactbundle.zip
           generate_release_notes: true
+
+  update-major-tag:
+    name: Update Major Version Tag
+    runs-on: ubuntu-latest
+    needs: [validate, create-release]
+    # Prereleases must not move the major tag users pin actions to.
+    if: needs.validate.outputs.is_prerelease == 'false'
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Force-move major tag
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          MAJOR="v${VERSION%%.*}"
+          git tag -f "$MAJOR" "v${VERSION}"
+          git push -f origin "$MAJOR"
+          echo "Moved $MAJOR to v${VERSION}"
 
   update-homebrew-tap:
     name: Update Homebrew Tap

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ steps:
 
   - name: Analyze complexity
     id: analysis
-    uses: fummicc1/swift-complexity@v1.2.0
+    uses: fummicc1/swift-complexity@v1
     with:
       paths: Sources
       threshold: "10"

--- a/docs/user-guide/ci-integration.md
+++ b/docs/user-guide/ci-integration.md
@@ -26,7 +26,7 @@ jobs:
 
       - name: Analyze complexity
         id: analysis
-        uses: fummicc1/swift-complexity@v1.2.0
+        uses: fummicc1/swift-complexity@v1
         with:
           paths: Sources
           threshold: "10"
@@ -42,8 +42,10 @@ That's it. Pull requests that introduce functions above the threshold now
 fail the check, and each violation appears as an inline annotation on the
 diff and in the repository's Security tab.
 
-> **Note**: The action requires tag `v1.2.0` or later — earlier releases do
-> not contain `action.yml`.
+> **Note**: The `v1` tag tracks the latest stable `v1.x` release. Pin an
+> exact tag (e.g. `fummicc1/swift-complexity@v1.2.0`) if you prefer fully
+> reproducible workflows. The action requires `v1.2.0` or later — earlier
+> releases do not contain `action.yml`.
 
 ## Action Inputs
 


### PR DESCRIPTION
## Summary

Adds the deferred follow-up from #40: a moving major version tag (`v1`) so users can write the ecosystem-standard `uses: fummicc1/swift-complexity@v1` instead of chasing exact tags.

## Changes

- **`release.yml` trigger restricted to full semver tags (`v*.*.*`)** — this is the prerequisite that made the moving tag unsafe before: the workflow triggers on tag pushes and derives the version straight from the tag name, so pushing a bare `v1` would have started a bogus "release 1" run
- **New `update-major-tag` job**: after a successful release, force-moves `v<major>` to the released tag. Skipped for prereleases, so `@v1` users never receive a pre-release
- **Docs** (`README.md`, `ci-integration.md`): examples now use `@v1`, with exact-tag pinning kept documented for reproducibility

## Bootstrap note

`v1` does not exist yet and the automation only fires on **future** stable releases. After this merges, `v1` needs one manual bootstrap pointing at a commit that already carries the guarded trigger (i.e. this PR's merge commit or later):

```bash
git tag v1 <merge-commit> && git push origin v1
```

Pushing `v1` at that point is a no-op for the release workflow thanks to the `v*.*.*` guard. From v1.3.0 onward the job maintains it automatically.

## Verification

- `actionlint`: warning count identical to `main` on `release.yml`
- `markdownlint`: error count identical to `main`
- The job's tag-move logic is plain `git tag -f` / `git push -f` with `contents: write`, mirroring how the release itself is created

https://claude.ai/code/session_01GaTHVDhSAx76RbLmVziLQu