### PR TITLE
fix: Shorten action description to Marketplace's 125-char limit

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,8 +1,8 @@
 name: "Swift Complexity Analysis"
+# Marketplace requires the description to be 125 characters or fewer.
 description: >-
-  Analyze Swift code complexity (cyclomatic, cognitive, LCOM4) with
-  swift-complexity and enforce thresholds in CI. Generates SARIF for
-  GitHub Code Scanning by default.
+  Analyze Swift code complexity (cyclomatic, cognitive, LCOM4), enforce
+  thresholds in CI, and generate SARIF for Code Scanning
 author: "fummicc1"
 
 branding:


### PR DESCRIPTION
## Summary

GitHub Marketplace rejects publication when `action.yml`'s `description` exceeds 125 characters ("Your action.yml needs changes before it can be published"); ours was 165. Trimmed to 124 characters while keeping the metric names and the SARIF capability:

> Analyze Swift code complexity (cyclomatic, cognitive, LCOM4), enforce thresholds in CI, and generate SARIF for Code Scanning

## Note on publication flow

Marketplace validates `action.yml` **at the tag of the release being published**, so fixing `main` alone does not make v1.2.0 publishable. After this merges, cut **v1.2.1** and publish that release to the Marketplace instead. As a bonus, the v1.2.1 release will be the first production run of the `update-major-tag` automation from #42.

## Verification

- YAML parse + length assertion (124 ≤ 125) verified locally

https://claude.ai/code/session_01GaTHVDhSAx76RbLmVziLQu