### PR TITLE
chore: Bump version to 1.2.1

### DIFF
--- a/Sources/SwiftComplexityCore/Version.swift
+++ b/Sources/SwiftComplexityCore/Version.swift
@@ -3,5 +3,5 @@
 /// Referenced by the CLI (`--version`), the MCP server handshake, and the
 /// SARIF `tool.driver.version` field so a release bump happens in one place.
 public enum SwiftComplexityVersion {
-    public static let current = "1.1.0"
+    public static let current = "1.2.1"
 }

--- a/docs/user-guide/output-formats.md
+++ b/docs/user-guide/output-formats.md
@@ -295,7 +295,7 @@ tool from your repository root for GitHub-compatible URIs.
       "tool" : {
         "driver" : {
           "name" : "swift-complexity",
-          "version" : "1.1.0",
+          "version" : "1.2.1",
           "informationUri" : "https://github.com/fummicc1/swift-complexity",
           "rules" : [...]
         }


### PR DESCRIPTION
## Summary

Bumps `SwiftComplexityVersion.current` to `1.2.1` ahead of tagging the release that makes the action Marketplace-publishable (#44's description fix must be present at the published tag).

This also catches up the **missed 1.2.0 bump**: `Version.swift` still said `1.1.0`, so the published v1.2.0 binaries self-report `1.1.0` in `--version`, the MCP handshake, and SARIF's `tool.driver.version`. The SARIF doc example is updated to match.

## Verification

- `swift build` / `swift test`: 107 tests pass (the CLI test asserts `configuration.version == SwiftComplexityVersion.current`, so the constant and `--version` stay in lockstep)

https://claude.ai/code/session_01GaTHVDhSAx76RbLmVziLQu