### PR TITLE
fix: Buffer the release lookup response before parsing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,21 +142,22 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
 
-      - name: Run swift-complexity action (local checkout)
+      - name: Run swift-complexity action (local checkout, latest version)
         id: analysis
         uses: ./
         with:
-          # Pinned to a published release so the download path is deterministic;
-          # fail-on-threshold is off because this job verifies the action
-          # mechanics, not this repository's complexity.
-          version: "1.2.0"
+          # Default `version: latest` on purpose: this step runs the action
+          # code under review, so the latest-release lookup path is covered
+          # by CI before every merge. fail-on-threshold is off because this
+          # job verifies the action mechanics, not this repo's complexity.
           fail-on-threshold: "false"
 
       - name: Run swift-complexity action (released tag)
         id: analysis-tag
-        # Consumes the action the way users do - resolved from the tag,
-        # not the local checkout.
-        uses: fummicc1/swift-complexity@v1.2.0
+        # Consumes the action the way users do - resolved from the v1 tag,
+        # not the local checkout. The binary version stays pinned so this
+        # step is deterministic regardless of newer releases.
+        uses: fummicc1/swift-complexity@v1
         with:
           version: "1.2.0"
           output-file: swift-complexity-tag.sarif

--- a/action.yml
+++ b/action.yml
@@ -74,11 +74,15 @@ runs:
       run: |
         set -euo pipefail
         if [[ "$REQUESTED_VERSION" == "latest" ]]; then
-          TAG=$(curl -fsSL \
+          # Buffer the whole response before parsing: piping curl straight
+          # into `grep -m1` makes grep close the pipe on the first match,
+          # which kills curl with a write error (exit 23) under pipefail.
+          RESPONSE=$(curl -fsSL \
             -H "Authorization: Bearer $GH_TOKEN" \
             -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/fummicc1/swift-complexity/releases/latest" \
-            | grep -m1 '"tag_name"' | sed -E 's/.*"tag_name": *"v?([^"]+)".*/\1/')
+            "https://api.github.com/repos/fummicc1/swift-complexity/releases/latest")
+          TAG=$(grep -m1 '"tag_name"' <<<"$RESPONSE" \
+            | sed -E 's/.*"tag_name": *"v?([^"]+)".*/\1/')
           if [[ -z "$TAG" ]]; then
             echo "::error::Failed to resolve the latest swift-complexity release."
             exit 1


### PR DESCRIPTION
## Summary

Fixes the `version: latest` resolution path, which failed with curl exit 23 on its **first real-world use** ([GeoHashSwift#14](https://github.com/fummicc1/GeoHashSwift/pull/14)'s workflow run).

## Root cause

```bash
TAG=$(curl -fsSL ... | grep -m1 '"tag_name"' | sed ...)
```

`grep -m1` exits on the first match and closes the pipe while curl is still streaming the (large, asset-list-bearing) `releases/latest` response. curl dies with a write error (exit 23), and `set -o pipefail` surfaces it, aborting the step before `report-file` is ever set — which then cascaded into the confusing `Input required and not supplied: sarif_file` error on the caller's upload step.

**Why CI never caught it**: every prior `action-test` run pinned `version`, so the `latest` branch of the resolve step had never actually executed.

Reproduced locally under `set -euo pipefail`:
- old pipeline → `curl: (23) Failure writing output to destination, passed 1370`, exit 23, deterministically
- fixed version → resolves `1.2.0`

## Fix

Buffer the whole response into a variable first, then parse it (`grep -m1` on a herestring can't hurt anything).

## Coverage so this can't regress silently

`action-test` steps are rearranged:
- **local-checkout step** (`uses: ./`) now uses the default `version: latest` — the lookup path runs against the code under review on every PR
- **tag step** (`uses: @v1`) keeps a pinned binary version for determinism (and to avoid the old-v1 chicken-and-egg on this very PR: `v1` still points at the buggy `action.yml` until it is moved post-merge)

## Post-merge

1. Move `v1` to the merge commit (manual, same as the bootstrap — the automation only fires on releases)
2. Re-run GeoHashSwift#14's workflow, which should then pass with `@v1` + default `latest`

https://claude.ai/code/session_01GaTHVDhSAx76RbLmVziLQu