### PR TITLE
Add type-level coupling metrics: fan-in, fan-out, and instability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,6 @@ jobs:
           jq -e '[.files[].typeCouplings[]?] | any(.name == "ComplexityCommand" and .instability == 1)' coupling-report.json
           jq -e '[.files[].typeCouplings[]?] | any(.name == "SuppressedMetric" and .fanOut == 0 and .fanIn >= 5)' coupling-report.json
           jq -e '[.files[].typeCouplings[]?] | any(.name == "OutputFormatter" and .fanOut >= 15)' coupling-report.json
-          # The stderr diagnostics line must exist and report high attribution.
           grep -q "coupling:" coupling-diag.txt
           # Gate round trip: an absurdly low threshold must exit 1...
           printf 'coupling:\n  fanOut: 1\n' > /tmp/coupling-gate.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,54 @@ jobs:
             --toolchain-path "${TOOLCHAIN}" \
             --format json --recursive
 
+      - name: Test coupling analysis (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          # Reuses the debug build + index store from the LCOM4 step above.
+          .build/debug/SwiftComplexityCLI Sources --coupling \
+            --index-store-path .build/debug/index/store \
+            --format json --recursive > coupling-report.json 2> coupling-diag.txt
+          cat coupling-diag.txt
+          # Structural invariants rather than pinned values, so refactors
+          # don't break CI: the CLI entry point is referenced by nothing
+          # (instability exactly 1.0), pure models depend on nothing
+          # project-side, and the formatter touches most models.
+          jq -e '[.files[].typeCouplings[]?] | length > 20' coupling-report.json
+          jq -e '[.files[].typeCouplings[]?] | any(.name == "ComplexityCommand" and .instability == 1)' coupling-report.json
+          jq -e '[.files[].typeCouplings[]?] | any(.name == "SuppressedMetric" and .fanOut == 0 and .fanIn >= 5)' coupling-report.json
+          jq -e '[.files[].typeCouplings[]?] | any(.name == "OutputFormatter" and .fanOut >= 15)' coupling-report.json
+          # The stderr diagnostics line must exist and report high attribution.
+          grep -q "coupling:" coupling-diag.txt
+          # Gate round trip: an absurdly low threshold must exit 1...
+          printf 'coupling:\n  fanOut: 1\n' > /tmp/coupling-gate.yml
+          if .build/debug/SwiftComplexityCLI Sources --coupling \
+            --index-store-path .build/debug/index/store \
+            --config /tmp/coupling-gate.yml --recursive > /dev/null 2>&1; then
+            echo "Expected exit 1 with coupling fanOut threshold 1"; exit 1
+          fi
+          # ...and an unreachable one must exit 0 (config present, no violation).
+          printf 'coupling:\n  fanOut: 9999\n' > /tmp/coupling-gate.yml
+          .build/debug/SwiftComplexityCLI Sources --coupling \
+            --index-store-path .build/debug/index/store \
+            --config /tmp/coupling-gate.yml --recursive > /dev/null
+
+      - name: Test coupling analysis (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          SWIFTLY_HOME="${HOME}/.local/share/swiftly"
+          TOOLCHAIN=$(ls -d ${SWIFTLY_HOME}/toolchains/* 2>/dev/null | head -1)
+          # Reuses the debug build + index store from the LCOM4 step above.
+          .build/debug/SwiftComplexityCLI Sources --coupling \
+            --index-store-path .build/debug/index/store \
+            --toolchain-path "${TOOLCHAIN}" \
+            --format json --recursive > coupling-report.json 2> coupling-diag.txt
+          cat coupling-diag.txt
+          jq -e '[.files[].typeCouplings[]?] | length > 20' coupling-report.json
+          jq -e '[.files[].typeCouplings[]?] | any(.name == "ComplexityCommand" and .instability == 1)' coupling-report.json
+          jq -e '[.files[].typeCouplings[]?] | any(.name == "SuppressedMetric" and .fanOut == 0 and .fanIn >= 5)' coupling-report.json
+          jq -e '[.files[].typeCouplings[]?] | any(.name == "OutputFormatter" and .fanOut >= 15)' coupling-report.json
+          grep -q "coupling:" coupling-diag.txt
+
   action-test:
     name: Action Test
     strategy:

--- a/README.md
+++ b/README.md
@@ -4,14 +4,15 @@ A command-line tool to analyze Swift code complexity and quality metrics using s
 
 ## Features
 
-- **Multiple Complexity Metrics**: Supports cyclomatic complexity, cognitive complexity, and LCOM4 cohesion analysis
+- **Multiple Complexity Metrics**: Supports cyclomatic complexity, cognitive complexity, LCOM4 cohesion, and type coupling analysis
 - **LCOM4 Class Cohesion**: High-precision class cohesion measurement using IndexStore-DB semantic analysis
+- **Type Coupling Metrics**: Semantic fan-in / fan-out / instability per type, plus a hotspot ranking that orders complexity violations by their blast radius ([details](docs/user-guide/coupling-metrics.md))
 - **Web-based Debug Interface**: Interactive browser-based complexity analyzer ([Try it online](https://swift-complexity.fummicc1.dev))
 - **Xcode Integration**: Seamless integration with Xcode via Build Tool Plugin for complexity feedback during build phase
 - **Xcode Diagnostics**: Display complexity warnings and errors directly in Xcode editor with accurate line numbers
 - **Configurable Thresholds**: Set custom complexity thresholds via Xcode Build Settings or environment variables
 - **Per-Type Thresholds**: Assign different thresholds to types by name (prefix/suffix) via a `.swift-complexity.yml` config — e.g. stricter limits for `*Repository`, looser for `*UseCase`
-- **Inline Suppression**: Exempt a specific function or type from threshold checks with a `// swift-complexity:disable` comment, optionally scoped to `cyclomatic`, `cognitive`, or `lcom4`
+- **Inline Suppression**: Exempt a specific function or type from threshold checks with a `// swift-complexity:disable` comment, optionally scoped to `cyclomatic`, `cognitive`, `lcom4`, or `coupling`
 - **Exit Code Integration**: Returns exit code 1 when complexity thresholds are exceeded, perfect for CI/CD pipelines
 - **Multiple Output Formats**: Text, JSON, XML, Xcode diagnostics, and SARIF output for different use cases
 - **Flexible Analysis**: Single files, directories, or recursive directory analysis
@@ -68,6 +69,9 @@ swift run SwiftComplexityCLI Sources --format sarif --threshold 10 --recursive >
 # LCOM4 class cohesion analysis (requires swift build first)
 swift build  # Generate index
 swift run SwiftComplexityCLI Sources --lcom4 --index-store-path .build/debug/index/store
+
+# Type coupling analysis: fan-in / fan-out / instability (requires swift build first)
+swift run SwiftComplexityCLI Sources --coupling --index-store-path .build/debug/index/store --recursive
 ```
 
 ## CLI Integration
@@ -186,6 +190,12 @@ See the [Usage Guide](docs/user-guide/usage.md#per-type-complexity-thresholds) f
   - **High Precision**: Semantic analysis powered by IndexStore-DB
   - **Implicit self Detection**: Automatically detects both `self.property` and `property` accesses
   - **Requirements**: Requires `swift build` to generate index data
+- **Type Coupling (fan-in / fan-out / instability)**: Measures how tangled types are with each other over the project's semantic reference graph
+  - **Fan-out**: How many other project types a type depends on (fragility)
+  - **Fan-in**: How many project types depend on it (blast radius)
+  - **Instability**: Martin's fan-out / (fan-in + fan-out) ratio
+  - **Hotspots**: Ranks complexity violations by their enclosing type's fan-in
+  - **Requirements**: Requires `swift build` to generate index data ([details](docs/user-guide/coupling-metrics.md))
 
 ## Documentation
 

--- a/Sources/SwiftComplexityCLI/ComplexityCommand.swift
+++ b/Sources/SwiftComplexityCLI/ComplexityCommand.swift
@@ -364,8 +364,6 @@ public struct ComplexityCommand: AsyncParsableCommand {
                 cohesion.lcom4 >= 3 && !cohesion.isSuppressed(.lcom4)
             }
 
-            // Keep result if functions or cohesions pass threshold, or the
-            // file carries coupling data.
             guard
                 !filteredFunctions.isEmpty || filteredCohesions?.isEmpty == false
                     || !(result.typeCouplings ?? []).isEmpty

--- a/Sources/SwiftComplexityCLI/ComplexityCommand.swift
+++ b/Sources/SwiftComplexityCLI/ComplexityCommand.swift
@@ -296,8 +296,8 @@ public struct ComplexityCommand: AsyncParsableCommand {
                         return "cyclomatic (\(function.cyclomaticComplexity))"
                     case .cognitive:
                         return "cognitive (\(function.cognitiveComplexity))"
-                    case .lcom4:
-                        return nil  // type-level metric, never present on a function
+                    case .lcom4, .coupling:
+                        return nil  // type-level metrics, never present on a function
                     }
                 }
                 lines.append(

--- a/Sources/SwiftComplexityCLI/ComplexityCommand.swift
+++ b/Sources/SwiftComplexityCLI/ComplexityCommand.swift
@@ -149,6 +149,15 @@ public struct ComplexityCommand: AsyncParsableCommand {
                         .utf8))
         }
 
+        // A configured coupling gate that never runs would pass CI silently,
+        // e.g. when the --coupling flag is dropped from one job.
+        if configuration.coupling != nil, !coupling {
+            FileHandle.standardError.write(
+                Data(
+                    "Warning: coupling thresholds are configured but --coupling is not enabled, so they will not gate this run.\n"
+                        .utf8))
+        }
+
         logVerboseConfiguration(configuration: configuration)
 
         do {

--- a/Sources/SwiftComplexityCLI/ComplexityCommand.swift
+++ b/Sources/SwiftComplexityCLI/ComplexityCommand.swift
@@ -86,16 +86,23 @@ public struct ComplexityCommand: AsyncParsableCommand {
     )
     public var lcom4: Bool = false
 
+    @Flag(
+        name: .long,
+        help: "Show type coupling metrics (fan-in, fan-out, instability)"
+    )
+    public var coupling: Bool = false
+
     @Option(
         name: .long,
-        help: "IndexStore path for LCOM4 analysis (e.g., .build/debug/index/store)",
+        help: "IndexStore path for index-backed analysis (e.g., .build/debug/index/store)",
         completion: .directory
     )
     public var indexStorePath: String?
 
     @Option(
         name: .long,
-        help: "Swift toolchain path for LCOM4 (required on Linux, optional on macOS)"
+        help:
+            "Swift toolchain path for index-backed analysis (required on Linux, optional on macOS)"
     )
     public var toolchainPath: String?
 
@@ -151,11 +158,16 @@ public struct ComplexityCommand: AsyncParsableCommand {
             let processingOptions = ProcessingOptions(
                 recursive: recursive,
                 excludePatterns: exclude,
-                verbose: verbose
+                verbose: verbose,
+                couplingEnabled: coupling
             )
 
             let results = try await fileProcessor.processFiles(
                 at: paths, options: processingOptions)
+
+            if coupling, let diagnostics = await fileProcessor.lastCouplingDiagnostics {
+                printCouplingDiagnostics(diagnostics)
+            }
 
             if reportSuppressions {
                 printSuppressionsReport(results: results)
@@ -178,7 +190,7 @@ public struct ComplexityCommand: AsyncParsableCommand {
 
             print(output)
 
-            if threshold != nil || !configuration.isEmpty,
+            if threshold != nil || !configuration.isEmpty || configuration.coupling != nil,
                 hasExceededThreshold(
                     results: results, threshold: threshold, configuration: configuration)
             {
@@ -223,19 +235,23 @@ public struct ComplexityCommand: AsyncParsableCommand {
 
     /// Validates LCOM4 options
     private func validateLCOM4Options() throws {
-        if lcom4 && indexStorePath == nil {
-            print("Error: --lcom4 requires --index-store-path option.")
+        // Both index-backed analyses share the same prerequisites.
+        let indexBackedFlag: String? = lcom4 ? "--lcom4" : (coupling ? "--coupling" : nil)
+        guard let flag = indexBackedFlag else { return }
+
+        if indexStorePath == nil {
+            print("Error: \(flag) requires --index-store-path option.")
             print(
-                "Example: swift-complexity Sources --lcom4 --index-store-path .build/debug/index/store"
+                "Example: swift-complexity Sources \(flag) --index-store-path .build/debug/index/store"
             )
             throw ExitCode.failure
         }
 
         #if os(Linux)
-            if lcom4 && toolchainPath == nil {
-                print("Error: --lcom4 requires --toolchain-path option on Linux.")
+            if toolchainPath == nil {
+                print("Error: \(flag) requires --toolchain-path option on Linux.")
                 print(
-                    "Example: swift-complexity Sources --lcom4 --index-store-path .build/debug/index/store --toolchain-path ~/.local/share/swiftly/toolchains/swift-6.2"
+                    "Example: swift-complexity Sources \(flag) --index-store-path .build/debug/index/store --toolchain-path ~/.local/share/swiftly/toolchains/swift-6.2"
                 )
                 throw ExitCode.failure
             }
@@ -267,13 +283,16 @@ public struct ComplexityCommand: AsyncParsableCommand {
 
     /// Creates a ComplexityAnalyzer instance
     private func createAnalyzer() throws -> ComplexityAnalyzer {
-        guard lcom4, let indexStorePath = indexStorePath else {
+        guard lcom4 || coupling, let indexStorePath = indexStorePath else {
             return try ComplexityAnalyzer()
         }
         let toolchainURL = toolchainPath.map { URL(fileURLWithPath: $0) }
+        // lcom4Enabled keeps cohesion fields out of coupling-only runs; the
+        // index store itself is shared by both analyses.
         return try ComplexityAnalyzer(
             indexStorePath: URL(fileURLWithPath: indexStorePath),
-            toolchainPath: toolchainURL
+            toolchainPath: toolchainURL,
+            lcom4Enabled: lcom4
         )
     }
 
@@ -310,6 +329,12 @@ public struct ComplexityCommand: AsyncParsableCommand {
                     "\(result.filePath):\(cohesion.location.line): \(cohesion.name) — lcom4 (\(cohesion.lcom4))"
                 )
             }
+            for coupling in result.typeCouplings ?? [] {
+                guard coupling.isSuppressed(.coupling) else { continue }
+                lines.append(
+                    "\(result.filePath):\(coupling.location.line): \(coupling.name) — coupling (fan-in \(coupling.fanIn), fan-out \(coupling.fanOut))"
+                )
+            }
         }
 
         let header =
@@ -339,15 +364,24 @@ public struct ComplexityCommand: AsyncParsableCommand {
                 cohesion.lcom4 >= 3 && !cohesion.isSuppressed(.lcom4)
             }
 
-            // Keep result if either functions or cohesions pass threshold
-            guard !filteredFunctions.isEmpty || filteredCohesions?.isEmpty == false else {
+            // Keep result if functions or cohesions pass threshold, or the
+            // file carries coupling data.
+            guard
+                !filteredFunctions.isEmpty || filteredCohesions?.isEmpty == false
+                    || !(result.typeCouplings ?? []).isEmpty
+            else {
                 return nil
             }
 
+            // Coupling metrics pass through unfiltered: they are ranking
+            // context (Hotspots needs every type's fan-in) and report data,
+            // not a violations list. Coupling violations gate through the
+            // exit code and SARIF levels instead.
             return ComplexityResult(
                 filePath: result.filePath,
                 functions: filteredFunctions,
-                classCohesions: filteredCohesions
+                classCohesions: filteredCohesions,
+                typeCouplings: result.typeCouplings
             )
         }
     }
@@ -363,7 +397,32 @@ public struct ComplexityCommand: AsyncParsableCommand {
                     return true
                 }
             }
+            for coupling in result.typeCouplings ?? []
+            where !configuration.couplingViolations(coupling).isEmpty {
+                return true
+            }
         }
         return false
+    }
+
+    /// One-line attribution summary to stderr (details with --verbose). The
+    /// percentage covers project references only: stdlib/framework symbols
+    /// are excluded by design, not lost.
+    private func printCouplingDiagnostics(_ diagnostics: CouplingDiagnostics) {
+        let projectRefs = diagnostics.attributedTotal + diagnostics.droppedUnattributable
+        let percent = projectRefs == 0 ? 100 : diagnostics.attributedTotal * 100 / projectRefs
+        var lines = [
+            "coupling: \(diagnostics.refsTotal) refs (\(projectRefs) project), "
+                + "\(percent)% attributed (containedBy \(diagnostics.attributedByContainedBy), "
+                + "baseOf \(diagnostics.attributedByBaseOf), "
+                + "location \(diagnostics.attributedByLocation)), "
+                + "\(diagnostics.droppedUnattributable) unattributed"
+        ]
+        if verbose {
+            lines.append("  external symbols: \(diagnostics.droppedNonProjectSymbol)")
+            lines.append("  typealias refs:   \(diagnostics.droppedTypealias)")
+            lines.append("  self references:  \(diagnostics.selfReferencesSkipped)")
+        }
+        FileHandle.standardError.write(Data((lines.joined(separator: "\n") + "\n").utf8))
     }
 }

--- a/Sources/SwiftComplexityCore/Analysis/ComplexityAnalyzer.swift
+++ b/Sources/SwiftComplexityCore/Analysis/ComplexityAnalyzer.swift
@@ -13,12 +13,22 @@ public actor ComplexityAnalyzer: ComplexityAnalyzing {
     private let lcomCalculator: SemanticLCOMCalculator?
     private let enableLCOM4: Bool
 
+    /// The index store opened for this analyzer, shared with other
+    /// index-backed passes (coupling) so the database is populated once.
+    /// Immutable and Sendable, so cross-actor access needs no await.
+    let sharedIndexStore: SharedIndexStore?
+
     /// Initialize the analyzer
     /// - Parameters:
-    ///   - indexStorePath: Optional IndexStore path for LCOM4 analysis (e.g., .build/debug/index/store). If nil, LCOM4 will be disabled.
-    ///   - toolchainPath: Optional Swift toolchain path for LCOM4 (e.g., ~/.local/share/swiftly/toolchains/swift-6.2).
-    ///                    On macOS, if nil, Xcode toolchain is auto-detected. On Linux, this is required for LCOM4.
-    public init(indexStorePath: URL? = nil, toolchainPath: URL? = nil) throws {
+    ///   - indexStorePath: Optional IndexStore path for index-backed analysis (e.g., .build/debug/index/store). If nil, LCOM4 and coupling are disabled.
+    ///   - toolchainPath: Optional Swift toolchain path (e.g., ~/.local/share/swiftly/toolchains/swift-6.2).
+    ///                    On macOS, if nil, Xcode toolchain is auto-detected. On Linux, this is required for index-backed analysis.
+    ///   - lcom4Enabled: Whether LCOM4 cohesion is computed when an index
+    ///     store is available. Coupling-only runs pass false so cohesion
+    ///     fields stay absent from their output.
+    public init(
+        indexStorePath: URL? = nil, toolchainPath: URL? = nil, lcom4Enabled: Bool = true
+    ) throws {
         self.cyclomaticCalculator = CyclomaticComplexityCalculator(viewMode: .sourceAccurate)
         self.cognitiveCalculator = CognitiveComplexityCalculator(viewMode: .sourceAccurate)
         self.functionDetector = FunctionDetector(viewMode: .sourceAccurate)
@@ -26,12 +36,13 @@ public actor ComplexityAnalyzer: ComplexityAnalyzing {
 
         // LCOM4: High-accuracy (90-95%) semantic analysis with IndexStore-DB integration
         if let indexStorePath = indexStorePath {
-            self.lcomCalculator = try SemanticLCOMCalculator(
-                indexStorePath: indexStorePath,
-                toolchainPath: toolchainPath
-            )
-            self.enableLCOM4 = true
+            let store = try IndexStoreService.open(
+                indexStorePath: indexStorePath, toolchainPath: toolchainPath)
+            self.sharedIndexStore = store
+            self.lcomCalculator = lcom4Enabled ? SemanticLCOMCalculator(indexStore: store) : nil
+            self.enableLCOM4 = lcom4Enabled
         } else {
+            self.sharedIndexStore = nil
             self.lcomCalculator = nil
             self.enableLCOM4 = false
         }

--- a/Sources/SwiftComplexityCore/Analysis/HotspotRanker.swift
+++ b/Sources/SwiftComplexityCore/Analysis/HotspotRanker.swift
@@ -2,12 +2,12 @@ import Foundation
 
 /// One entry of the hotspot ranking: a complexity-violating function paired
 /// with how widely its enclosing type is depended upon.
-public struct Hotspot: Sendable, Equatable {
-    public let function: FunctionComplexity
-    public let filePath: String
+struct Hotspot: Sendable, Equatable {
+    let function: FunctionComplexity
+    let filePath: String
     /// Fan-in of the enclosing type; 0 when the type cannot be resolved
     /// (free functions, ambiguous names), which sinks the entry naturally.
-    public let typeFanIn: Int
+    let typeFanIn: Int
 }
 
 /// Ranks complexity violations by the blast radius of their enclosing type.
@@ -17,15 +17,14 @@ public struct Hotspot: Sendable, Equatable {
 /// plain lexicographic sort - (type fan-in desc, cognitive desc, cyclomatic
 /// desc, name) - rather than a weighted score, so users can verify the
 /// ranking by eye.
-public enum HotspotRanker {
+enum HotspotRanker {
 
-    public static func rank(
+    static func rank(
         results: [ComplexityResult],
         configuration: ThresholdConfiguration,
         fallbackThreshold: Int?,
         limit: Int = 10
     ) -> [Hotspot] {
-        // Type name -> (file, fanIn) candidates across all analyzed files.
         var fanInCandidates: [String: [(file: String, fanIn: Int)]] = [:]
         for result in results {
             for coupling in result.typeCouplings ?? [] {

--- a/Sources/SwiftComplexityCore/Analysis/HotspotRanker.swift
+++ b/Sources/SwiftComplexityCore/Analysis/HotspotRanker.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+/// One entry of the hotspot ranking: a complexity-violating function paired
+/// with how widely its enclosing type is depended upon.
+public struct Hotspot: Sendable, Equatable {
+    public let function: FunctionComplexity
+    public let filePath: String
+    /// Fan-in of the enclosing type; 0 when the type cannot be resolved
+    /// (free functions, ambiguous names), which sinks the entry naturally.
+    public let typeFanIn: Int
+}
+
+/// Ranks complexity violations by the blast radius of their enclosing type.
+///
+/// Answers "which violation should be fixed first": a complex function inside
+/// a high fan-in type is the riskiest code in the project. The order is a
+/// plain lexicographic sort - (type fan-in desc, cognitive desc, cyclomatic
+/// desc, name) - rather than a weighted score, so users can verify the
+/// ranking by eye.
+public enum HotspotRanker {
+
+    public static func rank(
+        results: [ComplexityResult],
+        configuration: ThresholdConfiguration,
+        fallbackThreshold: Int?,
+        limit: Int = 10
+    ) -> [Hotspot] {
+        // Type name -> (file, fanIn) candidates across all analyzed files.
+        var fanInCandidates: [String: [(file: String, fanIn: Int)]] = [:]
+        for result in results {
+            for coupling in result.typeCouplings ?? [] {
+                fanInCandidates[coupling.name, default: []].append(
+                    (result.filePath, coupling.fanIn))
+            }
+        }
+
+        /// Resolves a function's enclosing type to its fan-in. Coupling names
+        /// are dotted for nested types while `enclosingTypeName` is simple,
+        /// so suffix matches count too. Same-file candidates win; ambiguity
+        /// without a same-file match resolves to 0 instead of guessing.
+        func typeFanIn(enclosingTypeName: String?, file: String) -> Int {
+            guard let name = enclosingTypeName else { return 0 }
+            let matches = fanInCandidates.flatMap { candidateName, candidates in
+                candidateName == name || candidateName.hasSuffix(".\(name)")
+                    ? candidates : []
+            }
+            if matches.isEmpty { return 0 }
+            let sameFile = matches.filter { $0.file == file }
+            if sameFile.count == 1 { return sameFile[0].fanIn }
+            return matches.count == 1 ? matches[0].fanIn : 0
+        }
+
+        var hotspots: [Hotspot] = []
+        for result in results {
+            for function in result.functions
+            where configuration.isExceeded(function, fallback: fallbackThreshold) {
+                hotspots.append(
+                    Hotspot(
+                        function: function,
+                        filePath: result.filePath,
+                        typeFanIn: typeFanIn(
+                            enclosingTypeName: function.enclosingTypeName,
+                            file: result.filePath)
+                    ))
+            }
+        }
+
+        return
+            hotspots
+            .sorted { lhs, rhs in
+                if lhs.typeFanIn != rhs.typeFanIn { return lhs.typeFanIn > rhs.typeFanIn }
+                if lhs.function.cognitiveComplexity != rhs.function.cognitiveComplexity {
+                    return lhs.function.cognitiveComplexity > rhs.function.cognitiveComplexity
+                }
+                if lhs.function.cyclomaticComplexity != rhs.function.cyclomaticComplexity {
+                    return lhs.function.cyclomaticComplexity > rhs.function.cyclomaticComplexity
+                }
+                return lhs.function.name < rhs.function.name
+            }
+            .prefix(limit)
+            .map { $0 }
+    }
+}

--- a/Sources/SwiftComplexityCore/Analysis/IndexStoreService.swift
+++ b/Sources/SwiftComplexityCore/Analysis/IndexStoreService.swift
@@ -1,0 +1,162 @@
+import Foundation
+import IndexStoreDB
+
+// MARK: - Errors
+
+/// Errors raised while opening an index store, shared by every index-backed
+/// analysis (LCOM4, coupling).
+enum IndexStoreError: LocalizedError {
+    case indexStoreNotFound(indexStorePath: String)
+    case libIndexStoreNotFound(searchedPath: String)
+    case toolchainRequired
+    case initializationFailed(underlying: Error)
+
+    var errorDescription: String? {
+        switch self {
+        case .indexStoreNotFound(let indexStorePath):
+            return """
+                Index store not found at '\(indexStorePath)'.
+                Run 'swift build' first to generate the index.
+                """
+        case .libIndexStoreNotFound(let searchedPath):
+            return "libIndexStore not found at: \(searchedPath)"
+        case .toolchainRequired:
+            #if os(Linux)
+                return "--toolchain-path is required for index-backed analysis on Linux"
+            #else
+                return "Failed to detect Xcode toolchain. Please specify --toolchain-path"
+            #endif
+        case .initializationFailed(let error):
+            return "Failed to initialize IndexStoreDB: \(error.localizedDescription)"
+        }
+    }
+}
+
+// MARK: - Shared store handle
+
+/// A single opened IndexStoreDB shared between index-backed calculators so
+/// the database is populated once per run (opening costs seconds).
+///
+/// `@unchecked Sendable`: IndexStoreDB is a class without a Sendable
+/// annotation, but its query API is documented thread-safe (SourceKit-LSP
+/// issues concurrent queries against one instance); this wrapper only ever
+/// exposes it immutably.
+struct SharedIndexStore: @unchecked Sendable {
+    let database: IndexStoreDB
+    let storePath: URL
+}
+
+// MARK: - Opening
+
+/// Opens IndexStoreDB instances. Centralizes libIndexStore discovery and the
+/// database configuration for every index-backed analysis.
+enum IndexStoreService {
+
+    static func open(indexStorePath: URL, toolchainPath: URL? = nil) throws -> SharedIndexStore {
+        guard FileManager.default.fileExists(atPath: indexStorePath.path) else {
+            throw IndexStoreError.indexStoreNotFound(indexStorePath: indexStorePath.path)
+        }
+
+        let libIndexStorePath = try findLibIndexStore(toolchainPath: toolchainPath)
+
+        do {
+            // The database path is keyed to the store path so repeated runs
+            // reuse the populated database per project without ever mixing
+            // different projects' indexes in one database.
+            //
+            // waitUntilDoneInitializing guarantees queries see the fully
+            // populated database; a one-shot CLI has no later delegate event
+            // to await, so returning earlier would race the first query.
+            let database = try IndexStoreDB(
+                storePath: indexStorePath.path,
+                databasePath: NSTemporaryDirectory()
+                    + "swift-complexity-index-\(stableHash(of: indexStorePath.path)).db",
+                library: IndexStoreLibrary(dylibPath: libIndexStorePath),
+                waitUntilDoneInitializing: true
+            )
+            return SharedIndexStore(database: database, storePath: indexStorePath)
+        } catch {
+            throw IndexStoreError.initializationFailed(underlying: error)
+        }
+    }
+
+    /// FNV-1a, chosen over `Hashable.hashValue` because the database path
+    /// must stay identical across processes (hashValue is seeded per run).
+    private static func stableHash(of string: String) -> String {
+        var hash: UInt64 = 0xcbf2_9ce4_8422_2325
+        for byte in string.utf8 {
+            hash ^= UInt64(byte)
+            hash = hash &* 0x0000_0100_0000_01B3
+        }
+        return String(hash, radix: 16)
+    }
+
+    // MARK: - libIndexStore discovery
+
+    /// Searches for the libIndexStore dynamic library.
+    /// - Parameter toolchainPath: Optional toolchain path (e.g.
+    ///   `~/.local/share/swiftly/toolchains/swift-6.2`). On macOS, `nil`
+    ///   auto-detects the Xcode toolchain. On Linux, this is required.
+    private static func findLibIndexStore(toolchainPath: URL?) throws -> String {
+        #if os(Linux)
+            let libName = "libIndexStore.so"
+        #else
+            let libName = "libIndexStore.dylib"
+        #endif
+
+        // Expected structure: <toolchainPath>/usr/lib/libIndexStore.{so,dylib}
+        if let toolchainPath = toolchainPath {
+            let libPath =
+                toolchainPath
+                .appendingPathComponent("usr")
+                .appendingPathComponent("lib")
+                .appendingPathComponent(libName)
+            guard FileManager.default.fileExists(atPath: libPath.path) else {
+                throw IndexStoreError.libIndexStoreNotFound(searchedPath: libPath.path)
+            }
+            return libPath.path
+        }
+
+        #if os(macOS)
+            return try findLibIndexStoreFromXcode()
+        #else
+            throw IndexStoreError.toolchainRequired
+        #endif
+    }
+
+    #if os(macOS)
+        /// Auto-detects libIndexStore from the active Xcode toolchain.
+        private static func findLibIndexStoreFromXcode() throws -> String {
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/xcrun")
+            process.arguments = ["--show-sdk-path"]
+
+            let pipe = Pipe()
+            process.standardOutput = pipe
+            process.standardError = pipe
+
+            try process.run()
+            process.waitUntilExit()
+
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            guard
+                let sdkPath = String(data: data, encoding: .utf8)?.trimmingCharacters(
+                    in: .whitespacesAndNewlines)
+            else {
+                throw IndexStoreError.toolchainRequired
+            }
+
+            // /Applications/Xcode.app/.../SDKs/MacOSX.sdk
+            // -> /Applications/Xcode.app/.../Toolchains/XcodeDefault.xctoolchain/usr/lib/libIndexStore.dylib
+            let xcodeAppPath = sdkPath.components(separatedBy: "/Platforms/").first ?? ""
+            let libPath =
+                "\(xcodeAppPath)/Toolchains/XcodeDefault.xctoolchain/usr/lib/libIndexStore.dylib"
+
+            guard FileManager.default.fileExists(atPath: libPath) else {
+                throw IndexStoreError.libIndexStoreNotFound(searchedPath: libPath)
+            }
+
+            return libPath
+        }
+    #endif
+}

--- a/Sources/SwiftComplexityCore/Analysis/NominalTypeDetector.swift
+++ b/Sources/SwiftComplexityCore/Analysis/NominalTypeDetector.swift
@@ -65,6 +65,10 @@ class NominalTypeDetector: SyntaxVisitor {
         return detectedTypes
     }
 
+    // The scope is pinned to [.lcom4] rather than SuppressedMetric.typeLevel:
+    // ClassCohesion must keep reporting only LCOM4 suppression so that output
+    // without --coupling stays identical to previous releases. Coupling
+    // suppression is collected independently by TypeRangeCollector.
     override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
         let name = node.name.text
         let location = extractLocation(from: node.classKeyword)
@@ -75,7 +79,7 @@ class NominalTypeDetector: SyntaxVisitor {
             members: node.memberBlock.members,
             location: location,
             suppressedMetrics: SuppressionParser.suppressedMetrics(
-                in: node.leadingTrivia, applicableTo: SuppressedMetric.typeLevel)
+                in: node.leadingTrivia, applicableTo: [.lcom4])
         )
 
         detectedTypes.append(detectedNominal)
@@ -93,7 +97,7 @@ class NominalTypeDetector: SyntaxVisitor {
             members: node.memberBlock.members,
             location: location,
             suppressedMetrics: SuppressionParser.suppressedMetrics(
-                in: node.leadingTrivia, applicableTo: SuppressedMetric.typeLevel)
+                in: node.leadingTrivia, applicableTo: [.lcom4])
         )
 
         detectedTypes.append(detectedNominal)
@@ -111,7 +115,7 @@ class NominalTypeDetector: SyntaxVisitor {
             members: node.memberBlock.members,
             location: location,
             suppressedMetrics: SuppressionParser.suppressedMetrics(
-                in: node.leadingTrivia, applicableTo: SuppressedMetric.typeLevel)
+                in: node.leadingTrivia, applicableTo: [.lcom4])
         )
 
         detectedTypes.append(detectedNominal)

--- a/Sources/SwiftComplexityCore/Analysis/ReferenceGraph.swift
+++ b/Sources/SwiftComplexityCore/Analysis/ReferenceGraph.swift
@@ -292,7 +292,8 @@ enum ReferenceGraphBuilder {
         named name: String, inFile file: String, nodes: [String: ReferenceGraph.Node]
     ) -> String? {
         let exact = nodes.values.filter { $0.name == name }
-        let candidates = exact.isEmpty
+        let candidates =
+            exact.isEmpty
             ? nodes.values.filter { $0.name.hasSuffix(".\(name)") }
             : exact
         let sameFile = candidates.filter { $0.file == file }

--- a/Sources/SwiftComplexityCore/Analysis/ReferenceGraph.swift
+++ b/Sources/SwiftComplexityCore/Analysis/ReferenceGraph.swift
@@ -53,22 +53,30 @@ struct ReferenceGraph: Sendable {
     func fanIn(of usr: String) -> Int { inEdges[usr]?.count ?? 0 }
 }
 
-/// Attribution accounting for one build. Every reference lands in exactly one
-/// attributed/dropped bucket, so:
+/// Attribution accounting for one coupling run. Every reference lands in
+/// exactly one attributed/dropped bucket, so:
 /// refsTotal == attributedByContainedBy + attributedByBaseOf
 ///            + attributedByLocation + droppedNonProjectSymbol
 ///            + droppedTypealias + droppedUnattributable.
 /// Self-references are attributed but produce no edge; they are additionally
 /// counted in `selfReferencesSkipped`.
-struct CouplingDiagnostics: Sendable, Equatable {
-    var refsTotal = 0
-    var attributedByContainedBy = 0
-    var attributedByBaseOf = 0
-    var attributedByLocation = 0
-    var droppedNonProjectSymbol = 0
-    var droppedTypealias = 0
-    var droppedUnattributable = 0
-    var selfReferencesSkipped = 0
+///
+/// Public so the CLI can report attribution quality to stderr; construction
+/// and mutation stay internal to the analysis.
+public struct CouplingDiagnostics: Sendable, Equatable {
+    public internal(set) var refsTotal = 0
+    public internal(set) var attributedByContainedBy = 0
+    public internal(set) var attributedByBaseOf = 0
+    public internal(set) var attributedByLocation = 0
+    public internal(set) var droppedNonProjectSymbol = 0
+    public internal(set) var droppedTypealias = 0
+    public internal(set) var droppedUnattributable = 0
+    public internal(set) var selfReferencesSkipped = 0
+
+    /// References that resolved to a source type (self-references included).
+    public var attributedTotal: Int {
+        attributedByContainedBy + attributedByBaseOf + attributedByLocation
+    }
 }
 
 // MARK: - Builder

--- a/Sources/SwiftComplexityCore/Analysis/ReferenceGraph.swift
+++ b/Sources/SwiftComplexityCore/Analysis/ReferenceGraph.swift
@@ -1,0 +1,210 @@
+import Foundation
+import IndexStoreDB
+
+// MARK: - Pure input records
+
+/// One relation attached to an index occurrence.
+struct RecordRelation: Sendable {
+    let usr: String
+    let kind: IndexSymbolKind
+    let roles: SymbolRole
+}
+
+/// A pure-data projection of `SymbolOccurrence`.
+///
+/// The graph builder consumes these instead of IndexStoreDB types that
+/// require a live store, so the whole attribution algorithm is unit-testable
+/// with hand-written records (relation shapes were verified against a real
+/// index in the coupling spike).
+struct IndexOccurrenceRecord: Sendable {
+    let usr: String
+    let name: String
+    let kind: IndexSymbolKind
+    let file: String
+    let line: Int
+    let column: Int
+    let roles: SymbolRole
+    let relations: [RecordRelation]
+}
+
+// MARK: - Outputs
+
+/// Type-to-type reference graph over project-internal nominal types.
+struct ReferenceGraph: Sendable {
+    struct Node: Sendable {
+        let usr: String
+        /// Dotted display name from syntax when available (e.g. "Outer.Inner"),
+        /// otherwise the index symbol name.
+        let name: String
+        /// Syntax-derived kind when available: the index reports actors as
+        /// classes, so syntax wins.
+        let kind: NominalType
+        let file: String
+        let location: SourceLocation
+        let suppressedMetrics: Set<SuppressedMetric>
+    }
+
+    /// Project-internal types only, keyed by USR.
+    let nodes: [String: Node]
+    let outEdges: [String: Set<String>]
+    let inEdges: [String: Set<String>]
+
+    func fanOut(of usr: String) -> Int { outEdges[usr]?.count ?? 0 }
+    func fanIn(of usr: String) -> Int { inEdges[usr]?.count ?? 0 }
+}
+
+/// Attribution accounting for one build. Every reference lands in exactly one
+/// attributed/dropped bucket, so:
+/// refsTotal == attributedByContainedBy + attributedByBaseOf
+///            + attributedByLocation + droppedNonProjectSymbol
+///            + droppedTypealias + droppedUnattributable.
+/// Self-references are attributed but produce no edge; they are additionally
+/// counted in `selfReferencesSkipped`.
+struct CouplingDiagnostics: Sendable, Equatable {
+    var refsTotal = 0
+    var attributedByContainedBy = 0
+    var attributedByBaseOf = 0
+    var attributedByLocation = 0
+    var droppedNonProjectSymbol = 0
+    var droppedTypealias = 0
+    var droppedUnattributable = 0
+    var selfReferencesSkipped = 0
+}
+
+// MARK: - Builder
+
+/// Builds the type reference graph from index occurrences plus per-file
+/// syntax ranges. Pure: no IndexStoreDB queries happen here.
+enum ReferenceGraphBuilder {
+
+    /// Index kinds that appear as nominal type definitions. Actors are
+    /// indexed as classes; the syntax side corrects the display kind.
+    private static let typeKinds: Set<IndexSymbolKind> = [.class, .struct, .enum, .protocol]
+
+    static func build(
+        occurrences: [IndexOccurrenceRecord],
+        typeRanges: [String: TypeRangeIndex]
+    ) -> (graph: ReferenceGraph, diagnostics: CouplingDiagnostics) {
+        var diagnostics = CouplingDiagnostics()
+
+        // Pass 1: definitions, parent chains, and extension resolution.
+        var defs: [String: IndexOccurrenceRecord] = [:]
+        var parentOf: [String: String] = [:]
+        var extensionToType: [String: String] = [:]
+
+        for record in occurrences {
+            if record.roles.contains(.definition) {
+                defs[record.usr] = record
+                if let parent = record.relations.first(where: { $0.roles.contains(.childOf) }) {
+                    parentOf[record.usr] = parent.usr
+                }
+            }
+            // The reference to `Foo` in `extension Foo` carries an
+            // `extendedBy` relation pointing at the extension symbol.
+            if let extRelation = record.relations.first(where: { $0.roles.contains(.extendedBy) }
+            ) {
+                extensionToType[extRelation.usr] = record.usr
+            }
+        }
+
+        let typeUSRs = Set(defs.values.filter { typeKinds.contains($0.kind) }.map(\.usr))
+
+        /// Walks a symbol up to its owning nominal type: extensions resolve to
+        /// the extended type, members resolve through childOf parents. The
+        /// depth cap turns corrupt parent cycles into a dropped ref instead of
+        /// a hang.
+        func ownerType(_ usr: String) -> String? {
+            var current = usr
+            for _ in 0..<16 {
+                if let extended = extensionToType[current] {
+                    current = extended
+                    continue
+                }
+                guard defs[current] != nil else { return nil }
+                if typeUSRs.contains(current) { return current }
+                guard let parent = parentOf[current] else { return nil }
+                current = parent
+            }
+            return nil
+        }
+
+        // Pass 2: references become type-to-type edges.
+        var outEdges: [String: Set<String>] = [:]
+        var inEdges: [String: Set<String>] = [:]
+
+        for record in occurrences
+        where record.roles.contains(.reference) || record.roles.contains(.call) {
+            diagnostics.refsTotal += 1
+
+            // Target side: the referenced type, or the type owning the
+            // referenced member.
+            guard defs[record.usr] != nil else {
+                diagnostics.droppedNonProjectSymbol += 1
+                continue
+            }
+            guard let target = ownerType(record.usr) else {
+                diagnostics.droppedUnattributable += 1
+                continue
+            }
+
+            // Source side: who holds this reference.
+            let source: String?
+            if let container = record.relations.first(where: { $0.roles.contains(.containedBy) }),
+                let resolved = ownerType(container.usr)
+            {
+                source = resolved
+                diagnostics.attributedByContainedBy += 1
+            } else {
+                source = nil
+            }
+
+            guard let source else {
+                diagnostics.droppedUnattributable += 1
+                continue
+            }
+
+            if source == target {
+                diagnostics.selfReferencesSkipped += 1
+                continue
+            }
+            outEdges[source, default: []].insert(target)
+            inEdges[target, default: []].insert(source)
+        }
+
+        // Node construction: join index definitions with syntax ranges for
+        // dotted names, actor kinds, and suppression.
+        var nodes: [String: ReferenceGraph.Node] = [:]
+        for usr in typeUSRs {
+            guard let def = defs[usr] else { continue }
+            let entry = typeRanges[def.file]?.innermostType(line: def.line, column: def.column)
+
+            let kind: NominalType
+            if case .nominal(let syntaxKind)? = entry?.declKind {
+                kind = syntaxKind
+            } else {
+                kind = Self.fallbackKind(for: def.kind)
+            }
+
+            nodes[usr] = ReferenceGraph.Node(
+                usr: usr,
+                name: entry?.name ?? def.name,
+                kind: kind,
+                file: def.file,
+                location: SourceLocation(line: def.line, column: def.column),
+                suppressedMetrics: entry.map(\.suppressedMetrics) ?? []
+            )
+        }
+
+        let graph = ReferenceGraph(nodes: nodes, outEdges: outEdges, inEdges: inEdges)
+        return (graph, diagnostics)
+    }
+
+    private static func fallbackKind(for indexKind: IndexSymbolKind) -> NominalType {
+        switch indexKind {
+        case .struct: return .struct
+        case .enum: return .enum
+        case .protocol: return .protocol
+        default: return .class
+        }
+    }
+}

--- a/Sources/SwiftComplexityCore/Analysis/ReferenceGraph.swift
+++ b/Sources/SwiftComplexityCore/Analysis/ReferenceGraph.swift
@@ -228,8 +228,6 @@ enum ReferenceGraphBuilder {
             diagnostics.droppedTypealias += 1
             return nil
         }
-        // Target side: the referenced type, or the type owning the
-        // referenced member.
         guard index.defs[record.usr] != nil else {
             diagnostics.droppedNonProjectSymbol += 1
             return nil

--- a/Sources/SwiftComplexityCore/Analysis/ReferenceGraph.swift
+++ b/Sources/SwiftComplexityCore/Analysis/ReferenceGraph.swift
@@ -79,30 +79,27 @@ public struct CouplingDiagnostics: Sendable, Equatable {
     }
 }
 
-// MARK: - Builder
+// MARK: - Definition index (pass 1)
 
-/// Builds the type reference graph from index occurrences plus per-file
-/// syntax ranges. Pure: no IndexStoreDB queries happen here.
-enum ReferenceGraphBuilder {
-
+/// Definitions, parent chains, and extension resolution collected in one pass
+/// over the occurrences.
+private struct DefinitionIndex {
     /// Index kinds that appear as nominal type definitions. Actors are
     /// indexed as classes; the syntax side corrects the display kind.
-    private static let typeKinds: Set<IndexSymbolKind> = [.class, .struct, .enum, .protocol]
+    static let typeKinds: Set<IndexSymbolKind> = [.class, .struct, .enum, .protocol]
 
-    static func build(
-        occurrences: [IndexOccurrenceRecord],
-        typeRanges: [String: TypeRangeIndex]
-    ) -> (graph: ReferenceGraph, diagnostics: CouplingDiagnostics) {
-        var diagnostics = CouplingDiagnostics()
+    private(set) var defs: [String: IndexOccurrenceRecord] = [:]
+    private(set) var parentOf: [String: String] = [:]
+    private(set) var extensionToType: [String: String] = [:]
+    private(set) var typeUSRs: Set<String> = []
 
-        // Pass 1: definitions, parent chains, and extension resolution.
-        var defs: [String: IndexOccurrenceRecord] = [:]
-        var parentOf: [String: String] = [:]
-        var extensionToType: [String: String] = [:]
-
+    init(occurrences: [IndexOccurrenceRecord]) {
         for record in occurrences {
             if record.roles.contains(.definition) {
                 defs[record.usr] = record
+                if Self.typeKinds.contains(record.kind) {
+                    typeUSRs.insert(record.usr)
+                }
                 if let parent = record.relations.first(where: { $0.roles.contains(.childOf) }) {
                     parentOf[record.usr] = parent.usr
                 }
@@ -114,42 +111,82 @@ enum ReferenceGraphBuilder {
                 extensionToType[extRelation.usr] = record.usr
             }
         }
+    }
 
-        let typeUSRs = Set(defs.values.filter { typeKinds.contains($0.kind) }.map(\.usr))
-
-        /// Walks a symbol up to its owning nominal type: extensions resolve to
-        /// the extended type, members resolve through childOf parents. The
-        /// depth cap turns corrupt parent cycles into a dropped ref instead of
-        /// a hang.
-        func ownerType(_ usr: String) -> String? {
-            var current = usr
-            for _ in 0..<16 {
-                if let extended = extensionToType[current] {
-                    current = extended
-                    continue
-                }
-                guard defs[current] != nil else { return nil }
-                if typeUSRs.contains(current) { return current }
-                guard let parent = parentOf[current] else { return nil }
-                current = parent
+    /// Walks a symbol up to its owning nominal type: extensions resolve to
+    /// the extended type, members resolve through childOf parents. The depth
+    /// cap turns corrupt parent cycles into a dropped ref instead of a hang.
+    func ownerType(of usr: String) -> String? {
+        var current = usr
+        for _ in 0..<16 {
+            if let extended = extensionToType[current] {
+                current = extended
+                continue
             }
-            return nil
+            guard defs[current] != nil else { return nil }
+            if typeUSRs.contains(current) { return current }
+            guard let parent = parentOf[current] else { return nil }
+            current = parent
+        }
+        return nil
+    }
+}
+
+// MARK: - Builder
+
+/// Builds the type reference graph from index occurrences plus per-file
+/// syntax ranges. Pure: no IndexStoreDB queries happen here.
+enum ReferenceGraphBuilder {
+
+    static func build(
+        occurrences: [IndexOccurrenceRecord],
+        typeRanges: [String: TypeRangeIndex]
+    ) -> (graph: ReferenceGraph, diagnostics: CouplingDiagnostics) {
+        let index = DefinitionIndex(occurrences: occurrences)
+        let nodes = buildNodes(index: index, typeRanges: typeRanges)
+
+        var diagnostics = CouplingDiagnostics()
+        var outEdges: [String: Set<String>] = [:]
+        var inEdges: [String: Set<String>] = [:]
+
+        for record in occurrences
+        where record.roles.contains(.reference) || record.roles.contains(.call) {
+            diagnostics.refsTotal += 1
+            guard
+                let edge = resolveEdge(
+                    for: record, index: index, nodes: nodes,
+                    typeRanges: typeRanges, diagnostics: &diagnostics)
+            else { continue }
+
+            if edge.source == edge.target {
+                diagnostics.selfReferencesSkipped += 1
+                continue
+            }
+            outEdges[edge.source, default: []].insert(edge.target)
+            inEdges[edge.target, default: []].insert(edge.source)
         }
 
-        // Node construction: join index definitions with syntax ranges for
-        // dotted names, actor kinds, and suppression. Runs before the
-        // reference pass because location-based attribution needs the
-        // name-to-USR mapping.
+        let graph = ReferenceGraph(nodes: nodes, outEdges: outEdges, inEdges: inEdges)
+        return (graph, diagnostics)
+    }
+
+    // MARK: Node metadata
+
+    /// Joins index definitions with syntax ranges for dotted names, actor
+    /// kinds, and suppression.
+    private static func buildNodes(
+        index: DefinitionIndex, typeRanges: [String: TypeRangeIndex]
+    ) -> [String: ReferenceGraph.Node] {
         var nodes: [String: ReferenceGraph.Node] = [:]
-        for usr in typeUSRs {
-            guard let def = defs[usr] else { continue }
+        for usr in index.typeUSRs {
+            guard let def = index.defs[usr] else { continue }
             let entry = typeRanges[def.file]?.innermostType(line: def.line, column: def.column)
 
             let kind: NominalType
             if case .nominal(let syntaxKind)? = entry?.declKind {
                 kind = syntaxKind
             } else {
-                kind = Self.fallbackKind(for: def.kind)
+                kind = fallbackKind(for: def.kind)
             }
 
             nodes[usr] = ReferenceGraph.Node(
@@ -161,95 +198,7 @@ enum ReferenceGraphBuilder {
                 suppressedMetrics: entry.map(\.suppressedMetrics) ?? []
             )
         }
-
-        var typeUSRsByName: [String: [String]] = [:]
-        for node in nodes.values {
-            typeUSRsByName[node.name, default: []].append(node.usr)
-        }
-
-        /// Maps a syntax type name back to a USR. Same-file candidates win;
-        /// an ambiguous name with no same-file candidate resolves to nil
-        /// rather than guessing a wrong edge.
-        func typeUSR(named name: String, inFile file: String) -> String? {
-            guard let candidates = typeUSRsByName[name] else { return nil }
-            if let sameFile = candidates.first(where: { nodes[$0]?.file == file }),
-                candidates.filter({ nodes[$0]?.file == file }).count == 1
-            {
-                return sameFile
-            }
-            return candidates.count == 1 ? candidates[0] : nil
-        }
-
-        // Pass 2: references become type-to-type edges.
-        var outEdges: [String: Set<String>] = [:]
-        var inEdges: [String: Set<String>] = [:]
-
-        for record in occurrences
-        where record.roles.contains(.reference) || record.roles.contains(.call) {
-            diagnostics.refsTotal += 1
-
-            // Typealias references are excluded from coupling: resolving
-            // through the alias would need semantic type information the
-            // index does not expose directly.
-            if record.kind == .typealias {
-                diagnostics.droppedTypealias += 1
-                continue
-            }
-
-            // Target side: the referenced type, or the type owning the
-            // referenced member.
-            guard defs[record.usr] != nil else {
-                diagnostics.droppedNonProjectSymbol += 1
-                continue
-            }
-            guard let target = ownerType(record.usr) else {
-                diagnostics.droppedUnattributable += 1
-                continue
-            }
-
-            // Source side: who holds this reference. Attribution cascades
-            // from the most to the least semantic evidence:
-            // 1. containedBy - the reference sits inside a declaration.
-            // 2. baseOf - inheritance/conformance clauses carry only this
-            //    relation, pointing at the inheriting type.
-            // 3. Syntax location - e.g. enum case payload annotations carry
-            //    no relations at all.
-            let source: String?
-            if let container = record.relations.first(where: { $0.roles.contains(.containedBy) }),
-                let resolved = ownerType(container.usr)
-            {
-                source = resolved
-                diagnostics.attributedByContainedBy += 1
-            } else if let base = record.relations.first(where: { $0.roles.contains(.baseOf) }),
-                let resolved = ownerType(base.usr)
-            {
-                source = resolved
-                diagnostics.attributedByBaseOf += 1
-            } else if let entry = typeRanges[record.file]?.innermostType(
-                line: record.line, column: record.column),
-                let resolved = typeUSR(named: entry.resolvedTypeName, inFile: record.file)
-            {
-                source = resolved
-                diagnostics.attributedByLocation += 1
-            } else {
-                source = nil
-            }
-
-            guard let source else {
-                diagnostics.droppedUnattributable += 1
-                continue
-            }
-
-            if source == target {
-                diagnostics.selfReferencesSkipped += 1
-                continue
-            }
-            outEdges[source, default: []].insert(target)
-            inEdges[target, default: []].insert(source)
-        }
-
-        let graph = ReferenceGraph(nodes: nodes, outEdges: outEdges, inEdges: inEdges)
-        return (graph, diagnostics)
+        return nodes
     }
 
     private static func fallbackKind(for indexKind: IndexSymbolKind) -> NominalType {
@@ -259,5 +208,95 @@ enum ReferenceGraphBuilder {
         case .protocol: return .protocol
         default: return .class
         }
+    }
+
+    // MARK: Edge resolution (pass 2)
+
+    /// Resolves one reference into a source/target type pair, or records why
+    /// it was dropped.
+    private static func resolveEdge(
+        for record: IndexOccurrenceRecord,
+        index: DefinitionIndex,
+        nodes: [String: ReferenceGraph.Node],
+        typeRanges: [String: TypeRangeIndex],
+        diagnostics: inout CouplingDiagnostics
+    ) -> (source: String, target: String)? {
+        // Typealias references are excluded from coupling: resolving through
+        // the alias would need semantic type information the index does not
+        // expose directly.
+        if record.kind == .typealias {
+            diagnostics.droppedTypealias += 1
+            return nil
+        }
+        // Target side: the referenced type, or the type owning the
+        // referenced member.
+        guard index.defs[record.usr] != nil else {
+            diagnostics.droppedNonProjectSymbol += 1
+            return nil
+        }
+        guard let target = index.ownerType(of: record.usr) else {
+            diagnostics.droppedUnattributable += 1
+            return nil
+        }
+        guard
+            let source = resolveSource(
+                for: record, index: index, nodes: nodes,
+                typeRanges: typeRanges, diagnostics: &diagnostics)
+        else {
+            diagnostics.droppedUnattributable += 1
+            return nil
+        }
+        return (source, target)
+    }
+
+    /// Resolves who holds a reference. Attribution cascades from the most to
+    /// the least semantic evidence:
+    /// 1. containedBy - the reference sits inside a declaration.
+    /// 2. baseOf - inheritance/conformance clauses carry only this relation,
+    ///    pointing at the inheriting type.
+    /// 3. Syntax location - e.g. enum case payload annotations carry no
+    ///    relations at all.
+    private static func resolveSource(
+        for record: IndexOccurrenceRecord,
+        index: DefinitionIndex,
+        nodes: [String: ReferenceGraph.Node],
+        typeRanges: [String: TypeRangeIndex],
+        diagnostics: inout CouplingDiagnostics
+    ) -> String? {
+        if let container = record.relations.first(where: { $0.roles.contains(.containedBy) }),
+            let resolved = index.ownerType(of: container.usr)
+        {
+            diagnostics.attributedByContainedBy += 1
+            return resolved
+        }
+        if let base = record.relations.first(where: { $0.roles.contains(.baseOf) }),
+            let resolved = index.ownerType(of: base.usr)
+        {
+            diagnostics.attributedByBaseOf += 1
+            return resolved
+        }
+        if let entry = typeRanges[record.file]?.innermostType(
+            line: record.line, column: record.column),
+            let resolved = typeUSR(named: entry.resolvedTypeName, inFile: record.file, nodes: nodes)
+        {
+            diagnostics.attributedByLocation += 1
+            return resolved
+        }
+        return nil
+    }
+
+    /// Maps a syntax type name back to a USR. Exact name matches win over
+    /// dotted-suffix matches, same-file candidates win over other files, and
+    /// an ambiguous name resolves to nil rather than guessing a wrong edge.
+    private static func typeUSR(
+        named name: String, inFile file: String, nodes: [String: ReferenceGraph.Node]
+    ) -> String? {
+        let exact = nodes.values.filter { $0.name == name }
+        let candidates = exact.isEmpty
+            ? nodes.values.filter { $0.name.hasSuffix(".\(name)") }
+            : exact
+        let sameFile = candidates.filter { $0.file == file }
+        if sameFile.count == 1 { return sameFile[0].usr }
+        return candidates.count == 1 ? candidates.first?.usr : nil
     }
 }

--- a/Sources/SwiftComplexityCore/Analysis/ReferenceGraph.swift
+++ b/Sources/SwiftComplexityCore/Analysis/ReferenceGraph.swift
@@ -128,51 +128,10 @@ enum ReferenceGraphBuilder {
             return nil
         }
 
-        // Pass 2: references become type-to-type edges.
-        var outEdges: [String: Set<String>] = [:]
-        var inEdges: [String: Set<String>] = [:]
-
-        for record in occurrences
-        where record.roles.contains(.reference) || record.roles.contains(.call) {
-            diagnostics.refsTotal += 1
-
-            // Target side: the referenced type, or the type owning the
-            // referenced member.
-            guard defs[record.usr] != nil else {
-                diagnostics.droppedNonProjectSymbol += 1
-                continue
-            }
-            guard let target = ownerType(record.usr) else {
-                diagnostics.droppedUnattributable += 1
-                continue
-            }
-
-            // Source side: who holds this reference.
-            let source: String?
-            if let container = record.relations.first(where: { $0.roles.contains(.containedBy) }),
-                let resolved = ownerType(container.usr)
-            {
-                source = resolved
-                diagnostics.attributedByContainedBy += 1
-            } else {
-                source = nil
-            }
-
-            guard let source else {
-                diagnostics.droppedUnattributable += 1
-                continue
-            }
-
-            if source == target {
-                diagnostics.selfReferencesSkipped += 1
-                continue
-            }
-            outEdges[source, default: []].insert(target)
-            inEdges[target, default: []].insert(source)
-        }
-
         // Node construction: join index definitions with syntax ranges for
-        // dotted names, actor kinds, and suppression.
+        // dotted names, actor kinds, and suppression. Runs before the
+        // reference pass because location-based attribution needs the
+        // name-to-USR mapping.
         var nodes: [String: ReferenceGraph.Node] = [:]
         for usr in typeUSRs {
             guard let def = defs[usr] else { continue }
@@ -193,6 +152,92 @@ enum ReferenceGraphBuilder {
                 location: SourceLocation(line: def.line, column: def.column),
                 suppressedMetrics: entry.map(\.suppressedMetrics) ?? []
             )
+        }
+
+        var typeUSRsByName: [String: [String]] = [:]
+        for node in nodes.values {
+            typeUSRsByName[node.name, default: []].append(node.usr)
+        }
+
+        /// Maps a syntax type name back to a USR. Same-file candidates win;
+        /// an ambiguous name with no same-file candidate resolves to nil
+        /// rather than guessing a wrong edge.
+        func typeUSR(named name: String, inFile file: String) -> String? {
+            guard let candidates = typeUSRsByName[name] else { return nil }
+            if let sameFile = candidates.first(where: { nodes[$0]?.file == file }),
+                candidates.filter({ nodes[$0]?.file == file }).count == 1
+            {
+                return sameFile
+            }
+            return candidates.count == 1 ? candidates[0] : nil
+        }
+
+        // Pass 2: references become type-to-type edges.
+        var outEdges: [String: Set<String>] = [:]
+        var inEdges: [String: Set<String>] = [:]
+
+        for record in occurrences
+        where record.roles.contains(.reference) || record.roles.contains(.call) {
+            diagnostics.refsTotal += 1
+
+            // Typealias references are excluded from coupling: resolving
+            // through the alias would need semantic type information the
+            // index does not expose directly.
+            if record.kind == .typealias {
+                diagnostics.droppedTypealias += 1
+                continue
+            }
+
+            // Target side: the referenced type, or the type owning the
+            // referenced member.
+            guard defs[record.usr] != nil else {
+                diagnostics.droppedNonProjectSymbol += 1
+                continue
+            }
+            guard let target = ownerType(record.usr) else {
+                diagnostics.droppedUnattributable += 1
+                continue
+            }
+
+            // Source side: who holds this reference. Attribution cascades
+            // from the most to the least semantic evidence:
+            // 1. containedBy - the reference sits inside a declaration.
+            // 2. baseOf - inheritance/conformance clauses carry only this
+            //    relation, pointing at the inheriting type.
+            // 3. Syntax location - e.g. enum case payload annotations carry
+            //    no relations at all.
+            let source: String?
+            if let container = record.relations.first(where: { $0.roles.contains(.containedBy) }),
+                let resolved = ownerType(container.usr)
+            {
+                source = resolved
+                diagnostics.attributedByContainedBy += 1
+            } else if let base = record.relations.first(where: { $0.roles.contains(.baseOf) }),
+                let resolved = ownerType(base.usr)
+            {
+                source = resolved
+                diagnostics.attributedByBaseOf += 1
+            } else if let entry = typeRanges[record.file]?.innermostType(
+                line: record.line, column: record.column),
+                let resolved = typeUSR(named: entry.resolvedTypeName, inFile: record.file)
+            {
+                source = resolved
+                diagnostics.attributedByLocation += 1
+            } else {
+                source = nil
+            }
+
+            guard let source else {
+                diagnostics.droppedUnattributable += 1
+                continue
+            }
+
+            if source == target {
+                diagnostics.selfReferencesSkipped += 1
+                continue
+            }
+            outEdges[source, default: []].insert(target)
+            inEdges[target, default: []].insert(source)
         }
 
         let graph = ReferenceGraph(nodes: nodes, outEdges: outEdges, inEdges: inEdges)

--- a/Sources/SwiftComplexityCore/Analysis/SemanticLCOMCalculator.swift
+++ b/Sources/SwiftComplexityCore/Analysis/SemanticLCOMCalculator.swift
@@ -7,10 +7,6 @@ import SwiftSyntax
 enum LCOMError: LocalizedError {
     case noMembersFound(className: String)
     case parsingFailed(className: String, underlying: Error)
-    case indexStoreNotFound(indexStorePath: String)
-    case libIndexStoreNotFound(searchedPath: String)
-    case toolchainRequired
-    case indexDBInitializationFailed(underlying: Error)
     case symbolNotFound(symbolName: String, usr: String?)
     case queryTimeout(query: String)
 
@@ -20,21 +16,6 @@ enum LCOMError: LocalizedError {
             return "No members found in class '\(className)'"
         case .parsingFailed(let className, let error):
             return "Failed to parse class '\(className)': \(error.localizedDescription)"
-        case .indexStoreNotFound(let indexStorePath):
-            return """
-                Index store not found at '\(indexStorePath)'.
-                Run 'swift build' first to generate the index.
-                """
-        case .libIndexStoreNotFound(let searchedPath):
-            return "libIndexStore not found at: \(searchedPath)"
-        case .toolchainRequired:
-            #if os(Linux)
-                return "--toolchain-path is required for LCOM4 analysis on Linux"
-            #else
-                return "Failed to detect Xcode toolchain. Please specify --toolchain-path"
-            #endif
-        case .indexDBInitializationFailed(let error):
-            return "Failed to initialize IndexStoreDB: \(error.localizedDescription)"
         case .symbolNotFound(let symbolName, let usr):
             let usrInfo = usr.map { " (USR: \($0))" } ?? ""
             return "Symbol '\(symbolName)' not found in index\(usrInfo)"
@@ -104,6 +85,13 @@ actor SemanticLCOMCalculator {
     private let indexStoreDB: IndexStoreDB
     private let indexStorePath: URL
 
+    /// Initialize with an already opened index store, shared with other
+    /// index-backed calculators so the database is populated only once.
+    init(indexStore: SharedIndexStore) {
+        self.indexStoreDB = indexStore.database
+        self.indexStorePath = indexStore.storePath
+    }
+
     /// Initialize with explicit IndexStore path
     /// - Parameters:
     ///   - indexStorePath: Direct path to the IndexStore (e.g., .build/debug/index/store)
@@ -111,20 +99,10 @@ actor SemanticLCOMCalculator {
     ///                    On macOS, if nil, Xcode toolchain is auto-detected.
     ///                    On Linux, this is required.
     init(indexStorePath: URL, toolchainPath: URL? = nil) throws {
-        self.indexStorePath = indexStorePath
-
-        guard FileManager.default.fileExists(atPath: indexStorePath.path) else {
-            throw LCOMError.indexStoreNotFound(indexStorePath: indexStorePath.path)
-        }
-
-        // Get libIndexStore path (platform-specific)
-        let libIndexStorePath = try Self.findLibIndexStore(toolchainPath: toolchainPath)
-
-        self.indexStoreDB = try IndexStoreDB(
-            storePath: indexStorePath.path,
-            databasePath: NSTemporaryDirectory() + "lcom4-index.db",
-            library: IndexStoreLibrary(dylibPath: libIndexStorePath)
-        )
+        let store = try IndexStoreService.open(
+            indexStorePath: indexStorePath, toolchainPath: toolchainPath)
+        self.indexStoreDB = store.database
+        self.indexStorePath = store.storePath
     }
 
     /// Calculates LCOM4 value for Nominal Type (class/struct/actor)
@@ -447,80 +425,6 @@ actor SemanticLCOMCalculator {
         return methodCalls
     }
 
-    // MARK: - Helper Methods
-
-    /// Searches for libIndexStore path
-    /// - Parameter toolchainPath: Optional toolchain path (e.g., ~/.local/share/swiftly/toolchains/swift-6.2).
-    ///   On macOS, if nil, auto-detects from Xcode.
-    ///   On Linux, this is required.
-    /// - Returns: Path to libIndexStore.dylib (macOS) or libIndexStore.so (Linux)
-    private static func findLibIndexStore(toolchainPath: URL?) throws -> String {
-        #if os(Linux)
-            let libName = "libIndexStore.so"
-        #else
-            let libName = "libIndexStore.dylib"
-        #endif
-
-        // If toolchainPath is provided, use it directly
-        // Expected structure: <toolchainPath>/usr/lib/libIndexStore.{so,dylib}
-        if let toolchainPath = toolchainPath {
-            let libPath =
-                toolchainPath
-                .appendingPathComponent("usr")
-                .appendingPathComponent("lib")
-                .appendingPathComponent(libName)
-            guard FileManager.default.fileExists(atPath: libPath.path) else {
-                throw LCOMError.libIndexStoreNotFound(searchedPath: libPath.path)
-            }
-            return libPath.path
-        }
-
-        #if os(macOS)
-            // Auto-detect Xcode toolchain on macOS
-            return try findLibIndexStoreFromXcode()
-        #else
-            // On Linux, toolchainPath is required
-            throw LCOMError.toolchainRequired
-        #endif
-    }
-
-    #if os(macOS)
-        /// Auto-detect libIndexStore from Xcode toolchain (macOS only)
-        private static func findLibIndexStoreFromXcode() throws -> String {
-            // Get Xcode toolchain path using xcrun
-            let process = Process()
-            process.executableURL = URL(fileURLWithPath: "/usr/bin/xcrun")
-            process.arguments = ["--show-sdk-path"]
-
-            let pipe = Pipe()
-            process.standardOutput = pipe
-            process.standardError = pipe
-
-            try process.run()
-            process.waitUntilExit()
-
-            let data = pipe.fileHandleForReading.readDataToEndOfFile()
-            guard
-                let sdkPath = String(data: data, encoding: .utf8)?.trimmingCharacters(
-                    in: .whitespacesAndNewlines)
-            else {
-                throw LCOMError.toolchainRequired
-            }
-
-            // Infer toolchain lib directory from SDK path
-            // /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
-            // -> /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/libIndexStore.dylib
-            let xcodeAppPath = sdkPath.components(separatedBy: "/Platforms/").first ?? ""
-            let libPath =
-                "\(xcodeAppPath)/Toolchains/XcodeDefault.xctoolchain/usr/lib/libIndexStore.dylib"
-
-            guard FileManager.default.fileExists(atPath: libPath) else {
-                throw LCOMError.libIndexStoreNotFound(searchedPath: libPath)
-            }
-
-            return libPath
-        }
-    #endif
 }
 
 // MARK: - Syntax Visitors (Fallback)

--- a/Sources/SwiftComplexityCore/Analysis/TypeCouplingCalculator.swift
+++ b/Sources/SwiftComplexityCore/Analysis/TypeCouplingCalculator.swift
@@ -1,0 +1,74 @@
+import Foundation
+import IndexStoreDB
+
+/// Computes type-level coupling in one whole-project pass.
+///
+/// A thin adapter: scans the index occurrences of every analyzed file,
+/// projects them into pure records, and delegates all attribution logic to
+/// `ReferenceGraphBuilder` (which is what the unit tests cover).
+actor TypeCouplingCalculator {
+    private let indexStore: SharedIndexStore
+
+    init(indexStore: SharedIndexStore) {
+        self.indexStore = indexStore
+    }
+
+    /// - Parameters:
+    ///   - analyzedFiles: All Swift files in this run; defines the
+    ///     project-internal type population.
+    ///   - typeRanges: Per-file syntax ranges from `TypeRangeCollector`.
+    /// - Returns: Couplings grouped by the file defining each type (sorted by
+    ///   location for deterministic output), plus attribution accounting.
+    func calculate(
+        analyzedFiles: [String],
+        typeRanges: [String: TypeRangeIndex]
+    ) -> (byFile: [String: [TypeCoupling]], diagnostics: CouplingDiagnostics) {
+        var records: [IndexOccurrenceRecord] = []
+        for file in analyzedFiles {
+            for occurrence in indexStore.database.symbolOccurrences(inFilePath: file) {
+                records.append(
+                    IndexOccurrenceRecord(
+                        usr: occurrence.symbol.usr,
+                        name: occurrence.symbol.name,
+                        kind: occurrence.symbol.kind,
+                        // The query path, not occurrence.location.path: it is
+                        // guaranteed to match typeRanges keys and the result
+                        // file paths.
+                        file: file,
+                        line: occurrence.location.line,
+                        column: occurrence.location.utf8Column,
+                        roles: occurrence.roles,
+                        relations: occurrence.relations.map {
+                            RecordRelation(
+                                usr: $0.symbol.usr, kind: $0.symbol.kind, roles: $0.roles)
+                        }
+                    ))
+            }
+        }
+
+        let (graph, diagnostics) = ReferenceGraphBuilder.build(
+            occurrences: records, typeRanges: typeRanges)
+
+        var byFile: [String: [TypeCoupling]] = [:]
+        for node in graph.nodes.values {
+            byFile[node.file, default: []].append(
+                TypeCoupling(
+                    name: node.name,
+                    kind: node.kind,
+                    fanIn: graph.fanIn(of: node.usr),
+                    fanOut: graph.fanOut(of: node.usr),
+                    location: node.location,
+                    suppressedMetrics: node.suppressedMetrics.isEmpty
+                        ? nil : node.suppressedMetrics
+                ))
+        }
+        for (file, couplings) in byFile {
+            byFile[file] = couplings.sorted {
+                ($0.location.line, $0.location.column, $0.name)
+                    < ($1.location.line, $1.location.column, $1.name)
+            }
+        }
+
+        return (byFile, diagnostics)
+    }
+}

--- a/Sources/SwiftComplexityCore/Analysis/TypeRangeCollector.swift
+++ b/Sources/SwiftComplexityCore/Analysis/TypeRangeCollector.swift
@@ -1,0 +1,166 @@
+import SwiftSyntax
+
+/// One type or extension declaration's source extent within a file.
+///
+/// Collected for coupling analysis: index references that carry no
+/// `containedBy` relation (e.g. enum case payload annotations) are attributed
+/// to the innermost declaration whose extent contains their location.
+struct TypeRangeEntry: Sendable, Equatable {
+    enum DeclKind: Sendable, Equatable {
+        case nominal(NominalType)
+        case ext(extendedTypeName: String)
+    }
+
+    /// Display name; nested types use dotted form (e.g. "Outer.Inner").
+    /// Extension entries carry the extended type's name as written.
+    let name: String
+
+    let declKind: DeclKind
+
+    let startLine: Int
+    let startColumn: Int
+    let endLine: Int
+    let endColumn: Int
+
+    /// Type-level suppression parsed from the declaration's leading trivia.
+    /// Always empty for extensions: suppression is scoped to the primary
+    /// declaration so multiple extensions cannot contradict each other.
+    let suppressedMetrics: Set<SuppressedMetric>
+
+    /// The type name coupling edges attribute to; extensions resolve to the
+    /// extended type.
+    var resolvedTypeName: String {
+        switch declKind {
+        case .nominal: return name
+        case .ext(let extendedTypeName): return extendedTypeName
+        }
+    }
+
+    func contains(line: Int, column: Int) -> Bool {
+        if line < startLine || line > endLine { return false }
+        if line == startLine && column < startColumn { return false }
+        if line == endLine && column > endColumn { return false }
+        return true
+    }
+}
+
+/// Per-file lookup of type declaration extents for location-based attribution.
+struct TypeRangeIndex: Sendable {
+    let entries: [TypeRangeEntry]
+
+    /// The innermost declaration containing the given position, or `nil` at
+    /// top level. Nested declarations start later than their containers, so
+    /// the containing entry with the greatest start position is the innermost.
+    /// Files hold few type declarations; a linear scan keeps the rule obvious.
+    func innermostType(line: Int, column: Int) -> TypeRangeEntry? {
+        entries
+            .filter { $0.contains(line: line, column: column) }
+            .max { ($0.startLine, $0.startColumn) < ($1.startLine, $1.startColumn) }
+    }
+}
+
+/// Collects type declaration extents (class/struct/enum/actor/protocol and
+/// extensions) with their type-level suppression state.
+///
+/// Deliberately separate from `NominalTypeDetector`: that detector feeds
+/// LCOM4 and must keep reporting lcom4-only suppression for unchanged output,
+/// while coupling needs enum/protocol/extension coverage on top.
+final class TypeRangeCollector: SyntaxVisitor {
+    private var converter: SourceLocationConverter
+    private var entries: [TypeRangeEntry] = []
+    private var nameStack: [String] = []
+
+    static func collect(from sourceFile: SourceFileSyntax, filePath: String) -> TypeRangeIndex {
+        let collector = TypeRangeCollector(
+            converter: SourceLocationConverter(fileName: filePath, tree: sourceFile))
+        collector.walk(sourceFile)
+        return TypeRangeIndex(entries: collector.entries)
+    }
+
+    private init(converter: SourceLocationConverter) {
+        self.converter = converter
+        super.init(viewMode: .sourceAccurate)
+    }
+
+    // MARK: - Nominal declarations
+
+    override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
+        enter(node, simpleName: node.name.text, kind: .nominal(.class))
+    }
+
+    override func visitPost(_ node: ClassDeclSyntax) { nameStack.removeLast() }
+
+    override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
+        enter(node, simpleName: node.name.text, kind: .nominal(.struct))
+    }
+
+    override func visitPost(_ node: StructDeclSyntax) { nameStack.removeLast() }
+
+    override func visit(_ node: ActorDeclSyntax) -> SyntaxVisitorContinueKind {
+        enter(node, simpleName: node.name.text, kind: .nominal(.actor))
+    }
+
+    override func visitPost(_ node: ActorDeclSyntax) { nameStack.removeLast() }
+
+    override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
+        enter(node, simpleName: node.name.text, kind: .nominal(.enum))
+    }
+
+    override func visitPost(_ node: EnumDeclSyntax) { nameStack.removeLast() }
+
+    override func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind {
+        enter(node, simpleName: node.name.text, kind: .nominal(.protocol))
+    }
+
+    override func visitPost(_ node: ProtocolDeclSyntax) { nameStack.removeLast() }
+
+    override func visit(_ node: ExtensionDeclSyntax) -> SyntaxVisitorContinueKind {
+        let extendedName = node.extendedType.trimmedDescription
+        return enter(node, simpleName: extendedName, kind: .ext(extendedTypeName: extendedName))
+    }
+
+    override func visitPost(_ node: ExtensionDeclSyntax) { nameStack.removeLast() }
+
+    // MARK: - Recording
+
+    private func enter(
+        _ node: some SyntaxProtocol,
+        simpleName: String,
+        kind: TypeRangeEntry.DeclKind
+    ) -> SyntaxVisitorContinueKind {
+        let start = converter.location(for: node.positionAfterSkippingLeadingTrivia)
+        let end = converter.location(for: node.endPosition)
+        let dottedName = (nameStack + [simpleName]).joined(separator: ".")
+
+        entries.append(
+            TypeRangeEntry(
+                name: dottedName,
+                declKind: kind,
+                startLine: start.line,
+                startColumn: start.column,
+                endLine: end.line,
+                endColumn: end.column,
+                suppressedMetrics: suppression(for: kind, leadingTrivia: node.leadingTrivia)
+            ))
+
+        nameStack.append(simpleName)
+        return .visitChildren
+    }
+
+    private func suppression(
+        for kind: TypeRangeEntry.DeclKind, leadingTrivia: Trivia
+    ) -> Set<SuppressedMetric> {
+        switch kind {
+        case .nominal(.class), .nominal(.struct), .nominal(.actor):
+            return SuppressionParser.suppressedMetrics(
+                in: leadingTrivia, applicableTo: SuppressedMetric.typeLevel)
+        case .nominal(.enum), .nominal(.protocol):
+            // LCOM4 does not apply to enums/protocols, so a bare disable
+            // must not leak lcom4 into their suppression set.
+            return SuppressionParser.suppressedMetrics(
+                in: leadingTrivia, applicableTo: [.coupling])
+        case .ext:
+            return []
+        }
+    }
+}

--- a/Sources/SwiftComplexityCore/Models/ClassCohesion.swift
+++ b/Sources/SwiftComplexityCore/Models/ClassCohesion.swift
@@ -5,6 +5,10 @@ public enum NominalType: String, Codable, Sendable {
     case `class`
     case `struct`
     case actor
+    // Used by coupling metrics only: LCOM4 analyzes class/struct/actor and
+    // never produces these cases, keeping existing cohesion output unchanged.
+    case `enum`
+    case `protocol`
 }
 
 /// Classification of cohesion levels

--- a/Sources/SwiftComplexityCore/Models/ComplexityResult.swift
+++ b/Sources/SwiftComplexityCore/Models/ComplexityResult.swift
@@ -17,16 +17,39 @@ public struct ComplexityResult: Codable, Sendable {
     /// Cohesion summary (optional, only present when LCOM4 analysis is enabled)
     public let cohesionSummary: CohesionSummary?
 
+    /// Coupling metrics for types defined in this file (optional, only present
+    /// when coupling analysis is enabled)
+    public let typeCouplings: [TypeCoupling]?
+
+    /// Coupling summary (optional, only present when coupling analysis is enabled)
+    public let couplingSummary: CouplingSummary?
+
     public init(
         filePath: String,
         functions: [FunctionComplexity],
-        classCohesions: [ClassCohesion]? = nil
+        classCohesions: [ClassCohesion]? = nil,
+        typeCouplings: [TypeCoupling]? = nil
     ) {
         self.filePath = filePath
         self.functions = functions
         self.classCohesions = classCohesions
         self.summary = FileSummary(functions: functions)
         self.cohesionSummary = classCohesions.map { CohesionSummary(classes: $0) }
+        self.typeCouplings = typeCouplings
+        self.couplingSummary = typeCouplings.map { CouplingSummary(types: $0) }
+    }
+
+    /// Returns a copy of this result with coupling metrics attached. Coupling
+    /// is computed in a whole-project pass after per-file analysis, so results
+    /// are rebuilt rather than mutated; the summaries recompute
+    /// deterministically from the same inputs.
+    public func attaching(typeCouplings: [TypeCoupling]) -> ComplexityResult {
+        ComplexityResult(
+            filePath: filePath,
+            functions: functions,
+            classCohesions: classCohesions,
+            typeCouplings: typeCouplings
+        )
     }
 }
 

--- a/Sources/SwiftComplexityCore/Models/FunctionComplexity.swift
+++ b/Sources/SwiftComplexityCore/Models/FunctionComplexity.swift
@@ -4,13 +4,14 @@ import Foundation
 /// `// swift-complexity:disable` comment.
 ///
 /// `cyclomatic`/`cognitive` apply to function-level declarations,
-/// `lcom4` to type declarations (class/struct/actor). Which subset a
+/// `lcom4` and `coupling` to type declarations. Which subset a
 /// directive can actually suppress is decided by the declaration it
 /// precedes — see `SuppressedMetric.functionLevel`/`typeLevel`.
 public enum SuppressedMetric: String, Codable, Hashable, Sendable, CaseIterable {
     case cyclomatic
     case cognitive
     case lcom4
+    case coupling
 }
 
 extension SuppressedMetric {
@@ -18,7 +19,10 @@ extension SuppressedMetric {
     public static let functionLevel: Set<SuppressedMetric> = [.cyclomatic, .cognitive]
 
     /// Metrics a directive above a type declaration can suppress.
-    public static let typeLevel: Set<SuppressedMetric> = [.lcom4]
+    /// `lcom4` applies to class/struct/actor; `coupling` additionally applies
+    /// to enum/protocol — declaration kinds narrow this set further where
+    /// a metric is not applicable.
+    public static let typeLevel: Set<SuppressedMetric> = [.lcom4, .coupling]
 }
 
 /// Represents complexity metrics for a single function or method

--- a/Sources/SwiftComplexityCore/Models/ThresholdConfiguration.swift
+++ b/Sources/SwiftComplexityCore/Models/ThresholdConfiguration.swift
@@ -36,6 +36,40 @@ public struct ThresholdRule: Codable, Sendable, Hashable {
     }
 }
 
+/// Type-level coupling thresholds.
+///
+/// Absent keys mean "report-only": the metric is measured and reported but
+/// never gates the exit code. No defaults ship on purpose — unlike cyclomatic
+/// complexity's established 10/20 convention, sensible fan-in/fan-out limits
+/// depend on codebase size, and a wrong default would flood adopters with
+/// noise.
+public struct CouplingThresholds: Codable, Sendable, Equatable {
+    /// Flag types whose fan-out reaches this value (efferent coupling).
+    public let fanOut: Int?
+
+    /// Flag types whose fan-in reaches this value (afferent coupling).
+    /// Prefer starting with `fanOut`: high fan-in alone is often healthy
+    /// (stable shared models) and is better judged via the hotspot ranking.
+    public let fanIn: Int?
+
+    public init(fanOut: Int? = nil, fanIn: Int? = nil) {
+        self.fanOut = fanOut
+        self.fanIn = fanIn
+    }
+}
+
+/// One coupling threshold violation for a type.
+public struct CouplingViolation: Sendable, Equatable {
+    public enum Metric: String, Sendable {
+        case fanOut
+        case fanIn
+    }
+
+    public let metric: Metric
+    public let value: Int
+    public let threshold: Int
+}
+
 /// Per-type complexity threshold configuration.
 ///
 /// Loaded from a `.swift-complexity.yml` file. Functions are flagged using a
@@ -50,9 +84,31 @@ public struct ThresholdConfiguration: Codable, Sendable, Equatable {
     /// Ordered list of per-type threshold rules.
     public let rules: [ThresholdRule]
 
-    public init(defaultThreshold: Int? = nil, rules: [ThresholdRule] = []) {
+    /// Optional coupling thresholds. `nil` (key absent) keeps coupling
+    /// report-only, preserving the behavior of configurations written before
+    /// coupling metrics existed.
+    public let coupling: CouplingThresholds?
+
+    public init(
+        defaultThreshold: Int? = nil,
+        rules: [ThresholdRule] = [],
+        coupling: CouplingThresholds? = nil
+    ) {
         self.defaultThreshold = defaultThreshold
         self.rules = rules
+        self.coupling = coupling
+    }
+
+    /// Every key is optional: a configuration that only sets `coupling:` (or
+    /// only `defaultThreshold:`) is valid. The synthesized decoder would
+    /// reject files without a `rules:` key.
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.defaultThreshold = try container.decodeIfPresent(
+            Int.self, forKey: .defaultThreshold)
+        self.rules = try container.decodeIfPresent([ThresholdRule].self, forKey: .rules) ?? []
+        self.coupling = try container.decodeIfPresent(
+            CouplingThresholds.self, forKey: .coupling)
     }
 
     /// An empty configuration that defines no rules. Resolution then depends
@@ -60,8 +116,28 @@ public struct ThresholdConfiguration: Codable, Sendable, Equatable {
     public static let empty = ThresholdConfiguration()
 
     /// Whether this configuration carries no rules and no default threshold.
+    ///
+    /// Deliberately ignores `coupling`: every existing `isEmpty` call site
+    /// gates complexity-threshold behavior (SARIF warnings, result
+    /// filtering), which a coupling-only configuration must not change.
     public var isEmpty: Bool {
         defaultThreshold == nil && rules.isEmpty
+    }
+
+    /// Coupling threshold violations for `type`, using the same `>=` semantics
+    /// as the complexity exit-code check. Suppression excludes the type from
+    /// the judgment entirely; its values are still reported elsewhere.
+    public func couplingViolations(_ type: TypeCoupling) -> [CouplingViolation] {
+        guard let coupling, !type.isSuppressed(.coupling) else { return [] }
+
+        var violations: [CouplingViolation] = []
+        if let limit = coupling.fanOut, type.fanOut >= limit {
+            violations.append(.init(metric: .fanOut, value: type.fanOut, threshold: limit))
+        }
+        if let limit = coupling.fanIn, type.fanIn >= limit {
+            violations.append(.init(metric: .fanIn, value: type.fanIn, threshold: limit))
+        }
+        return violations
     }
 
     /// Resolves the effective complexity threshold for a function whose

--- a/Sources/SwiftComplexityCore/Models/TypeCoupling.swift
+++ b/Sources/SwiftComplexityCore/Models/TypeCoupling.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+/// Semantic coupling metrics for one nominal type, measured over the
+/// project-internal reference graph (IndexStoreDB).
+public struct TypeCoupling: Codable, Hashable, Sendable {
+    /// Display name; nested types use dotted form (e.g. "Outer.Inner").
+    public let name: String
+
+    /// Declaration kind. Sourced from syntax so actors are reported as
+    /// `.actor` even though the index classifies them as classes.
+    public let kind: NominalType
+
+    /// Number of distinct project-internal types that reference this type
+    /// (afferent coupling). High fan-in means changes here have a large
+    /// blast radius.
+    public let fanIn: Int
+
+    /// Number of distinct project-internal types this type references
+    /// (efferent coupling). High fan-out means this type is easily broken
+    /// by changes elsewhere.
+    public let fanOut: Int
+
+    /// Martin's instability: fanOut / (fanIn + fanOut), in 0...1.
+    /// `nil` when the type has no project-internal coupling at all
+    /// (both counts are zero), where the ratio is undefined.
+    public let instability: Double?
+
+    /// Location of the type declaration.
+    public let location: SourceLocation
+
+    /// Metrics excluded from threshold checks by a `// swift-complexity:disable`
+    /// comment above the type declaration. Values are still reported even when
+    /// suppressed; only the threshold judgment is skipped.
+    public let suppressedMetrics: Set<SuppressedMetric>?
+
+    /// Instability is always derived from the counts rather than accepted as
+    /// input, so a `TypeCoupling` can never carry an inconsistent ratio.
+    public init(
+        name: String,
+        kind: NominalType,
+        fanIn: Int,
+        fanOut: Int,
+        location: SourceLocation,
+        suppressedMetrics: Set<SuppressedMetric>? = nil
+    ) {
+        self.name = name
+        self.kind = kind
+        self.fanIn = fanIn
+        self.fanOut = fanOut
+        let total = fanIn + fanOut
+        self.instability = total == 0 ? nil : Double(fanOut) / Double(total)
+        self.location = location
+        self.suppressedMetrics = suppressedMetrics
+    }
+
+    /// Whether `metric` is suppressed for this type.
+    public func isSuppressed(_ metric: SuppressedMetric) -> Bool {
+        suppressedMetrics?.contains(metric) ?? false
+    }
+}
+
+extension TypeCoupling: CustomStringConvertible {
+    public var description: String {
+        let instabilityText = instability.map { String(format: "%.2f", $0) } ?? "-"
+        return
+            "\(name) (\(kind.rawValue)) - Fan-In: \(fanIn), Fan-Out: \(fanOut), Instability: \(instabilityText)"
+    }
+}
+
+/// Aggregated coupling statistics for one file's types.
+public struct CouplingSummary: Codable, Sendable {
+    public let totalTypes: Int
+    public let maxFanIn: Int
+    public let maxFanOut: Int
+    public let averageFanOut: Double
+
+    public init(types: [TypeCoupling]) {
+        self.totalTypes = types.count
+        self.maxFanIn = types.map(\.fanIn).max() ?? 0
+        self.maxFanOut = types.map(\.fanOut).max() ?? 0
+        self.averageFanOut =
+            types.isEmpty
+            ? 0.0 : Double(types.reduce(0) { $0 + $1.fanOut }) / Double(types.count)
+    }
+}

--- a/Sources/SwiftComplexityCore/Output/OutputFormatter.swift
+++ b/Sources/SwiftComplexityCore/Output/OutputFormatter.swift
@@ -152,7 +152,8 @@ public class OutputFormatter {
         guard !hotspots.isEmpty else { return nil }
 
         var output = "Hotspots (complexity violations x fan-in):\n"
-        let separator = "+----+----------------------+----------------------+--------+-------+-------+\n"
+        let separator =
+            "+----+----------------------+----------------------+--------+-------+-------+\n"
         output += "| #  | Function             | Type                 | Fan-In | Cyclo | Cogn  |\n"
         output += separator
         for (rank, hotspot) in hotspots.enumerated() {

--- a/Sources/SwiftComplexityCore/Output/OutputFormatter.swift
+++ b/Sources/SwiftComplexityCore/Output/OutputFormatter.swift
@@ -45,8 +45,11 @@ public class OutputFormatter {
     }
 
     private func formatAsText(results: [ComplexityResult], options: OutputOptions) -> String {
-        let sections = results.compactMap { result -> String? in
-            guard !result.functions.isEmpty || result.classCohesions != nil else { return nil }
+        var sections = results.compactMap { result -> String? in
+            guard
+                !result.functions.isEmpty || result.classCohesions != nil
+                    || !(result.typeCouplings ?? []).isEmpty
+            else { return nil }
 
             var parts: [String] = ["File: \(result.filePath)"]
 
@@ -58,7 +61,15 @@ public class OutputFormatter {
                 parts.append(cohesionSection)
             }
 
+            if let couplingSection = formatCouplingSection(result: result) {
+                parts.append(couplingSection)
+            }
+
             return parts.joined(separator: "\n")
+        }
+
+        if let hotspotSection = formatHotspotSection(results: results, options: options) {
+            sections.append(hotspotSection)
         }
 
         return sections.joined(separator: "\n\n").trimmingCharacters(in: .whitespacesAndNewlines)
@@ -92,6 +103,71 @@ public class OutputFormatter {
         if let summary = result.cohesionSummary {
             output += formatCohesionSummary(summary: summary)
         }
+        return output
+    }
+
+    /// Formats the type coupling table section
+    private func formatCouplingSection(result: ComplexityResult) -> String? {
+        guard let couplings = result.typeCouplings, !couplings.isEmpty else { return nil }
+
+        var output = "Type Coupling:\n"
+        let separator = "+----------------------+----------+--------+---------+-------------+\n"
+        let nameColumn = "Type".padding(toLength: 20, withPad: " ", startingAt: 0)
+        output += "| \(nameColumn) | Kind     | Fan-In | Fan-Out | Instability |\n"
+        output += separator
+        for coupling in couplings {
+            let name = coupling.name.padding(toLength: 20, withPad: " ", startingAt: 0)
+            let kind = coupling.kind.rawValue.padding(toLength: 8, withPad: " ", startingAt: 0)
+            let fanIn = String(coupling.fanIn).padding(toLength: 6, withPad: " ", startingAt: 0)
+            let fanOut = String(coupling.fanOut).padding(toLength: 7, withPad: " ", startingAt: 0)
+            let instability = (coupling.instability.map { String(format: "%.2f", $0) } ?? "-")
+                .padding(toLength: 11, withPad: " ", startingAt: 0)
+            output += "| \(name) | \(kind) | \(fanIn) | \(fanOut) | \(instability) |\n"
+        }
+        output += separator
+        if let summary = result.couplingSummary {
+            output +=
+                "Total: \(summary.totalTypes) types, "
+                + "Max Fan-In: \(summary.maxFanIn), Max Fan-Out: \(summary.maxFanOut), "
+                + "Average Fan-Out: \(String(format: "%.1f", summary.averageFanOut))\n"
+        }
+        return output
+    }
+
+    /// Formats the global hotspot ranking. Requires both a complexity
+    /// threshold (violations are undefined without one) and coupling data
+    /// (the ranking axis), and stays silent when there are no violations.
+    private func formatHotspotSection(results: [ComplexityResult], options: OutputOptions)
+        -> String?
+    {
+        let couplingRan = results.contains { $0.typeCouplings != nil }
+        let hasThreshold =
+            options.threshold != nil || !(options.thresholdConfiguration ?? .empty).isEmpty
+        guard couplingRan, hasThreshold else { return nil }
+
+        let hotspots = HotspotRanker.rank(
+            results: results,
+            configuration: options.thresholdConfiguration ?? .empty,
+            fallbackThreshold: options.threshold)
+        guard !hotspots.isEmpty else { return nil }
+
+        var output = "Hotspots (complexity violations x fan-in):\n"
+        let separator = "+----+----------------------+----------------------+--------+-------+-------+\n"
+        output += "| #  | Function             | Type                 | Fan-In | Cyclo | Cogn  |\n"
+        output += separator
+        for (rank, hotspot) in hotspots.enumerated() {
+            let index = String(rank + 1).padding(toLength: 2, withPad: " ", startingAt: 0)
+            let name = hotspot.function.name.padding(toLength: 20, withPad: " ", startingAt: 0)
+            let type = (hotspot.function.enclosingTypeName ?? "-")
+                .padding(toLength: 20, withPad: " ", startingAt: 0)
+            let fanIn = String(hotspot.typeFanIn).padding(toLength: 6, withPad: " ", startingAt: 0)
+            let cyclo = String(hotspot.function.cyclomaticComplexity)
+                .padding(toLength: 5, withPad: " ", startingAt: 0)
+            let cogn = String(hotspot.function.cognitiveComplexity)
+                .padding(toLength: 5, withPad: " ", startingAt: 0)
+            output += "| \(index) | \(name) | \(type) | \(fanIn) | \(cyclo) | \(cogn) |\n"
+        }
+        output += separator
         return output
     }
 

--- a/Sources/SwiftComplexityCore/Output/SARIFReport.swift
+++ b/Sources/SwiftComplexityCore/Output/SARIFReport.swift
@@ -139,14 +139,18 @@ extension OutputFormatter {
                 id: SARIFConstants.fanOutRuleId,
                 name: "TypeFanOut",
                 shortDescription: SARIFMessage(
-                    text: "Types should not depend on more types than the configured fan-out threshold"),
+                    text:
+                        "Types should not depend on more types than the configured fan-out threshold"
+                ),
                 helpUri: SARIFConstants.metricsHelpURI
             ),
             SARIFRule(
                 id: SARIFConstants.fanInRuleId,
                 name: "TypeFanIn",
                 shortDescription: SARIFMessage(
-                    text: "Types should not be depended upon by more types than the configured fan-in threshold"),
+                    text:
+                        "Types should not be depended upon by more types than the configured fan-in threshold"
+                ),
                 helpUri: SARIFConstants.metricsHelpURI
             ),
         ]

--- a/Sources/SwiftComplexityCore/Output/SARIFReport.swift
+++ b/Sources/SwiftComplexityCore/Output/SARIFReport.swift
@@ -80,12 +80,15 @@ extension OutputFormatter {
         static let cyclomaticRuleId = "cyclomatic_complexity"
         static let cognitiveRuleId = "cognitive_complexity"
         static let lcom4RuleId = "lcom4_cohesion"
+        static let fanOutRuleId = "type_fan_out"
+        static let fanInRuleId = "type_fan_in"
     }
 
     func formatAsSARIF(results: [ComplexityResult], options: OutputOptions) -> String {
         let sarifResults =
             results.flatMap { complexityResults(for: $0, options: options) }
             + results.flatMap { cohesionResults(for: $0) }
+            + results.flatMap { couplingResults(for: $0, options: options) }
 
         let driver = SARIFDriver(
             name: "swift-complexity",
@@ -130,6 +133,20 @@ extension OutputFormatter {
                 name: "LCOM4Cohesion",
                 shortDescription: SARIFMessage(
                     text: "Classes should not have low cohesion (LCOM4 >= 3)"),
+                helpUri: SARIFConstants.metricsHelpURI
+            ),
+            SARIFRule(
+                id: SARIFConstants.fanOutRuleId,
+                name: "TypeFanOut",
+                shortDescription: SARIFMessage(
+                    text: "Types should not depend on more types than the configured fan-out threshold"),
+                helpUri: SARIFConstants.metricsHelpURI
+            ),
+            SARIFRule(
+                id: SARIFConstants.fanInRuleId,
+                name: "TypeFanIn",
+                shortDescription: SARIFMessage(
+                    text: "Types should not be depended upon by more types than the configured fan-in threshold"),
                 helpUri: SARIFConstants.metricsHelpURI
             ),
         ]
@@ -195,6 +212,34 @@ extension OutputFormatter {
                 message: SARIFMessage(text: message),
                 locations: [sarifLocation(uri: uri, location: cohesion.location)]
             )
+        }
+    }
+
+    /// Coupling results exist only when coupling thresholds are configured,
+    /// mirroring the exit-code gate: report-only runs upload no violations.
+    private func couplingResults(
+        for result: ComplexityResult, options: OutputOptions
+    ) -> [SARIFResult] {
+        guard let configuration = options.thresholdConfiguration,
+            let couplings = result.typeCouplings
+        else { return [] }
+        let uri = relativizedURI(for: result.filePath)
+
+        return couplings.flatMap { coupling -> [SARIFResult] in
+            configuration.couplingViolations(coupling).map { violation in
+                let (ruleId, label) =
+                    violation.metric == .fanOut
+                    ? (SARIFConstants.fanOutRuleId, "fan-out")
+                    : (SARIFConstants.fanInRuleId, "fan-in")
+                let message =
+                    "\(coupling.kind.rawValue.capitalized) '\(coupling.name)' has \(label) \(violation.value) (threshold: \(violation.threshold))"
+                return SARIFResult(
+                    ruleId: ruleId,
+                    level: violation.value >= violation.threshold * 2 ? "error" : "warning",
+                    message: SARIFMessage(text: message),
+                    locations: [sarifLocation(uri: uri, location: coupling.location)]
+                )
+            }
         }
     }
 

--- a/Sources/SwiftComplexityCore/Processing/FileProcessor.swift
+++ b/Sources/SwiftComplexityCore/Processing/FileProcessor.swift
@@ -12,10 +12,20 @@ public struct ProcessingOptions: Sendable {
     public let excludePatterns: [String]
     public let verbose: Bool
 
-    public init(recursive: Bool = false, excludePatterns: [String] = [], verbose: Bool = false) {
+    /// Enables the whole-project coupling pass after per-file analysis.
+    /// Requires the processor's analyzer to hold an index store.
+    public let couplingEnabled: Bool
+
+    public init(
+        recursive: Bool = false,
+        excludePatterns: [String] = [],
+        verbose: Bool = false,
+        couplingEnabled: Bool = false
+    ) {
         self.recursive = recursive
         self.excludePatterns = excludePatterns
         self.verbose = verbose
+        self.couplingEnabled = couplingEnabled
     }
 }
 
@@ -24,6 +34,7 @@ public enum FileProcessorError: Error, LocalizedError {
     case fileNotReadable(String)
     case parseError(String, underlying: Error)
     case noSwiftFiles
+    case indexStoreRequired
 
     public var errorDescription: String? {
         switch self {
@@ -35,6 +46,11 @@ public enum FileProcessorError: Error, LocalizedError {
             return "Parse error in \(path): \(underlying.localizedDescription)"
         case .noSwiftFiles:
             return "No Swift files found"
+        case .indexStoreRequired:
+            return """
+                Coupling analysis requires an index store.
+                Pass --index-store-path (e.g. .build/debug/index/store) after running 'swift build'.
+                """
         }
     }
 }
@@ -42,6 +58,10 @@ public enum FileProcessorError: Error, LocalizedError {
 public actor FileProcessor: FileProcessing {
     private let analyzer: ComplexityAnalyzer
     private let fileManager: FileManager
+
+    /// Attribution accounting of the most recent coupling pass, for the CLI's
+    /// stderr diagnostics. `nil` until a coupling-enabled run completes.
+    public private(set) var lastCouplingDiagnostics: CouplingDiagnostics?
 
     /// Initialize with a custom analyzer
     public init(analyzer: ComplexityAnalyzer) {
@@ -80,23 +100,57 @@ public actor FileProcessor: FileProcessing {
             print("Found \(swiftFiles.count) Swift files to analyze")
         }
 
-        return try await withThrowingTaskGroup(of: ComplexityResult?.self) { group in
+        let (results, typeRanges) = try await withThrowingTaskGroup(
+            of: (result: ComplexityResult?, ranges: TypeRangeIndex?, filePath: String).self
+        ) { group in
             var results: [ComplexityResult] = []
+            var typeRanges: [String: TypeRangeIndex] = [:]
 
             for filePath in swiftFiles {
                 group.addTask {
-                    try await self.processFile(at: filePath, verbose: options.verbose)
+                    try await self.processFile(
+                        at: filePath,
+                        verbose: options.verbose,
+                        collectTypeRanges: options.couplingEnabled)
                 }
             }
 
-            for try await result in group {
-                if let result = result {
+            for try await item in group {
+                if let result = item.result {
                     results.append(result)
                 }
+                if let ranges = item.ranges {
+                    typeRanges[item.filePath] = ranges
+                }
             }
 
-            return results.sorted { $0.filePath < $1.filePath }
+            return (results.sorted { $0.filePath < $1.filePath }, typeRanges)
         }
+
+        guard options.couplingEnabled else { return results }
+        return try await runCouplingPass(
+            results: results, analyzedFiles: swiftFiles, typeRanges: typeRanges)
+    }
+
+    /// The whole-project coupling pass: one index scan over all analyzed
+    /// files, then distribution of each type's metrics to its defining file.
+    private func runCouplingPass(
+        results: [ComplexityResult],
+        analyzedFiles: [String],
+        typeRanges: [String: TypeRangeIndex]
+    ) async throws -> [ComplexityResult] {
+        guard let indexStore = analyzer.sharedIndexStore else {
+            throw FileProcessorError.indexStoreRequired
+        }
+
+        let calculator = TypeCouplingCalculator(indexStore: indexStore)
+        let (byFile, diagnostics) = await calculator.calculate(
+            analyzedFiles: analyzedFiles, typeRanges: typeRanges)
+        lastCouplingDiagnostics = diagnostics
+
+        // Every result gains coupling fields; an empty array (not nil) marks
+        // "coupling ran, this file defines no types".
+        return results.map { $0.attaching(typeCouplings: byFile[$0.filePath] ?? []) }
     }
 
     private func collectSwiftFiles(from paths: [String], options: ProcessingOptions) async throws
@@ -192,7 +246,9 @@ public actor FileProcessor: FileProcessing {
         }
     }
 
-    private func processFile(at filePath: String, verbose: Bool) async throws -> ComplexityResult? {
+    private func processFile(
+        at filePath: String, verbose: Bool, collectTypeRanges: Bool
+    ) async throws -> (result: ComplexityResult?, ranges: TypeRangeIndex?, filePath: String) {
         do {
             if verbose {
                 print("Analyzing: \(filePath)")
@@ -201,7 +257,13 @@ public actor FileProcessor: FileProcessing {
             let fileContent = try String(contentsOfFile: filePath)
             let sourceFile = Parser.parse(source: fileContent)
 
-            return try await analyzer.analyze(sourceFile: sourceFile, filePath: filePath)
+            let result = try await analyzer.analyze(sourceFile: sourceFile, filePath: filePath)
+            // Collected during the parallel phase to reuse the parsed tree;
+            // the coupling pass itself must wait for every file.
+            let ranges =
+                collectTypeRanges
+                ? TypeRangeCollector.collect(from: sourceFile, filePath: filePath) : nil
+            return (result, ranges, filePath)
 
         } catch {
             if verbose {

--- a/Tests/SwiftComplexityCLITests/SwiftComplexityCLITests.swift
+++ b/Tests/SwiftComplexityCLITests/SwiftComplexityCLITests.swift
@@ -96,6 +96,21 @@ struct CLIIntegrationTests {
 @Suite("CLI Validation Tests", .tags(.cli, .validation))
 struct CLIValidationTests {
 
+    @Test("--coupling parses and requires an index store path at run time")
+    func couplingFlagValidation() async throws {
+        // Parsing accepts the flag on its own...
+        let parsed = try ComplexityCommand.parse(["Sources", "--coupling"])
+        #expect(parsed.coupling)
+        #expect(parsed.indexStorePath == nil)
+
+        // ...but running without --index-store-path fails fast with a clear
+        // error, before any file processing happens.
+        await #expect(throws: ExitCode.self) {
+            var command = parsed
+            try await command.run()
+        }
+    }
+
     @Test("Mutually exclusive flags validation concept")
     func mutuallyExclusiveFlagsValidation() {
         // This test validates the concept of mutually exclusive flags

--- a/Tests/SwiftComplexityCoreTests/Fixtures/coupling_basic.swift
+++ b/Tests/SwiftComplexityCoreTests/Fixtures/coupling_basic.swift
@@ -1,0 +1,38 @@
+// Fixture for TypeRangeCollector / coupling attribution tests.
+// Expected type-range entries (name, kind):
+//   ServiceProtocol   protocol
+//   Outer             struct
+//   Outer.Inner       struct   (nested -> dotted name)
+//   MyActor           actor    (must not be reported as class)
+//   Outer             ext      (extension resolves to extended type "Outer")
+//   Payload           enum
+// The typealias is intentionally NOT an entry: coupling excludes typealiases.
+
+protocol ServiceProtocol {
+    func run()
+}
+
+struct Outer {
+    struct Inner {
+        let parent: Int
+    }
+
+    func use(_ value: Inner) -> Inner {
+        value
+    }
+}
+
+actor MyActor: ServiceProtocol {
+    func run() {}
+}
+
+extension Outer {
+    func extra() -> Int { 1 }
+}
+
+enum Payload {
+    case wrapped(Outer)
+    case empty
+}
+
+typealias OuterAlias = Outer

--- a/Tests/SwiftComplexityCoreTests/Fixtures/coupling_suppressed.swift
+++ b/Tests/SwiftComplexityCoreTests/Fixtures/coupling_suppressed.swift
@@ -1,0 +1,38 @@
+// Suppression fixture for coupling analysis.
+// Expected suppression sets collected by TypeRangeCollector:
+//   CouplingSuppressedClass  [coupling]          (explicit metric name)
+//   BareSuppressedEnum       [coupling]          (bare disable; lcom4 not applicable to enums)
+//   BareSuppressedProtocol   [coupling]          (bare disable; lcom4 not applicable to protocols)
+//   BareSuppressedStruct     [lcom4, coupling]   (bare disable suppresses all type-level metrics)
+//   TypoedClass              []                  (unknown metric name fails closed)
+//   extension entry          []                  (suppression on extensions is ignored by design)
+
+// swift-complexity:disable coupling
+class CouplingSuppressedClass {
+    func a() {}
+}
+
+// swift-complexity:disable
+enum BareSuppressedEnum {
+    case one
+}
+
+// swift-complexity:disable
+protocol BareSuppressedProtocol {
+    func requirement()
+}
+
+// swift-complexity:disable
+struct BareSuppressedStruct {
+    var x: Int
+}
+
+// swift-complexity:disable couplig
+class TypoedClass {
+    func b() {}
+}
+
+// swift-complexity:disable coupling
+extension CouplingSuppressedClass {
+    func fromExtension() {}
+}

--- a/Tests/SwiftComplexityCoreTests/Fixtures/golden/README.md
+++ b/Tests/SwiftComplexityCoreTests/Fixtures/golden/README.md
@@ -1,0 +1,41 @@
+# Golden fixtures for backward-compatibility regression tests
+
+These files freeze the JSON output of the CLI **before** the coupling-metrics
+feature (generated at commit `6aa21d0`, the `feature/coupling-metrics` branch
+point). The regression test asserts that analysis without `--coupling` still
+produces semantically identical output.
+
+## Comparison contract
+
+Raw output bytes are NOT comparable: `JSONEncoder` emits object keys in a
+nondeterministic order (varies per process), and `Set<SuppressedMetric>`
+encodes as an unordered array. The goldens are therefore stored in a
+**canonical form**, and the test must canonicalize the current output the same
+way before comparing:
+
+1. Make `filePath` values repo-relative (strip the absolute repo-root prefix).
+2. Sort all object keys.
+3. Sort every `suppressedMetrics` array.
+
+Everything else (file order, function order, all values) is deterministic and
+must match exactly.
+
+## Regeneration
+
+Only regenerate from a commit that predates the change under test, otherwise
+the regression guarantee is lost:
+
+```bash
+swift build
+FIX=Tests/SwiftComplexityCoreTests/Fixtures
+BIN=.build/debug/SwiftComplexityCLI
+NORM='walk(if type=="object" and has("suppressedMetrics") and (.suppressedMetrics != null) then .suppressedMetrics |= sort else . end)'
+"$BIN" "$FIX" --format json --recursive \
+  | sed "s|$(pwd)/||g" | jq -S "$NORM" > "$FIX/golden/complexity_plain.json"
+"$BIN" "$FIX" --format json --recursive --lcom4 --index-store-path .build/debug/index/store \
+  | sed "s|$(pwd)/||g" | jq -S "$NORM" > "$FIX/golden/complexity_lcom4.json"
+```
+
+Note: the fixture inputs are the `.swift` files directly under `Fixtures/` at
+generation time. New fixtures added for later features must live in
+subdirectories that the golden test excludes, or the goldens become stale.

--- a/Tests/SwiftComplexityCoreTests/Fixtures/golden/README.md
+++ b/Tests/SwiftComplexityCoreTests/Fixtures/golden/README.md
@@ -40,3 +40,8 @@ Note: `GoldenCompatibilityTests` pins the exact fixture file list that existed
 at generation time, so new fixture files added for later features do not
 affect this test. Extending the pinned list requires regenerating the goldens
 from a pre-change commit.
+
+The comparison runs on macOS only: the goldens are generated on macOS, and
+Foundation's JSON encoding/parsing differs slightly on Linux — platform
+variance is not what this regression gate measures. Linux behavior is covered
+by the CI integration steps.

--- a/Tests/SwiftComplexityCoreTests/Fixtures/golden/README.md
+++ b/Tests/SwiftComplexityCoreTests/Fixtures/golden/README.md
@@ -30,10 +30,12 @@ swift build
 FIX=Tests/SwiftComplexityCoreTests/Fixtures
 BIN=.build/debug/SwiftComplexityCLI
 NORM='walk(if type=="object" and has("suppressedMetrics") and (.suppressedMetrics != null) then .suppressedMetrics |= sort else . end)'
+# jq must run BEFORE the path relativization: the raw encoder output escapes
+# slashes ("\/"), so sed would silently match nothing on it.
 "$BIN" "$FIX" --format json --recursive \
-  | sed "s|$(pwd)/||g" | jq -S "$NORM" > "$FIX/golden/complexity_plain.json"
+  | jq -S "$NORM" | sed "s|$(pwd)/||g" > "$FIX/golden/complexity_plain.json"
 "$BIN" "$FIX" --format json --recursive --lcom4 --index-store-path .build/debug/index/store \
-  | sed "s|$(pwd)/||g" | jq -S "$NORM" > "$FIX/golden/complexity_lcom4.json"
+  | jq -S "$NORM" | sed "s|$(pwd)/||g" > "$FIX/golden/complexity_lcom4.json"
 ```
 
 Note: `GoldenCompatibilityTests` pins the exact fixture file list that existed

--- a/Tests/SwiftComplexityCoreTests/Fixtures/golden/README.md
+++ b/Tests/SwiftComplexityCoreTests/Fixtures/golden/README.md
@@ -36,6 +36,7 @@ NORM='walk(if type=="object" and has("suppressedMetrics") and (.suppressedMetric
   | sed "s|$(pwd)/||g" | jq -S "$NORM" > "$FIX/golden/complexity_lcom4.json"
 ```
 
-Note: the fixture inputs are the `.swift` files directly under `Fixtures/` at
-generation time. New fixtures added for later features must live in
-subdirectories that the golden test excludes, or the goldens become stale.
+Note: `GoldenCompatibilityTests` pins the exact fixture file list that existed
+at generation time, so new fixture files added for later features do not
+affect this test. Extending the pinned list requires regenerating the goldens
+from a pre-change commit.

--- a/Tests/SwiftComplexityCoreTests/Fixtures/golden/complexity_lcom4.json
+++ b/Tests/SwiftComplexityCoreTests/Fixtures/golden/complexity_lcom4.json
@@ -20,7 +20,7 @@
         "maxLCOM4": 0,
         "totalClasses": 1
       },
-      "filePath": "/Users/fumiyatanaka/Work/Apps/swift-complexity/Tests/SwiftComplexityCoreTests/Fixtures/class_with_methods.swift",
+      "filePath": "Tests/SwiftComplexityCoreTests/Fixtures/class_with_methods.swift",
       "functions": [
         {
           "cognitiveComplexity": 0,
@@ -67,7 +67,7 @@
       }
     },
     {
-      "filePath": "/Users/fumiyatanaka/Work/Apps/swift-complexity/Tests/SwiftComplexityCoreTests/Fixtures/cognitive_nested_conditions.swift",
+      "filePath": "Tests/SwiftComplexityCoreTests/Fixtures/cognitive_nested_conditions.swift",
       "functions": [
         {
           "cognitiveComplexity": 3,
@@ -110,7 +110,7 @@
         "maxLCOM4": 0,
         "totalClasses": 1
       },
-      "filePath": "/Users/fumiyatanaka/Work/Apps/swift-complexity/Tests/SwiftComplexityCoreTests/Fixtures/computed_property.swift",
+      "filePath": "Tests/SwiftComplexityCoreTests/Fixtures/computed_property.swift",
       "functions": [
         {
           "cognitiveComplexity": 3,
@@ -168,7 +168,7 @@
       }
     },
     {
-      "filePath": "/Users/fumiyatanaka/Work/Apps/swift-complexity/Tests/SwiftComplexityCoreTests/Fixtures/else_if_chain.swift",
+      "filePath": "Tests/SwiftComplexityCoreTests/Fixtures/else_if_chain.swift",
       "functions": [
         {
           "cognitiveComplexity": 3,
@@ -192,7 +192,7 @@
       }
     },
     {
-      "filePath": "/Users/fumiyatanaka/Work/Apps/swift-complexity/Tests/SwiftComplexityCoreTests/Fixtures/function_with_if.swift",
+      "filePath": "Tests/SwiftComplexityCoreTests/Fixtures/function_with_if.swift",
       "functions": [
         {
           "cognitiveComplexity": 1,
@@ -216,7 +216,7 @@
       }
     },
     {
-      "filePath": "/Users/fumiyatanaka/Work/Apps/swift-complexity/Tests/SwiftComplexityCoreTests/Fixtures/integration_test_sample.swift",
+      "filePath": "Tests/SwiftComplexityCoreTests/Fixtures/integration_test_sample.swift",
       "functions": [
         {
           "cognitiveComplexity": 0,
@@ -250,7 +250,7 @@
       }
     },
     {
-      "filePath": "/Users/fumiyatanaka/Work/Apps/swift-complexity/Tests/SwiftComplexityCoreTests/Fixtures/issue6_nested_else_if.swift",
+      "filePath": "Tests/SwiftComplexityCoreTests/Fixtures/issue6_nested_else_if.swift",
       "functions": [
         {
           "cognitiveComplexity": 46,
@@ -274,7 +274,7 @@
       }
     },
     {
-      "filePath": "/Users/fumiyatanaka/Work/Apps/swift-complexity/Tests/SwiftComplexityCoreTests/Fixtures/nested_conditions.swift",
+      "filePath": "Tests/SwiftComplexityCoreTests/Fixtures/nested_conditions.swift",
       "functions": [
         {
           "cognitiveComplexity": 5,
@@ -298,7 +298,7 @@
       }
     },
     {
-      "filePath": "/Users/fumiyatanaka/Work/Apps/swift-complexity/Tests/SwiftComplexityCoreTests/Fixtures/protocol_decl.swift",
+      "filePath": "Tests/SwiftComplexityCoreTests/Fixtures/protocol_decl.swift",
       "functions": [],
       "summary": {
         "averageCognitiveComplexity": 0,
@@ -311,7 +311,7 @@
       }
     },
     {
-      "filePath": "/Users/fumiyatanaka/Work/Apps/swift-complexity/Tests/SwiftComplexityCoreTests/Fixtures/protocol_extension_decl.swift",
+      "filePath": "Tests/SwiftComplexityCoreTests/Fixtures/protocol_extension_decl.swift",
       "functions": [
         {
           "cognitiveComplexity": 0,
@@ -336,7 +336,7 @@
       }
     },
     {
-      "filePath": "/Users/fumiyatanaka/Work/Apps/swift-complexity/Tests/SwiftComplexityCoreTests/Fixtures/simple_function.swift",
+      "filePath": "Tests/SwiftComplexityCoreTests/Fixtures/simple_function.swift",
       "functions": [
         {
           "cognitiveComplexity": 0,
@@ -360,7 +360,7 @@
       }
     },
     {
-      "filePath": "/Users/fumiyatanaka/Work/Apps/swift-complexity/Tests/SwiftComplexityCoreTests/Fixtures/single_function.swift",
+      "filePath": "Tests/SwiftComplexityCoreTests/Fixtures/single_function.swift",
       "functions": [
         {
           "cognitiveComplexity": 0,
@@ -403,7 +403,7 @@
         "maxLCOM4": 0,
         "totalClasses": 1
       },
-      "filePath": "/Users/fumiyatanaka/Work/Apps/swift-complexity/Tests/SwiftComplexityCoreTests/Fixtures/suppressed_functions.swift",
+      "filePath": "Tests/SwiftComplexityCoreTests/Fixtures/suppressed_functions.swift",
       "functions": [
         {
           "cognitiveComplexity": 2,
@@ -561,7 +561,7 @@
         "maxLCOM4": 2,
         "totalClasses": 5
       },
-      "filePath": "/Users/fumiyatanaka/Work/Apps/swift-complexity/Tests/SwiftComplexityCoreTests/Fixtures/suppressed_types.swift",
+      "filePath": "Tests/SwiftComplexityCoreTests/Fixtures/suppressed_types.swift",
       "functions": [
         {
           "cognitiveComplexity": 0,
@@ -685,7 +685,7 @@
       }
     },
     {
-      "filePath": "/Users/fumiyatanaka/Work/Apps/swift-complexity/Tests/SwiftComplexityCoreTests/Fixtures/very_complex_function.swift",
+      "filePath": "Tests/SwiftComplexityCoreTests/Fixtures/very_complex_function.swift",
       "functions": [
         {
           "cognitiveComplexity": 14,

--- a/Tests/SwiftComplexityCoreTests/Fixtures/golden/complexity_lcom4.json
+++ b/Tests/SwiftComplexityCoreTests/Fixtures/golden/complexity_lcom4.json
@@ -1,0 +1,712 @@
+{
+  "files": [
+    {
+      "classCohesions": [
+        {
+          "lcom4": 0,
+          "location": {
+            "column": 1,
+            "line": 5
+          },
+          "methodCount": 3,
+          "name": "TestClass",
+          "propertyCount": 0,
+          "type": "class"
+        }
+      ],
+      "cohesionSummary": {
+        "averageLCOM4": 0,
+        "classesWithLowCohesion": 0,
+        "maxLCOM4": 0,
+        "totalClasses": 1
+      },
+      "filePath": "/Users/fumiyatanaka/Work/Apps/swift-complexity/Tests/SwiftComplexityCoreTests/Fixtures/class_with_methods.swift",
+      "functions": [
+        {
+          "cognitiveComplexity": 0,
+          "cyclomaticComplexity": 1,
+          "enclosingTypeName": "TestClass",
+          "location": {
+            "column": 5,
+            "line": 6
+          },
+          "name": "init",
+          "signature": "init(value: Int)"
+        },
+        {
+          "cognitiveComplexity": 0,
+          "cyclomaticComplexity": 1,
+          "enclosingTypeName": "TestClass",
+          "location": {
+            "column": 5,
+            "line": 10
+          },
+          "name": "method1",
+          "signature": "func method1()"
+        },
+        {
+          "cognitiveComplexity": 0,
+          "cyclomaticComplexity": 1,
+          "enclosingTypeName": "TestClass",
+          "location": {
+            "column": 5,
+            "line": 14
+          },
+          "name": "method2",
+          "signature": "func method2()  -> String"
+        }
+      ],
+      "summary": {
+        "averageCognitiveComplexity": 0,
+        "averageCyclomaticComplexity": 1,
+        "maxCognitiveComplexity": 0,
+        "maxCyclomaticComplexity": 1,
+        "totalCognitiveComplexity": 0,
+        "totalCyclomaticComplexity": 3,
+        "totalFunctions": 3
+      }
+    },
+    {
+      "filePath": "/Users/fumiyatanaka/Work/Apps/swift-complexity/Tests/SwiftComplexityCoreTests/Fixtures/cognitive_nested_conditions.swift",
+      "functions": [
+        {
+          "cognitiveComplexity": 3,
+          "cyclomaticComplexity": 3,
+          "location": {
+            "column": 1,
+            "line": 5
+          },
+          "name": "nestedFunction",
+          "signature": "func nestedFunction(a: Int, b: Int)"
+        }
+      ],
+      "summary": {
+        "averageCognitiveComplexity": 3,
+        "averageCyclomaticComplexity": 3,
+        "maxCognitiveComplexity": 3,
+        "maxCyclomaticComplexity": 3,
+        "totalCognitiveComplexity": 3,
+        "totalCyclomaticComplexity": 3,
+        "totalFunctions": 1
+      }
+    },
+    {
+      "classCohesions": [
+        {
+          "lcom4": 0,
+          "location": {
+            "column": 1,
+            "line": 1
+          },
+          "methodCount": 0,
+          "name": "ComputedPropertyExample",
+          "propertyCount": 1,
+          "type": "struct"
+        }
+      ],
+      "cohesionSummary": {
+        "averageLCOM4": 0,
+        "classesWithLowCohesion": 0,
+        "maxLCOM4": 0,
+        "totalClasses": 1
+      },
+      "filePath": "/Users/fumiyatanaka/Work/Apps/swift-complexity/Tests/SwiftComplexityCoreTests/Fixtures/computed_property.swift",
+      "functions": [
+        {
+          "cognitiveComplexity": 3,
+          "cyclomaticComplexity": 3,
+          "enclosingTypeName": "ComputedPropertyExample",
+          "location": {
+            "column": 9,
+            "line": 4
+          },
+          "name": "shorthandGetter",
+          "signature": "var shorthandGetter : Bool"
+        },
+        {
+          "cognitiveComplexity": 1,
+          "cyclomaticComplexity": 2,
+          "enclosingTypeName": "ComputedPropertyExample",
+          "location": {
+            "column": 9,
+            "line": 21
+          },
+          "name": "explicitProperty.get",
+          "signature": "var explicitProperty { get }"
+        },
+        {
+          "cognitiveComplexity": 0,
+          "cyclomaticComplexity": 1,
+          "enclosingTypeName": "ComputedPropertyExample",
+          "location": {
+            "column": 9,
+            "line": 27
+          },
+          "name": "explicitProperty.set",
+          "signature": "var explicitProperty { set }"
+        },
+        {
+          "cognitiveComplexity": 1,
+          "cyclomaticComplexity": 2,
+          "enclosingTypeName": "ComputedPropertyExample",
+          "location": {
+            "column": 9,
+            "line": 35
+          },
+          "name": "observedProperty.didSet",
+          "signature": "var observedProperty { didSet }"
+        }
+      ],
+      "summary": {
+        "averageCognitiveComplexity": 1.25,
+        "averageCyclomaticComplexity": 2,
+        "maxCognitiveComplexity": 3,
+        "maxCyclomaticComplexity": 3,
+        "totalCognitiveComplexity": 5,
+        "totalCyclomaticComplexity": 8,
+        "totalFunctions": 4
+      }
+    },
+    {
+      "filePath": "/Users/fumiyatanaka/Work/Apps/swift-complexity/Tests/SwiftComplexityCoreTests/Fixtures/else_if_chain.swift",
+      "functions": [
+        {
+          "cognitiveComplexity": 3,
+          "cyclomaticComplexity": 3,
+          "location": {
+            "column": 1,
+            "line": 6
+          },
+          "name": "checkValue",
+          "signature": "func checkValue(value: Int)  -> String"
+        }
+      ],
+      "summary": {
+        "averageCognitiveComplexity": 3,
+        "averageCyclomaticComplexity": 3,
+        "maxCognitiveComplexity": 3,
+        "maxCyclomaticComplexity": 3,
+        "totalCognitiveComplexity": 3,
+        "totalCyclomaticComplexity": 3,
+        "totalFunctions": 1
+      }
+    },
+    {
+      "filePath": "/Users/fumiyatanaka/Work/Apps/swift-complexity/Tests/SwiftComplexityCoreTests/Fixtures/function_with_if.swift",
+      "functions": [
+        {
+          "cognitiveComplexity": 1,
+          "cyclomaticComplexity": 2,
+          "location": {
+            "column": 1,
+            "line": 5
+          },
+          "name": "functionWithIf",
+          "signature": "func functionWithIf(value: Int)"
+        }
+      ],
+      "summary": {
+        "averageCognitiveComplexity": 1,
+        "averageCyclomaticComplexity": 2,
+        "maxCognitiveComplexity": 1,
+        "maxCyclomaticComplexity": 2,
+        "totalCognitiveComplexity": 1,
+        "totalCyclomaticComplexity": 2,
+        "totalFunctions": 1
+      }
+    },
+    {
+      "filePath": "/Users/fumiyatanaka/Work/Apps/swift-complexity/Tests/SwiftComplexityCoreTests/Fixtures/integration_test_sample.swift",
+      "functions": [
+        {
+          "cognitiveComplexity": 0,
+          "cyclomaticComplexity": 1,
+          "location": {
+            "column": 1,
+            "line": 6
+          },
+          "name": "simpleFunction",
+          "signature": "func simpleFunction()  -> String"
+        },
+        {
+          "cognitiveComplexity": 5,
+          "cyclomaticComplexity": 3,
+          "location": {
+            "column": 1,
+            "line": 10
+          },
+          "name": "complexFunction",
+          "signature": "func complexFunction(number: Int)  -> String"
+        }
+      ],
+      "summary": {
+        "averageCognitiveComplexity": 2.5,
+        "averageCyclomaticComplexity": 2,
+        "maxCognitiveComplexity": 5,
+        "maxCyclomaticComplexity": 3,
+        "totalCognitiveComplexity": 5,
+        "totalCyclomaticComplexity": 4,
+        "totalFunctions": 2
+      }
+    },
+    {
+      "filePath": "/Users/fumiyatanaka/Work/Apps/swift-complexity/Tests/SwiftComplexityCoreTests/Fixtures/issue6_nested_else_if.swift",
+      "functions": [
+        {
+          "cognitiveComplexity": 46,
+          "cyclomaticComplexity": 14,
+          "location": {
+            "column": 1,
+            "line": 6
+          },
+          "name": "processData",
+          "signature": "func processData(data: [String: Any])  -> String"
+        }
+      ],
+      "summary": {
+        "averageCognitiveComplexity": 46,
+        "averageCyclomaticComplexity": 14,
+        "maxCognitiveComplexity": 46,
+        "maxCyclomaticComplexity": 14,
+        "totalCognitiveComplexity": 46,
+        "totalCyclomaticComplexity": 14,
+        "totalFunctions": 1
+      }
+    },
+    {
+      "filePath": "/Users/fumiyatanaka/Work/Apps/swift-complexity/Tests/SwiftComplexityCoreTests/Fixtures/nested_conditions.swift",
+      "functions": [
+        {
+          "cognitiveComplexity": 5,
+          "cyclomaticComplexity": 3,
+          "location": {
+            "column": 1,
+            "line": 5
+          },
+          "name": "complexFunction",
+          "signature": "func complexFunction(a: Int, b: Int)"
+        }
+      ],
+      "summary": {
+        "averageCognitiveComplexity": 5,
+        "averageCyclomaticComplexity": 3,
+        "maxCognitiveComplexity": 5,
+        "maxCyclomaticComplexity": 3,
+        "totalCognitiveComplexity": 5,
+        "totalCyclomaticComplexity": 3,
+        "totalFunctions": 1
+      }
+    },
+    {
+      "filePath": "/Users/fumiyatanaka/Work/Apps/swift-complexity/Tests/SwiftComplexityCoreTests/Fixtures/protocol_decl.swift",
+      "functions": [],
+      "summary": {
+        "averageCognitiveComplexity": 0,
+        "averageCyclomaticComplexity": 0,
+        "maxCognitiveComplexity": 0,
+        "maxCyclomaticComplexity": 0,
+        "totalCognitiveComplexity": 0,
+        "totalCyclomaticComplexity": 0,
+        "totalFunctions": 0
+      }
+    },
+    {
+      "filePath": "/Users/fumiyatanaka/Work/Apps/swift-complexity/Tests/SwiftComplexityCoreTests/Fixtures/protocol_extension_decl.swift",
+      "functions": [
+        {
+          "cognitiveComplexity": 0,
+          "cyclomaticComplexity": 1,
+          "enclosingTypeName": "P",
+          "location": {
+            "column": 5,
+            "line": 9
+          },
+          "name": "foo",
+          "signature": "func foo()"
+        }
+      ],
+      "summary": {
+        "averageCognitiveComplexity": 0,
+        "averageCyclomaticComplexity": 1,
+        "maxCognitiveComplexity": 0,
+        "maxCyclomaticComplexity": 1,
+        "totalCognitiveComplexity": 0,
+        "totalCyclomaticComplexity": 1,
+        "totalFunctions": 1
+      }
+    },
+    {
+      "filePath": "/Users/fumiyatanaka/Work/Apps/swift-complexity/Tests/SwiftComplexityCoreTests/Fixtures/simple_function.swift",
+      "functions": [
+        {
+          "cognitiveComplexity": 0,
+          "cyclomaticComplexity": 1,
+          "location": {
+            "column": 1,
+            "line": 5
+          },
+          "name": "simpleFunction",
+          "signature": "func simpleFunction()"
+        }
+      ],
+      "summary": {
+        "averageCognitiveComplexity": 0,
+        "averageCyclomaticComplexity": 1,
+        "maxCognitiveComplexity": 0,
+        "maxCyclomaticComplexity": 1,
+        "totalCognitiveComplexity": 0,
+        "totalCyclomaticComplexity": 1,
+        "totalFunctions": 1
+      }
+    },
+    {
+      "filePath": "/Users/fumiyatanaka/Work/Apps/swift-complexity/Tests/SwiftComplexityCoreTests/Fixtures/single_function.swift",
+      "functions": [
+        {
+          "cognitiveComplexity": 0,
+          "cyclomaticComplexity": 1,
+          "location": {
+            "column": 1,
+            "line": 6
+          },
+          "name": "testFunction",
+          "signature": "func testFunction(param: String)  -> Int"
+        }
+      ],
+      "summary": {
+        "averageCognitiveComplexity": 0,
+        "averageCyclomaticComplexity": 1,
+        "maxCognitiveComplexity": 0,
+        "maxCyclomaticComplexity": 1,
+        "totalCognitiveComplexity": 0,
+        "totalCyclomaticComplexity": 1,
+        "totalFunctions": 1
+      }
+    },
+    {
+      "classCohesions": [
+        {
+          "lcom4": 0,
+          "location": {
+            "column": 1,
+            "line": 59
+          },
+          "methodCount": 0,
+          "name": "SuppressedComputedProperty",
+          "propertyCount": 0,
+          "type": "struct"
+        }
+      ],
+      "cohesionSummary": {
+        "averageLCOM4": 0,
+        "classesWithLowCohesion": 0,
+        "maxLCOM4": 0,
+        "totalClasses": 1
+      },
+      "filePath": "/Users/fumiyatanaka/Work/Apps/swift-complexity/Tests/SwiftComplexityCoreTests/Fixtures/suppressed_functions.swift",
+      "functions": [
+        {
+          "cognitiveComplexity": 2,
+          "cyclomaticComplexity": 3,
+          "location": {
+            "column": 1,
+            "line": 6
+          },
+          "name": "fullySuppressed",
+          "signature": "func fullySuppressed(a: Int, b: Int)",
+          "suppressedMetrics": [
+            "cognitive",
+            "cyclomatic"
+          ]
+        },
+        {
+          "cognitiveComplexity": 2,
+          "cyclomaticComplexity": 3,
+          "location": {
+            "column": 1,
+            "line": 16
+          },
+          "name": "cyclomaticOnlySuppressed",
+          "signature": "func cyclomaticOnlySuppressed(a: Int, b: Int)",
+          "suppressedMetrics": [
+            "cyclomatic"
+          ]
+        },
+        {
+          "cognitiveComplexity": 2,
+          "cyclomaticComplexity": 3,
+          "location": {
+            "column": 1,
+            "line": 28
+          },
+          "name": "cognitiveOnlySuppressed",
+          "signature": "func cognitiveOnlySuppressed(a: Int, b: Int)",
+          "suppressedMetrics": [
+            "cognitive"
+          ]
+        },
+        {
+          "cognitiveComplexity": 2,
+          "cyclomaticComplexity": 3,
+          "location": {
+            "column": 1,
+            "line": 38
+          },
+          "name": "notSuppressed",
+          "signature": "func notSuppressed(a: Int, b: Int)"
+        },
+        {
+          "cognitiveComplexity": 2,
+          "cyclomaticComplexity": 3,
+          "location": {
+            "column": 1,
+            "line": 50
+          },
+          "name": "typoedMetricNotSuppressed",
+          "signature": "func typoedMetricNotSuppressed(a: Int, b: Int)"
+        },
+        {
+          "cognitiveComplexity": 3,
+          "cyclomaticComplexity": 3,
+          "enclosingTypeName": "SuppressedComputedProperty",
+          "location": {
+            "column": 9,
+            "line": 61
+          },
+          "name": "isValid",
+          "signature": "var isValid : Bool",
+          "suppressedMetrics": [
+            "cognitive",
+            "cyclomatic"
+          ]
+        }
+      ],
+      "summary": {
+        "averageCognitiveComplexity": 2.1666666666666665,
+        "averageCyclomaticComplexity": 3,
+        "maxCognitiveComplexity": 3,
+        "maxCyclomaticComplexity": 3,
+        "totalCognitiveComplexity": 13,
+        "totalCyclomaticComplexity": 18,
+        "totalFunctions": 6
+      }
+    },
+    {
+      "classCohesions": [
+        {
+          "lcom4": 2,
+          "location": {
+            "column": 1,
+            "line": 6
+          },
+          "methodCount": 2,
+          "name": "BareSuppressedClass",
+          "propertyCount": 2,
+          "suppressedMetrics": [
+            "lcom4"
+          ],
+          "type": "class"
+        },
+        {
+          "lcom4": 2,
+          "location": {
+            "column": 1,
+            "line": 14
+          },
+          "methodCount": 2,
+          "name": "Lcom4SuppressedStruct",
+          "propertyCount": 2,
+          "suppressedMetrics": [
+            "lcom4"
+          ],
+          "type": "struct"
+        },
+        {
+          "lcom4": 2,
+          "location": {
+            "column": 1,
+            "line": 22
+          },
+          "methodCount": 2,
+          "name": "NotSuppressedActor",
+          "propertyCount": 2,
+          "type": "actor"
+        },
+        {
+          "lcom4": 2,
+          "location": {
+            "column": 1,
+            "line": 31
+          },
+          "methodCount": 2,
+          "name": "WrongLevelMetricClass",
+          "propertyCount": 2,
+          "type": "class"
+        },
+        {
+          "lcom4": 2,
+          "location": {
+            "column": 1,
+            "line": 40
+          },
+          "methodCount": 2,
+          "name": "TypoedMetricClass",
+          "propertyCount": 2,
+          "type": "class"
+        }
+      ],
+      "cohesionSummary": {
+        "averageLCOM4": 2,
+        "classesWithLowCohesion": 0,
+        "maxLCOM4": 2,
+        "totalClasses": 5
+      },
+      "filePath": "/Users/fumiyatanaka/Work/Apps/swift-complexity/Tests/SwiftComplexityCoreTests/Fixtures/suppressed_types.swift",
+      "functions": [
+        {
+          "cognitiveComplexity": 0,
+          "cyclomaticComplexity": 1,
+          "enclosingTypeName": "BareSuppressedClass",
+          "location": {
+            "column": 5,
+            "line": 9
+          },
+          "name": "useA",
+          "signature": "func useA()"
+        },
+        {
+          "cognitiveComplexity": 0,
+          "cyclomaticComplexity": 1,
+          "enclosingTypeName": "BareSuppressedClass",
+          "location": {
+            "column": 5,
+            "line": 10
+          },
+          "name": "useB",
+          "signature": "func useB()"
+        },
+        {
+          "cognitiveComplexity": 0,
+          "cyclomaticComplexity": 1,
+          "enclosingTypeName": "Lcom4SuppressedStruct",
+          "location": {
+            "column": 5,
+            "line": 17
+          },
+          "name": "useA",
+          "signature": "func useA()  -> Int"
+        },
+        {
+          "cognitiveComplexity": 0,
+          "cyclomaticComplexity": 1,
+          "enclosingTypeName": "Lcom4SuppressedStruct",
+          "location": {
+            "column": 5,
+            "line": 18
+          },
+          "name": "useB",
+          "signature": "func useB()  -> Int"
+        },
+        {
+          "cognitiveComplexity": 0,
+          "cyclomaticComplexity": 1,
+          "enclosingTypeName": "NotSuppressedActor",
+          "location": {
+            "column": 5,
+            "line": 25
+          },
+          "name": "useA",
+          "signature": "func useA()"
+        },
+        {
+          "cognitiveComplexity": 0,
+          "cyclomaticComplexity": 1,
+          "enclosingTypeName": "NotSuppressedActor",
+          "location": {
+            "column": 5,
+            "line": 26
+          },
+          "name": "useB",
+          "signature": "func useB()"
+        },
+        {
+          "cognitiveComplexity": 0,
+          "cyclomaticComplexity": 1,
+          "enclosingTypeName": "WrongLevelMetricClass",
+          "location": {
+            "column": 5,
+            "line": 34
+          },
+          "name": "useA",
+          "signature": "func useA()"
+        },
+        {
+          "cognitiveComplexity": 0,
+          "cyclomaticComplexity": 1,
+          "enclosingTypeName": "WrongLevelMetricClass",
+          "location": {
+            "column": 5,
+            "line": 35
+          },
+          "name": "useB",
+          "signature": "func useB()"
+        },
+        {
+          "cognitiveComplexity": 0,
+          "cyclomaticComplexity": 1,
+          "enclosingTypeName": "TypoedMetricClass",
+          "location": {
+            "column": 5,
+            "line": 43
+          },
+          "name": "useA",
+          "signature": "func useA()"
+        },
+        {
+          "cognitiveComplexity": 0,
+          "cyclomaticComplexity": 1,
+          "enclosingTypeName": "TypoedMetricClass",
+          "location": {
+            "column": 5,
+            "line": 44
+          },
+          "name": "useB",
+          "signature": "func useB()"
+        }
+      ],
+      "summary": {
+        "averageCognitiveComplexity": 0,
+        "averageCyclomaticComplexity": 1,
+        "maxCognitiveComplexity": 0,
+        "maxCyclomaticComplexity": 1,
+        "totalCognitiveComplexity": 0,
+        "totalCyclomaticComplexity": 10,
+        "totalFunctions": 10
+      }
+    },
+    {
+      "filePath": "/Users/fumiyatanaka/Work/Apps/swift-complexity/Tests/SwiftComplexityCoreTests/Fixtures/very_complex_function.swift",
+      "functions": [
+        {
+          "cognitiveComplexity": 14,
+          "cyclomaticComplexity": 5,
+          "location": {
+            "column": 1,
+            "line": 5
+          },
+          "name": "veryComplexFunction",
+          "signature": "func veryComplexFunction(a: Int, b: Int, c: Int, d: Int)  -> String"
+        }
+      ],
+      "summary": {
+        "averageCognitiveComplexity": 14,
+        "averageCyclomaticComplexity": 5,
+        "maxCognitiveComplexity": 14,
+        "maxCyclomaticComplexity": 5,
+        "totalCognitiveComplexity": 14,
+        "totalCyclomaticComplexity": 5,
+        "totalFunctions": 1
+      }
+    }
+  ]
+}

--- a/Tests/SwiftComplexityCoreTests/Fixtures/golden/complexity_plain.json
+++ b/Tests/SwiftComplexityCoreTests/Fixtures/golden/complexity_plain.json
@@ -1,0 +1,586 @@
+{
+  "files": [
+    {
+      "filePath": "/Users/fumiyatanaka/Work/Apps/swift-complexity/Tests/SwiftComplexityCoreTests/Fixtures/class_with_methods.swift",
+      "functions": [
+        {
+          "cognitiveComplexity": 0,
+          "cyclomaticComplexity": 1,
+          "enclosingTypeName": "TestClass",
+          "location": {
+            "column": 5,
+            "line": 6
+          },
+          "name": "init",
+          "signature": "init(value: Int)"
+        },
+        {
+          "cognitiveComplexity": 0,
+          "cyclomaticComplexity": 1,
+          "enclosingTypeName": "TestClass",
+          "location": {
+            "column": 5,
+            "line": 10
+          },
+          "name": "method1",
+          "signature": "func method1()"
+        },
+        {
+          "cognitiveComplexity": 0,
+          "cyclomaticComplexity": 1,
+          "enclosingTypeName": "TestClass",
+          "location": {
+            "column": 5,
+            "line": 14
+          },
+          "name": "method2",
+          "signature": "func method2()  -> String"
+        }
+      ],
+      "summary": {
+        "averageCognitiveComplexity": 0,
+        "averageCyclomaticComplexity": 1,
+        "maxCognitiveComplexity": 0,
+        "maxCyclomaticComplexity": 1,
+        "totalCognitiveComplexity": 0,
+        "totalCyclomaticComplexity": 3,
+        "totalFunctions": 3
+      }
+    },
+    {
+      "filePath": "/Users/fumiyatanaka/Work/Apps/swift-complexity/Tests/SwiftComplexityCoreTests/Fixtures/cognitive_nested_conditions.swift",
+      "functions": [
+        {
+          "cognitiveComplexity": 3,
+          "cyclomaticComplexity": 3,
+          "location": {
+            "column": 1,
+            "line": 5
+          },
+          "name": "nestedFunction",
+          "signature": "func nestedFunction(a: Int, b: Int)"
+        }
+      ],
+      "summary": {
+        "averageCognitiveComplexity": 3,
+        "averageCyclomaticComplexity": 3,
+        "maxCognitiveComplexity": 3,
+        "maxCyclomaticComplexity": 3,
+        "totalCognitiveComplexity": 3,
+        "totalCyclomaticComplexity": 3,
+        "totalFunctions": 1
+      }
+    },
+    {
+      "filePath": "/Users/fumiyatanaka/Work/Apps/swift-complexity/Tests/SwiftComplexityCoreTests/Fixtures/computed_property.swift",
+      "functions": [
+        {
+          "cognitiveComplexity": 3,
+          "cyclomaticComplexity": 3,
+          "enclosingTypeName": "ComputedPropertyExample",
+          "location": {
+            "column": 9,
+            "line": 4
+          },
+          "name": "shorthandGetter",
+          "signature": "var shorthandGetter : Bool"
+        },
+        {
+          "cognitiveComplexity": 1,
+          "cyclomaticComplexity": 2,
+          "enclosingTypeName": "ComputedPropertyExample",
+          "location": {
+            "column": 9,
+            "line": 21
+          },
+          "name": "explicitProperty.get",
+          "signature": "var explicitProperty { get }"
+        },
+        {
+          "cognitiveComplexity": 0,
+          "cyclomaticComplexity": 1,
+          "enclosingTypeName": "ComputedPropertyExample",
+          "location": {
+            "column": 9,
+            "line": 27
+          },
+          "name": "explicitProperty.set",
+          "signature": "var explicitProperty { set }"
+        },
+        {
+          "cognitiveComplexity": 1,
+          "cyclomaticComplexity": 2,
+          "enclosingTypeName": "ComputedPropertyExample",
+          "location": {
+            "column": 9,
+            "line": 35
+          },
+          "name": "observedProperty.didSet",
+          "signature": "var observedProperty { didSet }"
+        }
+      ],
+      "summary": {
+        "averageCognitiveComplexity": 1.25,
+        "averageCyclomaticComplexity": 2,
+        "maxCognitiveComplexity": 3,
+        "maxCyclomaticComplexity": 3,
+        "totalCognitiveComplexity": 5,
+        "totalCyclomaticComplexity": 8,
+        "totalFunctions": 4
+      }
+    },
+    {
+      "filePath": "/Users/fumiyatanaka/Work/Apps/swift-complexity/Tests/SwiftComplexityCoreTests/Fixtures/else_if_chain.swift",
+      "functions": [
+        {
+          "cognitiveComplexity": 3,
+          "cyclomaticComplexity": 3,
+          "location": {
+            "column": 1,
+            "line": 6
+          },
+          "name": "checkValue",
+          "signature": "func checkValue(value: Int)  -> String"
+        }
+      ],
+      "summary": {
+        "averageCognitiveComplexity": 3,
+        "averageCyclomaticComplexity": 3,
+        "maxCognitiveComplexity": 3,
+        "maxCyclomaticComplexity": 3,
+        "totalCognitiveComplexity": 3,
+        "totalCyclomaticComplexity": 3,
+        "totalFunctions": 1
+      }
+    },
+    {
+      "filePath": "/Users/fumiyatanaka/Work/Apps/swift-complexity/Tests/SwiftComplexityCoreTests/Fixtures/function_with_if.swift",
+      "functions": [
+        {
+          "cognitiveComplexity": 1,
+          "cyclomaticComplexity": 2,
+          "location": {
+            "column": 1,
+            "line": 5
+          },
+          "name": "functionWithIf",
+          "signature": "func functionWithIf(value: Int)"
+        }
+      ],
+      "summary": {
+        "averageCognitiveComplexity": 1,
+        "averageCyclomaticComplexity": 2,
+        "maxCognitiveComplexity": 1,
+        "maxCyclomaticComplexity": 2,
+        "totalCognitiveComplexity": 1,
+        "totalCyclomaticComplexity": 2,
+        "totalFunctions": 1
+      }
+    },
+    {
+      "filePath": "/Users/fumiyatanaka/Work/Apps/swift-complexity/Tests/SwiftComplexityCoreTests/Fixtures/integration_test_sample.swift",
+      "functions": [
+        {
+          "cognitiveComplexity": 0,
+          "cyclomaticComplexity": 1,
+          "location": {
+            "column": 1,
+            "line": 6
+          },
+          "name": "simpleFunction",
+          "signature": "func simpleFunction()  -> String"
+        },
+        {
+          "cognitiveComplexity": 5,
+          "cyclomaticComplexity": 3,
+          "location": {
+            "column": 1,
+            "line": 10
+          },
+          "name": "complexFunction",
+          "signature": "func complexFunction(number: Int)  -> String"
+        }
+      ],
+      "summary": {
+        "averageCognitiveComplexity": 2.5,
+        "averageCyclomaticComplexity": 2,
+        "maxCognitiveComplexity": 5,
+        "maxCyclomaticComplexity": 3,
+        "totalCognitiveComplexity": 5,
+        "totalCyclomaticComplexity": 4,
+        "totalFunctions": 2
+      }
+    },
+    {
+      "filePath": "/Users/fumiyatanaka/Work/Apps/swift-complexity/Tests/SwiftComplexityCoreTests/Fixtures/issue6_nested_else_if.swift",
+      "functions": [
+        {
+          "cognitiveComplexity": 46,
+          "cyclomaticComplexity": 14,
+          "location": {
+            "column": 1,
+            "line": 6
+          },
+          "name": "processData",
+          "signature": "func processData(data: [String: Any])  -> String"
+        }
+      ],
+      "summary": {
+        "averageCognitiveComplexity": 46,
+        "averageCyclomaticComplexity": 14,
+        "maxCognitiveComplexity": 46,
+        "maxCyclomaticComplexity": 14,
+        "totalCognitiveComplexity": 46,
+        "totalCyclomaticComplexity": 14,
+        "totalFunctions": 1
+      }
+    },
+    {
+      "filePath": "/Users/fumiyatanaka/Work/Apps/swift-complexity/Tests/SwiftComplexityCoreTests/Fixtures/nested_conditions.swift",
+      "functions": [
+        {
+          "cognitiveComplexity": 5,
+          "cyclomaticComplexity": 3,
+          "location": {
+            "column": 1,
+            "line": 5
+          },
+          "name": "complexFunction",
+          "signature": "func complexFunction(a: Int, b: Int)"
+        }
+      ],
+      "summary": {
+        "averageCognitiveComplexity": 5,
+        "averageCyclomaticComplexity": 3,
+        "maxCognitiveComplexity": 5,
+        "maxCyclomaticComplexity": 3,
+        "totalCognitiveComplexity": 5,
+        "totalCyclomaticComplexity": 3,
+        "totalFunctions": 1
+      }
+    },
+    {
+      "filePath": "/Users/fumiyatanaka/Work/Apps/swift-complexity/Tests/SwiftComplexityCoreTests/Fixtures/protocol_decl.swift",
+      "functions": [],
+      "summary": {
+        "averageCognitiveComplexity": 0,
+        "averageCyclomaticComplexity": 0,
+        "maxCognitiveComplexity": 0,
+        "maxCyclomaticComplexity": 0,
+        "totalCognitiveComplexity": 0,
+        "totalCyclomaticComplexity": 0,
+        "totalFunctions": 0
+      }
+    },
+    {
+      "filePath": "/Users/fumiyatanaka/Work/Apps/swift-complexity/Tests/SwiftComplexityCoreTests/Fixtures/protocol_extension_decl.swift",
+      "functions": [
+        {
+          "cognitiveComplexity": 0,
+          "cyclomaticComplexity": 1,
+          "enclosingTypeName": "P",
+          "location": {
+            "column": 5,
+            "line": 9
+          },
+          "name": "foo",
+          "signature": "func foo()"
+        }
+      ],
+      "summary": {
+        "averageCognitiveComplexity": 0,
+        "averageCyclomaticComplexity": 1,
+        "maxCognitiveComplexity": 0,
+        "maxCyclomaticComplexity": 1,
+        "totalCognitiveComplexity": 0,
+        "totalCyclomaticComplexity": 1,
+        "totalFunctions": 1
+      }
+    },
+    {
+      "filePath": "/Users/fumiyatanaka/Work/Apps/swift-complexity/Tests/SwiftComplexityCoreTests/Fixtures/simple_function.swift",
+      "functions": [
+        {
+          "cognitiveComplexity": 0,
+          "cyclomaticComplexity": 1,
+          "location": {
+            "column": 1,
+            "line": 5
+          },
+          "name": "simpleFunction",
+          "signature": "func simpleFunction()"
+        }
+      ],
+      "summary": {
+        "averageCognitiveComplexity": 0,
+        "averageCyclomaticComplexity": 1,
+        "maxCognitiveComplexity": 0,
+        "maxCyclomaticComplexity": 1,
+        "totalCognitiveComplexity": 0,
+        "totalCyclomaticComplexity": 1,
+        "totalFunctions": 1
+      }
+    },
+    {
+      "filePath": "/Users/fumiyatanaka/Work/Apps/swift-complexity/Tests/SwiftComplexityCoreTests/Fixtures/single_function.swift",
+      "functions": [
+        {
+          "cognitiveComplexity": 0,
+          "cyclomaticComplexity": 1,
+          "location": {
+            "column": 1,
+            "line": 6
+          },
+          "name": "testFunction",
+          "signature": "func testFunction(param: String)  -> Int"
+        }
+      ],
+      "summary": {
+        "averageCognitiveComplexity": 0,
+        "averageCyclomaticComplexity": 1,
+        "maxCognitiveComplexity": 0,
+        "maxCyclomaticComplexity": 1,
+        "totalCognitiveComplexity": 0,
+        "totalCyclomaticComplexity": 1,
+        "totalFunctions": 1
+      }
+    },
+    {
+      "filePath": "/Users/fumiyatanaka/Work/Apps/swift-complexity/Tests/SwiftComplexityCoreTests/Fixtures/suppressed_functions.swift",
+      "functions": [
+        {
+          "cognitiveComplexity": 2,
+          "cyclomaticComplexity": 3,
+          "location": {
+            "column": 1,
+            "line": 6
+          },
+          "name": "fullySuppressed",
+          "signature": "func fullySuppressed(a: Int, b: Int)",
+          "suppressedMetrics": [
+            "cognitive",
+            "cyclomatic"
+          ]
+        },
+        {
+          "cognitiveComplexity": 2,
+          "cyclomaticComplexity": 3,
+          "location": {
+            "column": 1,
+            "line": 16
+          },
+          "name": "cyclomaticOnlySuppressed",
+          "signature": "func cyclomaticOnlySuppressed(a: Int, b: Int)",
+          "suppressedMetrics": [
+            "cyclomatic"
+          ]
+        },
+        {
+          "cognitiveComplexity": 2,
+          "cyclomaticComplexity": 3,
+          "location": {
+            "column": 1,
+            "line": 28
+          },
+          "name": "cognitiveOnlySuppressed",
+          "signature": "func cognitiveOnlySuppressed(a: Int, b: Int)",
+          "suppressedMetrics": [
+            "cognitive"
+          ]
+        },
+        {
+          "cognitiveComplexity": 2,
+          "cyclomaticComplexity": 3,
+          "location": {
+            "column": 1,
+            "line": 38
+          },
+          "name": "notSuppressed",
+          "signature": "func notSuppressed(a: Int, b: Int)"
+        },
+        {
+          "cognitiveComplexity": 2,
+          "cyclomaticComplexity": 3,
+          "location": {
+            "column": 1,
+            "line": 50
+          },
+          "name": "typoedMetricNotSuppressed",
+          "signature": "func typoedMetricNotSuppressed(a: Int, b: Int)"
+        },
+        {
+          "cognitiveComplexity": 3,
+          "cyclomaticComplexity": 3,
+          "enclosingTypeName": "SuppressedComputedProperty",
+          "location": {
+            "column": 9,
+            "line": 61
+          },
+          "name": "isValid",
+          "signature": "var isValid : Bool",
+          "suppressedMetrics": [
+            "cognitive",
+            "cyclomatic"
+          ]
+        }
+      ],
+      "summary": {
+        "averageCognitiveComplexity": 2.1666666666666665,
+        "averageCyclomaticComplexity": 3,
+        "maxCognitiveComplexity": 3,
+        "maxCyclomaticComplexity": 3,
+        "totalCognitiveComplexity": 13,
+        "totalCyclomaticComplexity": 18,
+        "totalFunctions": 6
+      }
+    },
+    {
+      "filePath": "/Users/fumiyatanaka/Work/Apps/swift-complexity/Tests/SwiftComplexityCoreTests/Fixtures/suppressed_types.swift",
+      "functions": [
+        {
+          "cognitiveComplexity": 0,
+          "cyclomaticComplexity": 1,
+          "enclosingTypeName": "BareSuppressedClass",
+          "location": {
+            "column": 5,
+            "line": 9
+          },
+          "name": "useA",
+          "signature": "func useA()"
+        },
+        {
+          "cognitiveComplexity": 0,
+          "cyclomaticComplexity": 1,
+          "enclosingTypeName": "BareSuppressedClass",
+          "location": {
+            "column": 5,
+            "line": 10
+          },
+          "name": "useB",
+          "signature": "func useB()"
+        },
+        {
+          "cognitiveComplexity": 0,
+          "cyclomaticComplexity": 1,
+          "enclosingTypeName": "Lcom4SuppressedStruct",
+          "location": {
+            "column": 5,
+            "line": 17
+          },
+          "name": "useA",
+          "signature": "func useA()  -> Int"
+        },
+        {
+          "cognitiveComplexity": 0,
+          "cyclomaticComplexity": 1,
+          "enclosingTypeName": "Lcom4SuppressedStruct",
+          "location": {
+            "column": 5,
+            "line": 18
+          },
+          "name": "useB",
+          "signature": "func useB()  -> Int"
+        },
+        {
+          "cognitiveComplexity": 0,
+          "cyclomaticComplexity": 1,
+          "enclosingTypeName": "NotSuppressedActor",
+          "location": {
+            "column": 5,
+            "line": 25
+          },
+          "name": "useA",
+          "signature": "func useA()"
+        },
+        {
+          "cognitiveComplexity": 0,
+          "cyclomaticComplexity": 1,
+          "enclosingTypeName": "NotSuppressedActor",
+          "location": {
+            "column": 5,
+            "line": 26
+          },
+          "name": "useB",
+          "signature": "func useB()"
+        },
+        {
+          "cognitiveComplexity": 0,
+          "cyclomaticComplexity": 1,
+          "enclosingTypeName": "WrongLevelMetricClass",
+          "location": {
+            "column": 5,
+            "line": 34
+          },
+          "name": "useA",
+          "signature": "func useA()"
+        },
+        {
+          "cognitiveComplexity": 0,
+          "cyclomaticComplexity": 1,
+          "enclosingTypeName": "WrongLevelMetricClass",
+          "location": {
+            "column": 5,
+            "line": 35
+          },
+          "name": "useB",
+          "signature": "func useB()"
+        },
+        {
+          "cognitiveComplexity": 0,
+          "cyclomaticComplexity": 1,
+          "enclosingTypeName": "TypoedMetricClass",
+          "location": {
+            "column": 5,
+            "line": 43
+          },
+          "name": "useA",
+          "signature": "func useA()"
+        },
+        {
+          "cognitiveComplexity": 0,
+          "cyclomaticComplexity": 1,
+          "enclosingTypeName": "TypoedMetricClass",
+          "location": {
+            "column": 5,
+            "line": 44
+          },
+          "name": "useB",
+          "signature": "func useB()"
+        }
+      ],
+      "summary": {
+        "averageCognitiveComplexity": 0,
+        "averageCyclomaticComplexity": 1,
+        "maxCognitiveComplexity": 0,
+        "maxCyclomaticComplexity": 1,
+        "totalCognitiveComplexity": 0,
+        "totalCyclomaticComplexity": 10,
+        "totalFunctions": 10
+      }
+    },
+    {
+      "filePath": "/Users/fumiyatanaka/Work/Apps/swift-complexity/Tests/SwiftComplexityCoreTests/Fixtures/very_complex_function.swift",
+      "functions": [
+        {
+          "cognitiveComplexity": 14,
+          "cyclomaticComplexity": 5,
+          "location": {
+            "column": 1,
+            "line": 5
+          },
+          "name": "veryComplexFunction",
+          "signature": "func veryComplexFunction(a: Int, b: Int, c: Int, d: Int)  -> String"
+        }
+      ],
+      "summary": {
+        "averageCognitiveComplexity": 14,
+        "averageCyclomaticComplexity": 5,
+        "maxCognitiveComplexity": 14,
+        "maxCyclomaticComplexity": 5,
+        "totalCognitiveComplexity": 14,
+        "totalCyclomaticComplexity": 5,
+        "totalFunctions": 1
+      }
+    }
+  ]
+}

--- a/Tests/SwiftComplexityCoreTests/Fixtures/golden/complexity_plain.json
+++ b/Tests/SwiftComplexityCoreTests/Fixtures/golden/complexity_plain.json
@@ -1,7 +1,7 @@
 {
   "files": [
     {
-      "filePath": "/Users/fumiyatanaka/Work/Apps/swift-complexity/Tests/SwiftComplexityCoreTests/Fixtures/class_with_methods.swift",
+      "filePath": "Tests/SwiftComplexityCoreTests/Fixtures/class_with_methods.swift",
       "functions": [
         {
           "cognitiveComplexity": 0,
@@ -48,7 +48,7 @@
       }
     },
     {
-      "filePath": "/Users/fumiyatanaka/Work/Apps/swift-complexity/Tests/SwiftComplexityCoreTests/Fixtures/cognitive_nested_conditions.swift",
+      "filePath": "Tests/SwiftComplexityCoreTests/Fixtures/cognitive_nested_conditions.swift",
       "functions": [
         {
           "cognitiveComplexity": 3,
@@ -72,7 +72,7 @@
       }
     },
     {
-      "filePath": "/Users/fumiyatanaka/Work/Apps/swift-complexity/Tests/SwiftComplexityCoreTests/Fixtures/computed_property.swift",
+      "filePath": "Tests/SwiftComplexityCoreTests/Fixtures/computed_property.swift",
       "functions": [
         {
           "cognitiveComplexity": 3,
@@ -130,7 +130,7 @@
       }
     },
     {
-      "filePath": "/Users/fumiyatanaka/Work/Apps/swift-complexity/Tests/SwiftComplexityCoreTests/Fixtures/else_if_chain.swift",
+      "filePath": "Tests/SwiftComplexityCoreTests/Fixtures/else_if_chain.swift",
       "functions": [
         {
           "cognitiveComplexity": 3,
@@ -154,7 +154,7 @@
       }
     },
     {
-      "filePath": "/Users/fumiyatanaka/Work/Apps/swift-complexity/Tests/SwiftComplexityCoreTests/Fixtures/function_with_if.swift",
+      "filePath": "Tests/SwiftComplexityCoreTests/Fixtures/function_with_if.swift",
       "functions": [
         {
           "cognitiveComplexity": 1,
@@ -178,7 +178,7 @@
       }
     },
     {
-      "filePath": "/Users/fumiyatanaka/Work/Apps/swift-complexity/Tests/SwiftComplexityCoreTests/Fixtures/integration_test_sample.swift",
+      "filePath": "Tests/SwiftComplexityCoreTests/Fixtures/integration_test_sample.swift",
       "functions": [
         {
           "cognitiveComplexity": 0,
@@ -212,7 +212,7 @@
       }
     },
     {
-      "filePath": "/Users/fumiyatanaka/Work/Apps/swift-complexity/Tests/SwiftComplexityCoreTests/Fixtures/issue6_nested_else_if.swift",
+      "filePath": "Tests/SwiftComplexityCoreTests/Fixtures/issue6_nested_else_if.swift",
       "functions": [
         {
           "cognitiveComplexity": 46,
@@ -236,7 +236,7 @@
       }
     },
     {
-      "filePath": "/Users/fumiyatanaka/Work/Apps/swift-complexity/Tests/SwiftComplexityCoreTests/Fixtures/nested_conditions.swift",
+      "filePath": "Tests/SwiftComplexityCoreTests/Fixtures/nested_conditions.swift",
       "functions": [
         {
           "cognitiveComplexity": 5,
@@ -260,7 +260,7 @@
       }
     },
     {
-      "filePath": "/Users/fumiyatanaka/Work/Apps/swift-complexity/Tests/SwiftComplexityCoreTests/Fixtures/protocol_decl.swift",
+      "filePath": "Tests/SwiftComplexityCoreTests/Fixtures/protocol_decl.swift",
       "functions": [],
       "summary": {
         "averageCognitiveComplexity": 0,
@@ -273,7 +273,7 @@
       }
     },
     {
-      "filePath": "/Users/fumiyatanaka/Work/Apps/swift-complexity/Tests/SwiftComplexityCoreTests/Fixtures/protocol_extension_decl.swift",
+      "filePath": "Tests/SwiftComplexityCoreTests/Fixtures/protocol_extension_decl.swift",
       "functions": [
         {
           "cognitiveComplexity": 0,
@@ -298,7 +298,7 @@
       }
     },
     {
-      "filePath": "/Users/fumiyatanaka/Work/Apps/swift-complexity/Tests/SwiftComplexityCoreTests/Fixtures/simple_function.swift",
+      "filePath": "Tests/SwiftComplexityCoreTests/Fixtures/simple_function.swift",
       "functions": [
         {
           "cognitiveComplexity": 0,
@@ -322,7 +322,7 @@
       }
     },
     {
-      "filePath": "/Users/fumiyatanaka/Work/Apps/swift-complexity/Tests/SwiftComplexityCoreTests/Fixtures/single_function.swift",
+      "filePath": "Tests/SwiftComplexityCoreTests/Fixtures/single_function.swift",
       "functions": [
         {
           "cognitiveComplexity": 0,
@@ -346,7 +346,7 @@
       }
     },
     {
-      "filePath": "/Users/fumiyatanaka/Work/Apps/swift-complexity/Tests/SwiftComplexityCoreTests/Fixtures/suppressed_functions.swift",
+      "filePath": "Tests/SwiftComplexityCoreTests/Fixtures/suppressed_functions.swift",
       "functions": [
         {
           "cognitiveComplexity": 2,
@@ -435,7 +435,7 @@
       }
     },
     {
-      "filePath": "/Users/fumiyatanaka/Work/Apps/swift-complexity/Tests/SwiftComplexityCoreTests/Fixtures/suppressed_types.swift",
+      "filePath": "Tests/SwiftComplexityCoreTests/Fixtures/suppressed_types.swift",
       "functions": [
         {
           "cognitiveComplexity": 0,
@@ -559,7 +559,7 @@
       }
     },
     {
-      "filePath": "/Users/fumiyatanaka/Work/Apps/swift-complexity/Tests/SwiftComplexityCoreTests/Fixtures/very_complex_function.swift",
+      "filePath": "Tests/SwiftComplexityCoreTests/Fixtures/very_complex_function.swift",
       "functions": [
         {
           "cognitiveComplexity": 14,

--- a/Tests/SwiftComplexityCoreTests/GoldenCompatibilityTests.swift
+++ b/Tests/SwiftComplexityCoreTests/GoldenCompatibilityTests.swift
@@ -101,7 +101,8 @@ struct GoldenCompatibilityTests {
         // LCOM4 resolves through the deterministic syntax fallback — exactly
         // how the golden was generated. `swift test` always builds first, so
         // the debug index store is present in every supported flow.
-        let indexStore = repoRoot
+        let indexStore =
+            repoRoot
             .appendingPathComponent(".build")
             .appendingPathComponent("debug")
             .appendingPathComponent("index")

--- a/Tests/SwiftComplexityCoreTests/GoldenCompatibilityTests.swift
+++ b/Tests/SwiftComplexityCoreTests/GoldenCompatibilityTests.swift
@@ -1,0 +1,174 @@
+import Foundation
+import Testing
+
+@testable import SwiftComplexityCore
+
+/// Regression gate for the coupling-metrics feature: analysis WITHOUT
+/// `--coupling` must keep producing exactly the output of the release the
+/// goldens were generated from (see `Fixtures/golden/README.md`).
+@Suite("Golden output compatibility", .tags(.integration))
+struct GoldenCompatibilityTests {
+
+    /// The fixture files frozen into the goldens. Pinned by name so that
+    /// fixtures added for later features cannot silently change this test's
+    /// input; regenerating the goldens is the only way to extend the list.
+    private static let goldenFixtureNames = [
+        "class_with_methods", "cognitive_nested_conditions", "computed_property",
+        "else_if_chain", "function_with_if", "integration_test_sample",
+        "issue6_nested_else_if", "nested_conditions", "protocol_decl",
+        "protocol_extension_decl", "simple_function", "single_function",
+        "suppressed_functions", "suppressed_types", "very_complex_function",
+    ]
+
+    /// Repository root, derived from this source file's location so the test
+    /// analyzes the repo-checkout fixtures with paths matching the goldens.
+    private var repoRoot: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // SwiftComplexityCoreTests
+            .deletingLastPathComponent()  // Tests
+            .deletingLastPathComponent()  // repo root
+    }
+
+    private var fixturesDirectory: URL {
+        repoRoot
+            .appendingPathComponent("Tests")
+            .appendingPathComponent("SwiftComplexityCoreTests")
+            .appendingPathComponent("Fixtures")
+    }
+
+    private func fixturePaths() -> [String] {
+        Self.goldenFixtureNames.map {
+            fixturesDirectory.appendingPathComponent("\($0).swift").path
+        }
+    }
+
+    /// Canonical form shared with the goldens: repo-relative paths, then a
+    /// JSON object tree whose `suppressedMetrics` arrays are sorted (Set
+    /// encoding order is nondeterministic). Object key order is irrelevant to
+    /// the NSDictionary comparison used by the tests.
+    private func canonicalize(_ json: String) throws -> NSDictionary {
+        let relativized = json.replacingOccurrences(of: repoRoot.path + "/", with: "")
+        let object = try JSONSerialization.jsonObject(with: Data(relativized.utf8))
+        let dictionary = try #require(object as? [String: Any])
+        return try #require(normalized(dictionary) as? NSDictionary)
+    }
+
+    private func normalized(_ value: Any) -> Any {
+        if let dictionary = value as? [String: Any] {
+            var result: [String: Any] = [:]
+            for (key, element) in dictionary {
+                if key == "suppressedMetrics", let metrics = element as? [String] {
+                    result[key] = metrics.sorted()
+                } else {
+                    result[key] = normalized(element)
+                }
+            }
+            return result
+        }
+        if let array = value as? [Any] {
+            return array.map(normalized)
+        }
+        return value
+    }
+
+    private func loadGolden(_ name: String) throws -> NSDictionary {
+        let url = try #require(
+            Bundle.module.url(
+                forResource: name, withExtension: "json", subdirectory: "Fixtures/golden"),
+            "golden fixture \(name).json must be bundled")
+        let json = try String(contentsOf: url, encoding: .utf8)
+        let object = try JSONSerialization.jsonObject(with: Data(json.utf8))
+        let dictionary = try #require(object as? [String: Any])
+        return try #require(normalized(dictionary) as? NSDictionary)
+    }
+
+    @Test("Plain JSON output matches the pre-coupling golden")
+    func plainOutputMatchesGolden() async throws {
+        let analyzer = try ComplexityAnalyzer()
+        let processor = FileProcessor(analyzer: analyzer)
+        let results = try await processor.processFiles(
+            at: fixturePaths(), options: ProcessingOptions())
+
+        let output = OutputFormatter().format(
+            results: results, format: .json, options: OutputOptions())
+
+        #expect(try canonicalize(output) == loadGolden("complexity_plain"))
+    }
+
+    @Test("LCOM4 JSON output matches the pre-coupling golden")
+    func lcom4OutputMatchesGolden() async throws {
+        // The store only needs to exist: fixture types are not indexed, so
+        // LCOM4 resolves through the deterministic syntax fallback — exactly
+        // how the golden was generated. `swift test` always builds first, so
+        // the debug index store is present in every supported flow.
+        let indexStore = repoRoot
+            .appendingPathComponent(".build")
+            .appendingPathComponent("debug")
+            .appendingPathComponent("index")
+            .appendingPathComponent("store")
+        try #require(
+            FileManager.default.fileExists(atPath: indexStore.path),
+            "debug index store missing — run via `swift test` (not a bare Xcode test action)")
+
+        let analyzer = try ComplexityAnalyzer(indexStorePath: indexStore)
+        let processor = FileProcessor(analyzer: analyzer)
+        let results = try await processor.processFiles(
+            at: fixturePaths(), options: ProcessingOptions())
+
+        let output = OutputFormatter().format(
+            results: results, format: .json, options: OutputOptions(showLCOM4: true))
+
+        #expect(try canonicalize(output) == loadGolden("complexity_lcom4"))
+    }
+}
+
+/// Behavior of the coupling fields themselves (additive schema).
+@Suite("ComplexityResult coupling fields", .tags(.unit, .models))
+struct ComplexityResultCouplingTests {
+
+    private func sampleResult() -> ComplexityResult {
+        ComplexityResult(
+            filePath: "A.swift",
+            functions: [
+                FunctionComplexity(
+                    name: "f", signature: "func f()",
+                    cyclomaticComplexity: 2, cognitiveComplexity: 3,
+                    location: SourceLocation(line: 1, column: 1))
+            ])
+    }
+
+    @Test("attaching(typeCouplings:) preserves inputs and recomputes summaries deterministically")
+    func attachingIsDeterministic() throws {
+        let base = sampleResult()
+        let coupling = TypeCoupling(
+            name: "A", kind: .struct, fanIn: 2, fanOut: 1,
+            location: SourceLocation(line: 1, column: 1))
+
+        let attached = base.attaching(typeCouplings: [coupling])
+
+        #expect(attached.filePath == base.filePath)
+        #expect(attached.functions == base.functions)
+        #expect(attached.classCohesions == base.classCohesions)
+        // Summary is rebuilt from the same functions, so it must be identical.
+        #expect(attached.summary.totalFunctions == base.summary.totalFunctions)
+        #expect(
+            attached.summary.averageCyclomaticComplexity
+                == base.summary.averageCyclomaticComplexity)
+        #expect(attached.typeCouplings == [coupling])
+        #expect(attached.couplingSummary?.totalTypes == 1)
+    }
+
+    @Test("Coupling keys are absent from JSON until coupling analysis runs")
+    func couplingKeysAbsentByDefault() throws {
+        let json = String(
+            decoding: try JSONEncoder().encode(sampleResult()), as: UTF8.self)
+        #expect(!json.contains("typeCouplings"))
+        #expect(!json.contains("couplingSummary"))
+
+        let attached = sampleResult().attaching(typeCouplings: [])
+        let attachedJSON = String(
+            decoding: try JSONEncoder().encode(attached), as: UTF8.self)
+        #expect(attachedJSON.contains("typeCouplings"))
+        #expect(attachedJSON.contains("couplingSummary"))
+    }
+}

--- a/Tests/SwiftComplexityCoreTests/GoldenCompatibilityTests.swift
+++ b/Tests/SwiftComplexityCoreTests/GoldenCompatibilityTests.swift
@@ -89,6 +89,52 @@ import Testing
             return try #require(normalized(dictionary) as? NSDictionary)
         }
 
+        /// Reports the exact key paths that differ, because a bare
+        /// NSDictionary inequality is undebuggable from CI logs.
+        private func structuralDiff(
+            _ lhs: Any, _ rhs: Any, path: String = "root", into diffs: inout [String]
+        ) {
+            guard diffs.count < 10 else { return }
+            if let l = lhs as? [String: Any], let r = rhs as? [String: Any] {
+                for key in Set(l.keys).union(r.keys).sorted() {
+                    switch (l[key], r[key]) {
+                    case (nil, let value?):
+                        diffs.append("\(path).\(key): missing in output, golden=\(value)")
+                    case (let value?, nil):
+                        diffs.append("\(path).\(key): output=\(value), missing in golden")
+                    case (let lv?, let rv?):
+                        structuralDiff(lv, rv, path: "\(path).\(key)", into: &diffs)
+                    case (nil, nil):
+                        break
+                    }
+                }
+                return
+            }
+            if let l = lhs as? [Any], let r = rhs as? [Any] {
+                if l.count != r.count {
+                    diffs.append("\(path): array count output=\(l.count) golden=\(r.count)")
+                    return
+                }
+                for (offset, pair) in zip(l, r).enumerated() {
+                    structuralDiff(pair.0, pair.1, path: "\(path)[\(offset)]", into: &diffs)
+                }
+                return
+            }
+            if !(lhs as AnyObject).isEqual(rhs as AnyObject) {
+                diffs.append("\(path): output=\(lhs) golden=\(rhs)")
+            }
+        }
+
+        private func expectMatchesGolden(_ output: String, _ goldenName: String) throws {
+            let canonical = try canonicalize(output)
+            let golden = try loadGolden(goldenName)
+            if canonical != golden {
+                var diffs: [String] = []
+                structuralDiff(canonical, golden, into: &diffs)
+                Issue.record("golden mismatch (\(goldenName)): \(diffs.joined(separator: " | "))")
+            }
+        }
+
         @Test("Plain JSON output matches the pre-coupling golden")
         func plainOutputMatchesGolden() async throws {
             let analyzer = try ComplexityAnalyzer()
@@ -99,7 +145,7 @@ import Testing
             let output = OutputFormatter().format(
                 results: results, format: .json, options: OutputOptions())
 
-            #expect(try canonicalize(output) == loadGolden("complexity_plain"))
+            try expectMatchesGolden(output, "complexity_plain")
         }
 
         @Test("LCOM4 JSON output matches the pre-coupling golden")
@@ -126,7 +172,7 @@ import Testing
             let output = OutputFormatter().format(
                 results: results, format: .json, options: OutputOptions(showLCOM4: true))
 
-            #expect(try canonicalize(output) == loadGolden("complexity_lcom4"))
+            try expectMatchesGolden(output, "complexity_lcom4")
         }
     }
 

--- a/Tests/SwiftComplexityCoreTests/GoldenCompatibilityTests.swift
+++ b/Tests/SwiftComplexityCoreTests/GoldenCompatibilityTests.swift
@@ -53,9 +53,12 @@ import Testing
         /// JSON object tree whose `suppressedMetrics` arrays are sorted (Set
         /// encoding order is nondeterministic). Object key order is irrelevant to
         /// the NSDictionary comparison used by the tests.
+        ///
+        /// Relativization happens on parsed values, never on the raw JSON
+        /// string: JSONEncoder escapes slashes ("\/"), so a textual search for
+        /// the repo root silently matches nothing.
         private func canonicalize(_ json: String) throws -> NSDictionary {
-            let relativized = json.replacingOccurrences(of: repoRoot.path + "/", with: "")
-            let object = try JSONSerialization.jsonObject(with: Data(relativized.utf8))
+            let object = try JSONSerialization.jsonObject(with: Data(json.utf8))
             let dictionary = try #require(object as? [String: Any])
             return try #require(normalized(dictionary) as? NSDictionary)
         }
@@ -66,6 +69,10 @@ import Testing
                 for (key, element) in dictionary {
                     if key == "suppressedMetrics", let metrics = element as? [String] {
                         result[key] = metrics.sorted()
+                    } else if key == "filePath", let path = element as? String,
+                        path.hasPrefix(repoRoot.path + "/")
+                    {
+                        result[key] = String(path.dropFirst(repoRoot.path.count + 1))
                     } else {
                         result[key] = normalized(element)
                     }

--- a/Tests/SwiftComplexityCoreTests/GoldenCompatibilityTests.swift
+++ b/Tests/SwiftComplexityCoreTests/GoldenCompatibilityTests.swift
@@ -3,125 +3,134 @@ import Testing
 
 @testable import SwiftComplexityCore
 
-/// Regression gate for the coupling-metrics feature: analysis WITHOUT
-/// `--coupling` must keep producing exactly the output of the release the
-/// goldens were generated from (see `Fixtures/golden/README.md`).
-@Suite("Golden output compatibility", .tags(.integration))
-struct GoldenCompatibilityTests {
+// macOS-only on purpose: the goldens are generated on macOS, and this gate
+// measures regressions introduced by code changes, not platform variance in
+// Foundation's JSON encoding/parsing (which made the comparison fail on
+// Linux). Linux output is exercised by the CI integration steps instead,
+// and Linux LCOM4 would additionally need a resolved --toolchain-path.
+#if os(macOS)
 
-    /// The fixture files frozen into the goldens. Pinned by name so that
-    /// fixtures added for later features cannot silently change this test's
-    /// input; regenerating the goldens is the only way to extend the list.
-    private static let goldenFixtureNames = [
-        "class_with_methods", "cognitive_nested_conditions", "computed_property",
-        "else_if_chain", "function_with_if", "integration_test_sample",
-        "issue6_nested_else_if", "nested_conditions", "protocol_decl",
-        "protocol_extension_decl", "simple_function", "single_function",
-        "suppressed_functions", "suppressed_types", "very_complex_function",
-    ]
+    /// Regression gate for the coupling-metrics feature: analysis WITHOUT
+    /// `--coupling` must keep producing exactly the output of the release the
+    /// goldens were generated from (see `Fixtures/golden/README.md`).
+    @Suite("Golden output compatibility", .tags(.integration))
+    struct GoldenCompatibilityTests {
 
-    /// Repository root, derived from this source file's location so the test
-    /// analyzes the repo-checkout fixtures with paths matching the goldens.
-    private var repoRoot: URL {
-        URL(fileURLWithPath: #filePath)
-            .deletingLastPathComponent()  // SwiftComplexityCoreTests
-            .deletingLastPathComponent()  // Tests
-            .deletingLastPathComponent()  // repo root
-    }
+        /// The fixture files frozen into the goldens. Pinned by name so that
+        /// fixtures added for later features cannot silently change this test's
+        /// input; regenerating the goldens is the only way to extend the list.
+        private static let goldenFixtureNames = [
+            "class_with_methods", "cognitive_nested_conditions", "computed_property",
+            "else_if_chain", "function_with_if", "integration_test_sample",
+            "issue6_nested_else_if", "nested_conditions", "protocol_decl",
+            "protocol_extension_decl", "simple_function", "single_function",
+            "suppressed_functions", "suppressed_types", "very_complex_function",
+        ]
 
-    private var fixturesDirectory: URL {
-        repoRoot
-            .appendingPathComponent("Tests")
-            .appendingPathComponent("SwiftComplexityCoreTests")
-            .appendingPathComponent("Fixtures")
-    }
-
-    private func fixturePaths() -> [String] {
-        Self.goldenFixtureNames.map {
-            fixturesDirectory.appendingPathComponent("\($0).swift").path
+        /// Repository root, derived from this source file's location so the test
+        /// analyzes the repo-checkout fixtures with paths matching the goldens.
+        private var repoRoot: URL {
+            URL(fileURLWithPath: #filePath)
+                .deletingLastPathComponent()  // SwiftComplexityCoreTests
+                .deletingLastPathComponent()  // Tests
+                .deletingLastPathComponent()  // repo root
         }
-    }
 
-    /// Canonical form shared with the goldens: repo-relative paths, then a
-    /// JSON object tree whose `suppressedMetrics` arrays are sorted (Set
-    /// encoding order is nondeterministic). Object key order is irrelevant to
-    /// the NSDictionary comparison used by the tests.
-    private func canonicalize(_ json: String) throws -> NSDictionary {
-        let relativized = json.replacingOccurrences(of: repoRoot.path + "/", with: "")
-        let object = try JSONSerialization.jsonObject(with: Data(relativized.utf8))
-        let dictionary = try #require(object as? [String: Any])
-        return try #require(normalized(dictionary) as? NSDictionary)
-    }
-
-    private func normalized(_ value: Any) -> Any {
-        if let dictionary = value as? [String: Any] {
-            var result: [String: Any] = [:]
-            for (key, element) in dictionary {
-                if key == "suppressedMetrics", let metrics = element as? [String] {
-                    result[key] = metrics.sorted()
-                } else {
-                    result[key] = normalized(element)
-                }
-            }
-            return result
-        }
-        if let array = value as? [Any] {
-            return array.map(normalized)
-        }
-        return value
-    }
-
-    private func loadGolden(_ name: String) throws -> NSDictionary {
-        let url = try #require(
-            Bundle.module.url(
-                forResource: name, withExtension: "json", subdirectory: "Fixtures/golden"),
-            "golden fixture \(name).json must be bundled")
-        let json = try String(contentsOf: url, encoding: .utf8)
-        let object = try JSONSerialization.jsonObject(with: Data(json.utf8))
-        let dictionary = try #require(object as? [String: Any])
-        return try #require(normalized(dictionary) as? NSDictionary)
-    }
-
-    @Test("Plain JSON output matches the pre-coupling golden")
-    func plainOutputMatchesGolden() async throws {
-        let analyzer = try ComplexityAnalyzer()
-        let processor = FileProcessor(analyzer: analyzer)
-        let results = try await processor.processFiles(
-            at: fixturePaths(), options: ProcessingOptions())
-
-        let output = OutputFormatter().format(
-            results: results, format: .json, options: OutputOptions())
-
-        #expect(try canonicalize(output) == loadGolden("complexity_plain"))
-    }
-
-    @Test("LCOM4 JSON output matches the pre-coupling golden")
-    func lcom4OutputMatchesGolden() async throws {
-        // The store only needs to exist: fixture types are not indexed, so
-        // LCOM4 resolves through the deterministic syntax fallback — exactly
-        // how the golden was generated. `swift test` always builds first, so
-        // the debug index store is present in every supported flow.
-        let indexStore =
+        private var fixturesDirectory: URL {
             repoRoot
-            .appendingPathComponent(".build")
-            .appendingPathComponent("debug")
-            .appendingPathComponent("index")
-            .appendingPathComponent("store")
-        try #require(
-            FileManager.default.fileExists(atPath: indexStore.path),
-            "debug index store missing — run via `swift test` (not a bare Xcode test action)")
+                .appendingPathComponent("Tests")
+                .appendingPathComponent("SwiftComplexityCoreTests")
+                .appendingPathComponent("Fixtures")
+        }
 
-        let analyzer = try ComplexityAnalyzer(indexStorePath: indexStore)
-        let processor = FileProcessor(analyzer: analyzer)
-        let results = try await processor.processFiles(
-            at: fixturePaths(), options: ProcessingOptions())
+        private func fixturePaths() -> [String] {
+            Self.goldenFixtureNames.map {
+                fixturesDirectory.appendingPathComponent("\($0).swift").path
+            }
+        }
 
-        let output = OutputFormatter().format(
-            results: results, format: .json, options: OutputOptions(showLCOM4: true))
+        /// Canonical form shared with the goldens: repo-relative paths, then a
+        /// JSON object tree whose `suppressedMetrics` arrays are sorted (Set
+        /// encoding order is nondeterministic). Object key order is irrelevant to
+        /// the NSDictionary comparison used by the tests.
+        private func canonicalize(_ json: String) throws -> NSDictionary {
+            let relativized = json.replacingOccurrences(of: repoRoot.path + "/", with: "")
+            let object = try JSONSerialization.jsonObject(with: Data(relativized.utf8))
+            let dictionary = try #require(object as? [String: Any])
+            return try #require(normalized(dictionary) as? NSDictionary)
+        }
 
-        #expect(try canonicalize(output) == loadGolden("complexity_lcom4"))
+        private func normalized(_ value: Any) -> Any {
+            if let dictionary = value as? [String: Any] {
+                var result: [String: Any] = [:]
+                for (key, element) in dictionary {
+                    if key == "suppressedMetrics", let metrics = element as? [String] {
+                        result[key] = metrics.sorted()
+                    } else {
+                        result[key] = normalized(element)
+                    }
+                }
+                return result
+            }
+            if let array = value as? [Any] {
+                return array.map(normalized)
+            }
+            return value
+        }
+
+        private func loadGolden(_ name: String) throws -> NSDictionary {
+            let url = try #require(
+                Bundle.module.url(
+                    forResource: name, withExtension: "json", subdirectory: "Fixtures/golden"),
+                "golden fixture \(name).json must be bundled")
+            let json = try String(contentsOf: url, encoding: .utf8)
+            let object = try JSONSerialization.jsonObject(with: Data(json.utf8))
+            let dictionary = try #require(object as? [String: Any])
+            return try #require(normalized(dictionary) as? NSDictionary)
+        }
+
+        @Test("Plain JSON output matches the pre-coupling golden")
+        func plainOutputMatchesGolden() async throws {
+            let analyzer = try ComplexityAnalyzer()
+            let processor = FileProcessor(analyzer: analyzer)
+            let results = try await processor.processFiles(
+                at: fixturePaths(), options: ProcessingOptions())
+
+            let output = OutputFormatter().format(
+                results: results, format: .json, options: OutputOptions())
+
+            #expect(try canonicalize(output) == loadGolden("complexity_plain"))
+        }
+
+        @Test("LCOM4 JSON output matches the pre-coupling golden")
+        func lcom4OutputMatchesGolden() async throws {
+            // The store only needs to exist: fixture types are not indexed, so
+            // LCOM4 resolves through the deterministic syntax fallback — exactly
+            // how the golden was generated. `swift test` always builds first, so
+            // the debug index store is present in every supported flow.
+            let indexStore =
+                repoRoot
+                .appendingPathComponent(".build")
+                .appendingPathComponent("debug")
+                .appendingPathComponent("index")
+                .appendingPathComponent("store")
+            try #require(
+                FileManager.default.fileExists(atPath: indexStore.path),
+                "debug index store missing — run via `swift test` (not a bare Xcode test action)")
+
+            let analyzer = try ComplexityAnalyzer(indexStorePath: indexStore)
+            let processor = FileProcessor(analyzer: analyzer)
+            let results = try await processor.processFiles(
+                at: fixturePaths(), options: ProcessingOptions())
+
+            let output = OutputFormatter().format(
+                results: results, format: .json, options: OutputOptions(showLCOM4: true))
+
+            #expect(try canonicalize(output) == loadGolden("complexity_lcom4"))
+        }
     }
-}
+
+#endif
 
 /// Behavior of the coupling fields themselves (additive schema).
 @Suite("ComplexityResult coupling fields", .tags(.unit, .models))

--- a/Tests/SwiftComplexityCoreTests/HotspotRankerTests.swift
+++ b/Tests/SwiftComplexityCoreTests/HotspotRankerTests.swift
@@ -54,9 +54,10 @@ struct HotspotRankerTests {
         let hotspots = HotspotRanker.rank(
             results: results, configuration: plainThreshold, fallbackThreshold: 10)
 
-        #expect(hotspots.map(\.function.name) == [
-            "highFanInHighCognitive", "highFanInLowCognitive", "lowFanInHighCognitive",
-        ])
+        #expect(
+            hotspots.map(\.function.name) == [
+                "highFanInHighCognitive", "highFanInLowCognitive", "lowFanInHighCognitive",
+            ])
         #expect(hotspots[0].typeFanIn == 9)
     }
 

--- a/Tests/SwiftComplexityCoreTests/HotspotRankerTests.swift
+++ b/Tests/SwiftComplexityCoreTests/HotspotRankerTests.swift
@@ -1,0 +1,192 @@
+import Foundation
+import Testing
+
+@testable import SwiftComplexityCore
+
+@Suite("Hotspot ranking", .tags(.unit, .calculators))
+struct HotspotRankerTests {
+
+    // MARK: - Builders
+
+    private func function(
+        _ name: String, in typeName: String? = nil,
+        cyclomatic: Int = 1, cognitive: Int = 1,
+        suppressed: Set<SuppressedMetric>? = nil
+    ) -> FunctionComplexity {
+        FunctionComplexity(
+            name: name, signature: "func \(name)()",
+            cyclomaticComplexity: cyclomatic, cognitiveComplexity: cognitive,
+            location: SourceLocation(line: 1, column: 1),
+            enclosingTypeName: typeName,
+            suppressedMetrics: suppressed)
+    }
+
+    private func coupling(_ name: String, fanIn: Int) -> TypeCoupling {
+        TypeCoupling(
+            name: name, kind: .class, fanIn: fanIn, fanOut: 0,
+            location: SourceLocation(line: 1, column: 1))
+    }
+
+    private func result(
+        _ file: String, functions: [FunctionComplexity], couplings: [TypeCoupling] = []
+    ) -> ComplexityResult {
+        ComplexityResult(
+            filePath: file, functions: functions,
+            typeCouplings: couplings.isEmpty ? nil : couplings)
+    }
+
+    private let plainThreshold = ThresholdConfiguration.empty
+
+    // MARK: - Ordering (D3)
+
+    @Test("Violations sort by type fan-in first, then cognitive complexity")
+    func lexicographicOrder() {
+        let results = [
+            result(
+                "A.swift",
+                functions: [
+                    function("lowFanInHighCognitive", in: "Quiet", cyclomatic: 12, cognitive: 30),
+                    function("highFanInLowCognitive", in: "Hub", cyclomatic: 12, cognitive: 11),
+                    function("highFanInHighCognitive", in: "Hub", cyclomatic: 12, cognitive: 25),
+                ],
+                couplings: [coupling("Hub", fanIn: 9), coupling("Quiet", fanIn: 1)])
+        ]
+        let hotspots = HotspotRanker.rank(
+            results: results, configuration: plainThreshold, fallbackThreshold: 10)
+
+        #expect(hotspots.map(\.function.name) == [
+            "highFanInHighCognitive", "highFanInLowCognitive", "lowFanInHighCognitive",
+        ])
+        #expect(hotspots[0].typeFanIn == 9)
+    }
+
+    @Test("Only functions at or above the threshold appear")
+    func thresholdFilter() {
+        let results = [
+            result(
+                "A.swift",
+                functions: [
+                    function("atThreshold", in: "T", cyclomatic: 10, cognitive: 1),
+                    function("belowThreshold", in: "T", cyclomatic: 9, cognitive: 1),
+                ],
+                couplings: [coupling("T", fanIn: 3)])
+        ]
+        let hotspots = HotspotRanker.rank(
+            results: results, configuration: plainThreshold, fallbackThreshold: 10)
+        #expect(hotspots.map(\.function.name) == ["atThreshold"])
+    }
+
+    @Test("The limit caps the ranking")
+    func limitApplies() {
+        let functions = (0..<12).map {
+            function("f\($0)", in: "T", cyclomatic: 11, cognitive: 20 - $0)
+        }
+        let results = [result("A.swift", functions: functions)]
+        let hotspots = HotspotRanker.rank(
+            results: results, configuration: plainThreshold, fallbackThreshold: 10, limit: 10)
+        #expect(hotspots.count == 10)
+        // The two lowest-cognitive entries fall off.
+        #expect(!hotspots.contains { $0.function.name == "f11" })
+    }
+
+    @Test("Per-type threshold rules decide the violation set")
+    func perTypeRules() {
+        let config = ThresholdConfiguration(
+            rules: [ThresholdRule(suffix: "ViewModel", threshold: 5)])
+        let results = [
+            result(
+                "A.swift",
+                functions: [
+                    function("strictlyJudged", in: "HomeViewModel", cyclomatic: 6, cognitive: 1),
+                    function("leniently", in: "HomeService", cyclomatic: 6, cognitive: 1),
+                ])
+        ]
+        // fallback 10: the ViewModel rule (5) flags the first function only.
+        let hotspots = HotspotRanker.rank(
+            results: results, configuration: config, fallbackThreshold: 10)
+        #expect(hotspots.map(\.function.name) == ["strictlyJudged"])
+    }
+
+    @Test("Suppressed functions never rank")
+    func suppressionExcludes() {
+        let results = [
+            result(
+                "A.swift",
+                functions: [
+                    function(
+                        "suppressed", in: "T", cyclomatic: 30, cognitive: 30,
+                        suppressed: [.cyclomatic, .cognitive])
+                ])
+        ]
+        let hotspots = HotspotRanker.rank(
+            results: results, configuration: plainThreshold, fallbackThreshold: 10)
+        #expect(hotspots.isEmpty)
+    }
+
+    // MARK: - Degenerate cases
+
+    @Test("No threshold anywhere means no hotspots")
+    func noThresholdNoHotspots() {
+        let results = [
+            result("A.swift", functions: [function("f", in: "T", cyclomatic: 99, cognitive: 99)])
+        ]
+        let hotspots = HotspotRanker.rank(
+            results: results, configuration: .empty, fallbackThreshold: nil)
+        #expect(hotspots.isEmpty)
+    }
+
+    @Test("Free functions rank with fan-in 0 and sink to the bottom")
+    func freeFunctionsSink() {
+        let results = [
+            result(
+                "A.swift",
+                functions: [
+                    function("free", in: nil, cyclomatic: 11, cognitive: 40),
+                    function("member", in: "T", cyclomatic: 11, cognitive: 12),
+                ],
+                couplings: [coupling("T", fanIn: 2)])
+        ]
+        let hotspots = HotspotRanker.rank(
+            results: results, configuration: plainThreshold, fallbackThreshold: 10)
+        #expect(hotspots.map(\.function.name) == ["member", "free"])
+        #expect(hotspots[1].typeFanIn == 0)
+    }
+
+    @Test("Ambiguous type names without a same-file match resolve to fan-in 0")
+    func ambiguousTypeName() {
+        let results = [
+            result(
+                "A.swift",
+                functions: [function("f", in: "Widget", cyclomatic: 11, cognitive: 11)]),
+            result("B.swift", functions: [], couplings: [coupling("Widget", fanIn: 5)]),
+            result("C.swift", functions: [], couplings: [coupling("Widget", fanIn: 8)]),
+        ]
+        let hotspots = HotspotRanker.rank(
+            results: results, configuration: plainThreshold, fallbackThreshold: 10)
+        #expect(hotspots[0].typeFanIn == 0)
+    }
+
+    @Test("Nested type coupling names match simple enclosing names by suffix")
+    func nestedNameSuffixMatch() {
+        let results = [
+            result(
+                "A.swift",
+                functions: [function("f", in: "Inner", cyclomatic: 11, cognitive: 11)],
+                couplings: [coupling("Outer.Inner", fanIn: 4)])
+        ]
+        let hotspots = HotspotRanker.rank(
+            results: results, configuration: plainThreshold, fallbackThreshold: 10)
+        #expect(hotspots[0].typeFanIn == 4)
+    }
+
+    @Test("Violations without any coupling data still rank (fan-in 0)")
+    func noCouplingDataStillRanks() {
+        let results = [
+            result("A.swift", functions: [function("f", in: "T", cyclomatic: 11, cognitive: 11)])
+        ]
+        let hotspots = HotspotRanker.rank(
+            results: results, configuration: plainThreshold, fallbackThreshold: 10)
+        #expect(hotspots.count == 1)
+        #expect(hotspots[0].typeFanIn == 0)
+    }
+}

--- a/Tests/SwiftComplexityCoreTests/OutputFormatterCouplingTests.swift
+++ b/Tests/SwiftComplexityCoreTests/OutputFormatterCouplingTests.swift
@@ -1,0 +1,95 @@
+import Foundation
+import Testing
+
+@testable import SwiftComplexityCore
+
+@Suite("Coupling text output", .tags(.unit, .formatters))
+struct OutputFormatterCouplingTests {
+
+    private func result(
+        functions: [FunctionComplexity] = [],
+        couplings: [TypeCoupling]? = nil
+    ) -> ComplexityResult {
+        ComplexityResult(filePath: "A.swift", functions: functions, typeCouplings: couplings)
+    }
+
+    private func function(
+        _ name: String, in typeName: String?, cyclomatic: Int, cognitive: Int
+    ) -> FunctionComplexity {
+        FunctionComplexity(
+            name: name, signature: "func \(name)()",
+            cyclomaticComplexity: cyclomatic, cognitiveComplexity: cognitive,
+            location: SourceLocation(line: 1, column: 1),
+            enclosingTypeName: typeName)
+    }
+
+    @Test("Type coupling table renders values and dashes for undefined instability")
+    func couplingTableRendering() {
+        let couplings = [
+            TypeCoupling(
+                name: "Hub", kind: .class, fanIn: 3, fanOut: 24,
+                location: SourceLocation(line: 1, column: 1)),
+            TypeCoupling(
+                name: "Isolated", kind: .enum, fanIn: 0, fanOut: 0,
+                location: SourceLocation(line: 9, column: 1)),
+        ]
+        let text = OutputFormatter().format(
+            results: [result(couplings: couplings)], format: .text, options: OutputOptions())
+
+        #expect(text.contains("Type Coupling:"))
+        #expect(text.contains("| Fan-In | Fan-Out | Instability |"))
+        #expect(text.contains("0.89"))  // 24 / 27
+        #expect(text.contains("Isolated"))
+        // Undefined instability renders as a dash, never 0.00.
+        let isolatedRow = text.split(separator: "\n").first { $0.contains("Isolated") }
+        #expect(isolatedRow?.contains("-") == true)
+        #expect(text.contains("Total: 2 types"))
+    }
+
+    @Test("Empty coupling arrays render no table (coupling ran, no types)")
+    func emptyCouplingsNoTable() {
+        let text = OutputFormatter().format(
+            results: [result(functions: [function("f", in: nil, cyclomatic: 1, cognitive: 1)], couplings: [])],
+            format: .text, options: OutputOptions())
+        #expect(!text.contains("Type Coupling:"))
+    }
+
+    @Test("Hotspots appear only with a threshold, coupling data, and violations")
+    func hotspotVisibilityConditions() {
+        let violating = function("busy", in: "Hub", cyclomatic: 12, cognitive: 15)
+        let hub = TypeCoupling(
+            name: "Hub", kind: .class, fanIn: 7, fanOut: 1,
+            location: SourceLocation(line: 1, column: 1))
+        let formatter = OutputFormatter()
+
+        // Threshold + coupling + violation: section renders with the rank row.
+        let shown = formatter.format(
+            results: [result(functions: [violating], couplings: [hub])],
+            format: .text, options: OutputOptions(threshold: 10))
+        #expect(shown.contains("Hotspots"))
+        #expect(shown.contains("busy"))
+        #expect(shown.contains("| 1 "))
+
+        // No threshold: violations are undefined, so no section.
+        let noThreshold = formatter.format(
+            results: [result(functions: [violating], couplings: [hub])],
+            format: .text, options: OutputOptions())
+        #expect(!noThreshold.contains("Hotspots"))
+
+        // Threshold but coupling never ran: no section.
+        let noCoupling = formatter.format(
+            results: [result(functions: [violating])],
+            format: .text, options: OutputOptions(threshold: 10))
+        #expect(!noCoupling.contains("Hotspots"))
+
+        // Threshold + coupling but nothing violates: no section.
+        let calm = formatter.format(
+            results: [
+                result(
+                    functions: [function("calm", in: "Hub", cyclomatic: 2, cognitive: 2)],
+                    couplings: [hub])
+            ],
+            format: .text, options: OutputOptions(threshold: 10))
+        #expect(!calm.contains("Hotspots"))
+    }
+}

--- a/Tests/SwiftComplexityCoreTests/OutputFormatterCouplingTests.swift
+++ b/Tests/SwiftComplexityCoreTests/OutputFormatterCouplingTests.swift
@@ -54,6 +54,82 @@ struct OutputFormatterCouplingTests {
         #expect(!text.contains("Type Coupling:"))
     }
 
+    // MARK: - SARIF
+
+    private func sarifResults(
+        couplings: [TypeCoupling], configuration: ThresholdConfiguration?
+    ) throws -> [[String: Any]] {
+        let output = OutputFormatter().format(
+            results: [result(couplings: couplings)], format: .sarif,
+            options: OutputOptions(thresholdConfiguration: configuration))
+        let json = try #require(
+            try JSONSerialization.jsonObject(with: Data(output.utf8)) as? [String: Any])
+        let runs = try #require(json["runs"] as? [[String: Any]])
+        return try #require(runs[0]["results"] as? [[String: Any]])
+    }
+
+    @Test("Fan-out violations become type_fan_out results, error at double the threshold")
+    func sarifFanOutLevels() throws {
+        let configuration = ThresholdConfiguration(coupling: CouplingThresholds(fanOut: 10))
+        let couplings = [
+            TypeCoupling(
+                name: "Warning", kind: .struct, fanIn: 0, fanOut: 10,
+                location: SourceLocation(line: 1, column: 1)),
+            TypeCoupling(
+                name: "Error", kind: .class, fanIn: 0, fanOut: 20,
+                location: SourceLocation(line: 9, column: 1)),
+        ]
+        let results = try sarifResults(couplings: couplings, configuration: configuration)
+
+        #expect(results.count == 2)
+        let warning = try #require(results.first { $0["level"] as? String == "warning" })
+        #expect(warning["ruleId"] as? String == "type_fan_out")
+        let message = try #require((warning["message"] as? [String: Any])?["text"] as? String)
+        #expect(message.contains("'Warning' has fan-out 10 (threshold: 10)"))
+        let error = try #require(results.first { $0["level"] as? String == "error" })
+        #expect((error["message"] as? [String: Any])?["text"] as? String != nil)
+    }
+
+    @Test("Fan-in thresholds are judged by their own rule")
+    func sarifFanInRule() throws {
+        let configuration = ThresholdConfiguration(coupling: CouplingThresholds(fanIn: 5))
+        let couplings = [
+            TypeCoupling(
+                name: "Hub", kind: .protocol, fanIn: 6, fanOut: 0,
+                location: SourceLocation(line: 1, column: 1))
+        ]
+        let results = try sarifResults(couplings: couplings, configuration: configuration)
+        #expect(results.count == 1)
+        #expect(results[0]["ruleId"] as? String == "type_fan_in")
+    }
+
+    @Test("Without coupling thresholds the SARIF report carries no coupling results")
+    func sarifReportOnlyWithoutConfig() throws {
+        let couplings = [
+            TypeCoupling(
+                name: "Huge", kind: .class, fanIn: 99, fanOut: 99,
+                location: SourceLocation(line: 1, column: 1))
+        ]
+        // A configuration without a coupling block, and no configuration at all.
+        for configuration in [ThresholdConfiguration(defaultThreshold: 10), nil] {
+            let results = try sarifResults(couplings: couplings, configuration: configuration)
+            #expect(results.isEmpty)
+        }
+    }
+
+    @Test("Suppressed types produce no SARIF coupling results")
+    func sarifSuppressionSkips() throws {
+        let configuration = ThresholdConfiguration(coupling: CouplingThresholds(fanOut: 1))
+        let couplings = [
+            TypeCoupling(
+                name: "Muted", kind: .class, fanIn: 0, fanOut: 30,
+                location: SourceLocation(line: 1, column: 1),
+                suppressedMetrics: [.coupling])
+        ]
+        let results = try sarifResults(couplings: couplings, configuration: configuration)
+        #expect(results.isEmpty)
+    }
+
     @Test("Hotspots appear only with a threshold, coupling data, and violations")
     func hotspotVisibilityConditions() {
         let violating = function("busy", in: "Hub", cyclomatic: 12, cognitive: 15)

--- a/Tests/SwiftComplexityCoreTests/OutputFormatterCouplingTests.swift
+++ b/Tests/SwiftComplexityCoreTests/OutputFormatterCouplingTests.swift
@@ -49,7 +49,10 @@ struct OutputFormatterCouplingTests {
     @Test("Empty coupling arrays render no table (coupling ran, no types)")
     func emptyCouplingsNoTable() {
         let text = OutputFormatter().format(
-            results: [result(functions: [function("f", in: nil, cyclomatic: 1, cognitive: 1)], couplings: [])],
+            results: [
+                result(
+                    functions: [function("f", in: nil, cyclomatic: 1, cognitive: 1)], couplings: [])
+            ],
             format: .text, options: OutputOptions())
         #expect(!text.contains("Type Coupling:"))
     }

--- a/Tests/SwiftComplexityCoreTests/ReferenceGraphBuilderTests.swift
+++ b/Tests/SwiftComplexityCoreTests/ReferenceGraphBuilderTests.swift
@@ -163,10 +163,11 @@ struct ReferenceGraphBuilderTests {
 
     @Test("Repeated references to one type count once (distinct types)")
     func distinctCounting() {
-        let records = basicScenario + [
-            ref("s:B", at: (51, 1), containedBy: "s:A.m"),
-            ref("s:B", at: (52, 1), containedBy: "s:A.m"),
-        ]
+        let records =
+            basicScenario + [
+                ref("s:B", at: (51, 1), containedBy: "s:A.m"),
+                ref("s:B", at: (52, 1), containedBy: "s:A.m"),
+            ]
         let (graph, _) = build(records)
         #expect(graph.fanOut(of: "s:A") == 1)
         #expect(graph.fanIn(of: "s:B") == 1)
@@ -243,10 +244,11 @@ struct ReferenceGraphBuilderTests {
 
     @Test("References to symbols outside the analyzed files are dropped")
     func nonProjectSymbolDropped() {
-        let records = basicScenario + [
-            // No definition record exists for String: not a project symbol.
-            ref("s:Swift.String", at: (60, 1), containedBy: "s:A.m")
-        ]
+        let records =
+            basicScenario + [
+                // No definition record exists for String: not a project symbol.
+                ref("s:Swift.String", at: (60, 1), containedBy: "s:A.m")
+            ]
         let (graph, diagnostics) = build(records)
         #expect(diagnostics.droppedNonProjectSymbol == 1)
         #expect(graph.fanOut(of: "s:A") == 1)  // only the edge to B

--- a/Tests/SwiftComplexityCoreTests/ReferenceGraphBuilderTests.swift
+++ b/Tests/SwiftComplexityCoreTests/ReferenceGraphBuilderTests.swift
@@ -427,7 +427,7 @@ struct ReferenceGraphBuilderTests {
         #expect(d.droppedTypealias == 1)
         #expect(d.droppedUnattributable == 1)
         #expect(d.selfReferencesSkipped == 1)
-        // The invariant documented on CouplingDiagnostics.
+        // Cross-check the partition invariant documented on CouplingDiagnostics.
         let attributed = d.attributedByContainedBy + d.attributedByBaseOf + d.attributedByLocation
         let dropped = d.droppedNonProjectSymbol + d.droppedTypealias + d.droppedUnattributable
         #expect(d.refsTotal == attributed + dropped)

--- a/Tests/SwiftComplexityCoreTests/ReferenceGraphBuilderTests.swift
+++ b/Tests/SwiftComplexityCoreTests/ReferenceGraphBuilderTests.swift
@@ -1,0 +1,267 @@
+import Foundation
+import IndexStoreDB
+import Testing
+
+@testable import SwiftComplexityCore
+
+/// Unit tests for the pure attribution algorithm. Records are hand-written
+/// stand-ins for IndexStoreDB occurrences; their relation shapes mirror what
+/// the coupling spike observed against a real index store.
+@Suite("Reference graph builder", .tags(.unit, .calculators))
+struct ReferenceGraphBuilderTests {
+
+    // MARK: - Record helpers
+
+    private func def(
+        _ usr: String, _ name: String, _ kind: IndexSymbolKind,
+        file: String = "A.swift", at position: (line: Int, column: Int) = (1, 1),
+        childOf parent: String? = nil
+    ) -> IndexOccurrenceRecord {
+        IndexOccurrenceRecord(
+            usr: usr, name: name, kind: kind,
+            file: file, line: position.line, column: position.column,
+            roles: .definition,
+            relations: parent.map {
+                [RecordRelation(usr: $0, kind: .struct, roles: .childOf)]
+            } ?? [])
+    }
+
+    private func ref(
+        _ usr: String, kind: IndexSymbolKind = .struct,
+        file: String = "A.swift", at position: (line: Int, column: Int) = (50, 1),
+        containedBy container: String? = nil,
+        extendedBy extensionUSR: String? = nil
+    ) -> IndexOccurrenceRecord {
+        var relations: [RecordRelation] = []
+        if let container {
+            relations.append(
+                RecordRelation(usr: container, kind: .instanceMethod, roles: .containedBy))
+        }
+        if let extensionUSR {
+            relations.append(
+                RecordRelation(usr: extensionUSR, kind: .extension, roles: .extendedBy))
+        }
+        return IndexOccurrenceRecord(
+            usr: usr, name: usr, kind: kind,
+            file: file, line: position.line, column: position.column,
+            roles: .reference, relations: relations)
+    }
+
+    private func build(
+        _ occurrences: [IndexOccurrenceRecord],
+        typeRanges: [String: TypeRangeIndex] = [:]
+    ) -> (graph: ReferenceGraph, diagnostics: CouplingDiagnostics) {
+        ReferenceGraphBuilder.build(occurrences: occurrences, typeRanges: typeRanges)
+    }
+
+    /// The standard two-type scenario: A.method references B.
+    private var basicScenario: [IndexOccurrenceRecord] {
+        [
+            def("s:A", "A", .struct),
+            def("s:A.m", "m()", .instanceMethod, childOf: "s:A"),
+            def("s:B", "B", .struct, at: (10, 1)),
+            ref("s:B", containedBy: "s:A.m"),
+        ]
+    }
+
+    // MARK: - Core attribution
+
+    @Test("Reference inside a method becomes an edge from the owning type")
+    func containedByAttribution() {
+        let (graph, diagnostics) = build(basicScenario)
+        #expect(graph.outEdges["s:A"] == ["s:B"])
+        #expect(graph.inEdges["s:B"] == ["s:A"])
+        #expect(diagnostics.attributedByContainedBy == 1)
+    }
+
+    @Test("Multi-hop childOf chains resolve to the innermost owning type")
+    func childOfChainResolution() {
+        // A reference contained by an accessor-like symbol nested under a
+        // method nested under the type.
+        let records = [
+            def("s:A", "A", .struct),
+            def("s:A.m", "m()", .instanceMethod, childOf: "s:A"),
+            def("s:A.m.acc", "get", .function, childOf: "s:A.m"),
+            def("s:B", "B", .struct, at: (10, 1)),
+            ref("s:B", containedBy: "s:A.m.acc"),
+        ]
+        let (graph, _) = build(records)
+        #expect(graph.outEdges["s:A"] == ["s:B"])
+    }
+
+    @Test("Members defined in extensions attribute to the extended type")
+    func extensionAttribution() {
+        let records = [
+            def("s:Foo", "Foo", .struct),
+            def("s:e:Foo", "Foo", .extension, at: (20, 1)),
+            // The `Foo` reference in `extension Foo` registers the mapping.
+            ref("s:Foo", at: (20, 11), extendedBy: "s:e:Foo"),
+            def("s:Foo.extra", "extra()", .instanceMethod, at: (21, 5), childOf: "s:e:Foo"),
+            def("s:Bar", "Bar", .struct, at: (30, 1)),
+            ref("s:Bar", at: (22, 9), containedBy: "s:Foo.extra"),
+        ]
+        let (graph, _) = build(records)
+        #expect(graph.outEdges["s:Foo"] == ["s:Bar"])
+    }
+
+    @Test("References to a member count toward the member's owning type")
+    func memberTargetResolution() {
+        // A.m references B.helper -> edge A -> B, not A -> helper.
+        let records = [
+            def("s:A", "A", .struct),
+            def("s:A.m", "m()", .instanceMethod, childOf: "s:A"),
+            def("s:B", "B", .struct, at: (10, 1)),
+            def("s:B.helper", "helper()", .instanceMethod, at: (11, 5), childOf: "s:B"),
+            ref("s:B.helper", kind: .instanceMethod, containedBy: "s:A.m"),
+        ]
+        let (graph, _) = build(records)
+        #expect(graph.outEdges["s:A"] == ["s:B"])
+    }
+
+    // MARK: - Aggregation
+
+    @Test("Fan counts aggregate distinct types over a small graph")
+    func fanAggregation() {
+        // A -> B, A -> C, C -> B
+        let records = [
+            def("s:A", "A", .struct),
+            def("s:A.m", "m()", .instanceMethod, childOf: "s:A"),
+            def("s:B", "B", .struct, at: (10, 1)),
+            def("s:C", "C", .struct, at: (20, 1)),
+            def("s:C.m", "m()", .instanceMethod, at: (21, 5), childOf: "s:C"),
+            ref("s:B", containedBy: "s:A.m"),
+            ref("s:C", containedBy: "s:A.m"),
+            ref("s:B", at: (60, 1), containedBy: "s:C.m"),
+        ]
+        let (graph, _) = build(records)
+        #expect(graph.fanOut(of: "s:A") == 2)
+        #expect(graph.fanIn(of: "s:A") == 0)
+        #expect(graph.fanOut(of: "s:B") == 0)
+        #expect(graph.fanIn(of: "s:B") == 2)
+        #expect(graph.fanOut(of: "s:C") == 1)
+        #expect(graph.fanIn(of: "s:C") == 1)
+    }
+
+    @Test("Repeated references to one type count once (distinct types)")
+    func distinctCounting() {
+        let records = basicScenario + [
+            ref("s:B", at: (51, 1), containedBy: "s:A.m"),
+            ref("s:B", at: (52, 1), containedBy: "s:A.m"),
+        ]
+        let (graph, _) = build(records)
+        #expect(graph.fanOut(of: "s:A") == 1)
+        #expect(graph.fanIn(of: "s:B") == 1)
+    }
+
+    @Test("Nested types are independent nodes; inner-outer references count")
+    func nestedTypesAreIndependent() {
+        let records = [
+            def("s:Outer", "Outer", .struct),
+            def("s:Outer.Inner", "Inner", .struct, at: (2, 5), childOf: "s:Outer"),
+            def("s:Outer.Inner.m", "m()", .instanceMethod, at: (3, 9), childOf: "s:Outer.Inner"),
+            ref("s:Outer", at: (3, 20), containedBy: "s:Outer.Inner.m"),
+        ]
+        let (graph, _) = build(records)
+        #expect(graph.outEdges["s:Outer.Inner"] == ["s:Outer"])
+        #expect(graph.nodes["s:Outer.Inner"] != nil)
+        #expect(graph.nodes["s:Outer"] != nil)
+    }
+
+    @Test("Mutual references stay directional")
+    func mutualReferences() {
+        let records = [
+            def("s:A", "A", .struct),
+            def("s:A.m", "m()", .instanceMethod, childOf: "s:A"),
+            def("s:B", "B", .struct, at: (10, 1)),
+            def("s:B.m", "m()", .instanceMethod, at: (11, 5), childOf: "s:B"),
+            ref("s:B", containedBy: "s:A.m"),
+            ref("s:A", at: (60, 1), containedBy: "s:B.m"),
+        ]
+        let (graph, _) = build(records)
+        #expect(graph.outEdges["s:A"] == ["s:B"])
+        #expect(graph.outEdges["s:B"] == ["s:A"])
+    }
+
+    // MARK: - Node metadata
+
+    @Test("Syntax ranges override the index kind (actor) and provide names")
+    func syntaxKindWins() {
+        let entry = TypeRangeEntry(
+            name: "MyActor", declKind: .nominal(.actor),
+            startLine: 1, startColumn: 1, endLine: 5, endColumn: 1,
+            suppressedMetrics: [.coupling])
+        let ranges = ["A.swift": TypeRangeIndex(entries: [entry])]
+        // The index reports actors as classes.
+        let records = [def("s:MyActor", "MyActor", .class, at: (1, 7))]
+
+        let (graph, _) = build(records, typeRanges: ranges)
+        #expect(graph.nodes["s:MyActor"]?.kind == .actor)
+        #expect(graph.nodes["s:MyActor"]?.suppressedMetrics == [.coupling])
+    }
+
+    @Test("Types without a syntax entry fall back to index metadata")
+    func fallbackToIndexMetadata() {
+        let (graph, _) = build([def("s:E", "E", .enum)])
+        #expect(graph.nodes["s:E"]?.kind == .enum)
+        #expect(graph.nodes["s:E"]?.name == "E")
+        #expect(graph.nodes["s:E"]?.suppressedMetrics == [])
+    }
+
+    // MARK: - Exclusions and robustness
+
+    @Test("Self references produce no edge but are accounted for")
+    func selfReferenceExcluded() {
+        let records = [
+            def("s:A", "A", .struct),
+            def("s:A.m", "m()", .instanceMethod, childOf: "s:A"),
+            def("s:A.other", "other()", .instanceMethod, at: (5, 5), childOf: "s:A"),
+            ref("s:A.other", kind: .instanceMethod, containedBy: "s:A.m"),
+        ]
+        let (graph, diagnostics) = build(records)
+        #expect(graph.outEdges["s:A"] == nil)
+        #expect(diagnostics.selfReferencesSkipped == 1)
+    }
+
+    @Test("References to symbols outside the analyzed files are dropped")
+    func nonProjectSymbolDropped() {
+        let records = basicScenario + [
+            // No definition record exists for String: not a project symbol.
+            ref("s:Swift.String", at: (60, 1), containedBy: "s:A.m")
+        ]
+        let (graph, diagnostics) = build(records)
+        #expect(diagnostics.droppedNonProjectSymbol == 1)
+        #expect(graph.fanOut(of: "s:A") == 1)  // only the edge to B
+    }
+
+    @Test("Isolated types keep zero fan counts")
+    func isolatedType() {
+        let (graph, _) = build([def("s:Lonely", "Lonely", .struct)])
+        #expect(graph.nodes["s:Lonely"] != nil)
+        #expect(graph.fanIn(of: "s:Lonely") == 0)
+        #expect(graph.fanOut(of: "s:Lonely") == 0)
+    }
+
+    @Test("Corrupt parent cycles drop the reference instead of hanging")
+    func parentCycleGuard() {
+        let records = [
+            def("s:A", "A", .struct),
+            def("s:A.m", "m()", .instanceMethod, childOf: "s:A"),
+            // x and y form a childOf cycle and never reach a type.
+            def("s:x", "x", .function, at: (30, 1), childOf: "s:y"),
+            def("s:y", "y", .function, at: (31, 1), childOf: "s:x"),
+            def("s:B", "B", .struct, at: (10, 1)),
+            ref("s:B", containedBy: "s:x"),
+        ]
+        let (graph, diagnostics) = build(records)
+        #expect(graph.outEdges.isEmpty)
+        #expect(diagnostics.droppedUnattributable == 1)
+    }
+
+    @Test("Empty input builds an empty graph with zeroed diagnostics")
+    func emptyInput() {
+        let (graph, diagnostics) = build([])
+        #expect(graph.nodes.isEmpty)
+        #expect(graph.outEdges.isEmpty)
+        #expect(diagnostics == CouplingDiagnostics())
+    }
+}

--- a/Tests/SwiftComplexityCoreTests/ReferenceGraphBuilderTests.swift
+++ b/Tests/SwiftComplexityCoreTests/ReferenceGraphBuilderTests.swift
@@ -30,7 +30,8 @@ struct ReferenceGraphBuilderTests {
         _ usr: String, kind: IndexSymbolKind = .struct,
         file: String = "A.swift", at position: (line: Int, column: Int) = (50, 1),
         containedBy container: String? = nil,
-        extendedBy extensionUSR: String? = nil
+        extendedBy extensionUSR: String? = nil,
+        baseOf conformer: String? = nil
     ) -> IndexOccurrenceRecord {
         var relations: [RecordRelation] = []
         if let container {
@@ -41,10 +42,28 @@ struct ReferenceGraphBuilderTests {
             relations.append(
                 RecordRelation(usr: extensionUSR, kind: .extension, roles: .extendedBy))
         }
+        if let conformer {
+            relations.append(
+                RecordRelation(usr: conformer, kind: .struct, roles: .baseOf))
+        }
         return IndexOccurrenceRecord(
             usr: usr, name: usr, kind: kind,
             file: file, line: position.line, column: position.column,
             roles: .reference, relations: relations)
+    }
+
+    /// A range index whose single entry spans the given lines of `file`.
+    private func rangeIndex(
+        _ name: String, kind: NominalType = .enum,
+        lines: ClosedRange<Int>
+    ) -> TypeRangeIndex {
+        TypeRangeIndex(entries: [
+            TypeRangeEntry(
+                name: name, declKind: .nominal(kind),
+                startLine: lines.lowerBound, startColumn: 1,
+                endLine: lines.upperBound, endColumn: 80,
+                suppressedMetrics: [])
+        ])
     }
 
     private func build(
@@ -263,5 +282,152 @@ struct ReferenceGraphBuilderTests {
         #expect(graph.nodes.isEmpty)
         #expect(graph.outEdges.isEmpty)
         #expect(diagnostics == CouplingDiagnostics())
+    }
+
+    // MARK: - Fallback attribution
+
+    @Test("Conformance clauses recover edges through the baseOf relation")
+    func baseOfConformanceEdge() {
+        // `struct Foo: P` - the P reference has only a baseOf relation
+        // pointing at the conforming type.
+        let records = [
+            def("s:P", "P", .protocol),
+            def("s:Foo", "Foo", .struct, at: (10, 1)),
+            ref("s:P", kind: .protocol, at: (10, 13), baseOf: "s:Foo"),
+        ]
+        let (graph, diagnostics) = build(records)
+        #expect(graph.outEdges["s:Foo"] == ["s:P"])
+        #expect(diagnostics.attributedByBaseOf == 1)
+    }
+
+    @Test("Protocol fan-in counts every conformer")
+    func protocolFanIn() {
+        let records = [
+            def("s:P", "P", .protocol),
+            def("s:A", "A", .struct, at: (10, 1)),
+            def("s:B", "B", .class, at: (20, 1)),
+            def("s:C", "C", .enum, at: (30, 1)),
+            ref("s:P", kind: .protocol, at: (10, 11), baseOf: "s:A"),
+            ref("s:P", kind: .protocol, at: (20, 10), baseOf: "s:B"),
+            ref("s:P", kind: .protocol, at: (30, 10), baseOf: "s:C"),
+        ]
+        let (graph, _) = build(records)
+        #expect(graph.fanIn(of: "s:P") == 3)
+        #expect(graph.fanOut(of: "s:P") == 0)
+    }
+
+    @Test("Relation-free references attribute by source location")
+    func locationFallback() {
+        // `case wrapped(Outer)` - the Outer reference carries no relations;
+        // its position inside Payload's syntax range attributes it.
+        let records = [
+            def("s:Outer", "Outer", .struct, at: (1, 8)),
+            def("s:Payload", "Payload", .enum, at: (32, 6)),
+            ref("s:Outer", at: (33, 18)),
+        ]
+        let ranges = ["A.swift": rangeIndex("Payload", lines: 32...35)]
+        let (graph, diagnostics) = build(records, typeRanges: ranges)
+        #expect(graph.outEdges["s:Payload"] == ["s:Outer"])
+        #expect(diagnostics.attributedByLocation == 1)
+    }
+
+    @Test("Location fallback refuses ambiguous names without a same-file match")
+    func locationFallbackAmbiguity() {
+        // Two types named "Payload" in other files; the reference sits in a
+        // third file whose range says "Payload" - guessing would risk a wrong
+        // edge, so the reference is dropped.
+        let records = [
+            def("s:P1", "Payload", .enum, file: "B.swift"),
+            def("s:P2", "Payload", .enum, file: "C.swift"),
+            def("s:Outer", "Outer", .struct, at: (1, 8)),
+            ref("s:Outer", at: (33, 18)),
+        ]
+        let ranges = ["A.swift": rangeIndex("Payload", lines: 32...35)]
+        let (graph, diagnostics) = build(records, typeRanges: ranges)
+        #expect(graph.outEdges.isEmpty)
+        #expect(diagnostics.droppedUnattributable == 1)
+
+        // With one candidate in the same file, resolution succeeds.
+        let sameFile = [
+            def("s:P3", "Payload", .enum, at: (32, 6)),
+            def("s:P1", "Payload", .enum, file: "B.swift"),
+            def("s:Outer", "Outer", .struct, at: (1, 8)),
+            ref("s:Outer", at: (33, 18)),
+        ]
+        let (resolved, _) = build(sameFile, typeRanges: ranges)
+        #expect(resolved.outEdges["s:P3"] == ["s:Outer"])
+    }
+
+    @Test("Typealias references are excluded and counted")
+    func typealiasExcluded() {
+        let records = [
+            def("s:A", "A", .struct),
+            def("s:A.m", "m()", .instanceMethod, childOf: "s:A"),
+            def("s:Alias", "Alias", .typealias, at: (40, 1)),
+            ref("s:Alias", kind: .typealias, containedBy: "s:A.m"),
+        ]
+        let (graph, diagnostics) = build(records)
+        #expect(graph.outEdges.isEmpty)
+        #expect(diagnostics.droppedTypealias == 1)
+    }
+
+    @Test("References with no attribution evidence drop without throwing")
+    func unattributableDropped() {
+        let records = [
+            def("s:B", "B", .struct, at: (10, 1)),
+            // No relations, and no syntax range covers the location.
+            ref("s:B", at: (99, 1)),
+        ]
+        let (graph, diagnostics) = build(records)
+        #expect(graph.outEdges.isEmpty)
+        #expect(diagnostics.droppedUnattributable == 1)
+    }
+
+    @Test("containedBy wins over baseOf: one reference, one edge")
+    func containedByBeatsBaseOf() {
+        let records = [
+            def("s:P", "P", .protocol),
+            def("s:Foo", "Foo", .struct, at: (10, 1)),
+            def("s:Foo.m", "m()", .instanceMethod, at: (11, 5), childOf: "s:Foo"),
+            ref("s:P", kind: .protocol, containedBy: "s:Foo.m", baseOf: "s:Foo"),
+        ]
+        let (graph, diagnostics) = build(records)
+        #expect(graph.outEdges["s:Foo"] == ["s:P"])
+        #expect(diagnostics.attributedByContainedBy == 1)
+        #expect(diagnostics.attributedByBaseOf == 0)
+    }
+
+    @Test("Diagnostics buckets partition every reference")
+    func diagnosticsInvariant() {
+        let records = [
+            def("s:P", "P", .protocol),
+            def("s:A", "A", .struct, at: (10, 1)),
+            def("s:A.m", "m()", .instanceMethod, at: (11, 5), childOf: "s:A"),
+            def("s:B", "B", .struct, at: (20, 1)),
+            def("s:Alias", "Alias", .typealias, at: (40, 1)),
+            def("s:Payload", "Payload", .enum, at: (32, 6)),
+            ref("s:B", containedBy: "s:A.m"),  // containedBy
+            ref("s:P", kind: .protocol, at: (10, 11), baseOf: "s:A"),  // baseOf
+            ref("s:B", at: (33, 18)),  // location (inside Payload)
+            ref("s:Swift.Int", at: (51, 1), containedBy: "s:A.m"),  // non-project
+            ref("s:Alias", kind: .typealias, at: (52, 1), containedBy: "s:A.m"),  // typealias
+            ref("s:B", at: (99, 1)),  // unattributable
+            ref("s:A", at: (53, 1), containedBy: "s:A.m"),  // self reference
+        ]
+        let ranges = ["A.swift": rangeIndex("Payload", lines: 32...35)]
+        let (_, d) = build(records, typeRanges: ranges)
+
+        #expect(d.refsTotal == 7)
+        #expect(d.attributedByContainedBy == 2)  // edge to B + self reference
+        #expect(d.attributedByBaseOf == 1)
+        #expect(d.attributedByLocation == 1)
+        #expect(d.droppedNonProjectSymbol == 1)
+        #expect(d.droppedTypealias == 1)
+        #expect(d.droppedUnattributable == 1)
+        #expect(d.selfReferencesSkipped == 1)
+        // The invariant documented on CouplingDiagnostics.
+        let attributed = d.attributedByContainedBy + d.attributedByBaseOf + d.attributedByLocation
+        let dropped = d.droppedNonProjectSymbol + d.droppedTypealias + d.droppedUnattributable
+        #expect(d.refsTotal == attributed + dropped)
     }
 }

--- a/Tests/SwiftComplexityCoreTests/SwiftComplexityTests.swift
+++ b/Tests/SwiftComplexityCoreTests/SwiftComplexityTests.swift
@@ -65,6 +65,54 @@ struct DataModelTests {
         }
     }
 
+    @Test("TypeCoupling derives instability from the counts")
+    func typeCouplingInstability() {
+        let location = SourceLocation(line: 1, column: 1)
+        // 2 / (1 + 2) = 0.666..., and isolated types have no defined ratio.
+        let coupled = TypeCoupling(
+            name: "A", kind: .struct, fanIn: 1, fanOut: 2, location: location)
+        #expect(coupled.instability != nil)
+        #expect(abs(coupled.instability! - 2.0 / 3.0) < 0.0001)
+        let entryPoint = TypeCoupling(
+            name: "B", kind: .class, fanIn: 0, fanOut: 5, location: location)
+        #expect(entryPoint.instability == 1.0)
+        let isolated = TypeCoupling(
+            name: "C", kind: .enum, fanIn: 0, fanOut: 0, location: location)
+        #expect(isolated.instability == nil)
+    }
+
+    @Test("TypeCoupling round-trips through Codable, nil instability omits the key")
+    func typeCouplingCodable() throws {
+        let coupling = TypeCoupling(
+            name: "Isolated", kind: .protocol, fanIn: 0, fanOut: 0,
+            location: SourceLocation(line: 3, column: 1),
+            suppressedMetrics: [.coupling])
+        let data = try JSONEncoder().encode(coupling)
+        let decoded = try JSONDecoder().decode(TypeCoupling.self, from: data)
+        #expect(decoded == coupling)
+        // Optionals encode via encodeIfPresent: an absent key keeps the JSON
+        // schema additive for consumers that reject unknown null values.
+        let json = String(decoding: data, as: UTF8.self)
+        #expect(!json.contains("instability"))
+    }
+
+    @Test("CouplingSummary aggregates and stays safe on empty input")
+    func couplingSummaryAggregation() {
+        let location = SourceLocation(line: 1, column: 1)
+        let types = [
+            TypeCoupling(name: "A", kind: .struct, fanIn: 4, fanOut: 1, location: location),
+            TypeCoupling(name: "B", kind: .class, fanIn: 0, fanOut: 7, location: location),
+        ]
+        let summary = CouplingSummary(types: types)
+        #expect(summary.totalTypes == 2)
+        #expect(summary.maxFanIn == 4)
+        #expect(summary.maxFanOut == 7)
+        #expect(abs(summary.averageFanOut - 4.0) < 0.0001)
+        let empty = CouplingSummary(types: [])
+        #expect(empty.totalTypes == 0)
+        #expect(empty.averageFanOut == 0.0)
+    }
+
     @Test("FileSummary with empty functions")
     func fileSummaryEmptyFunctions() {
         // When

--- a/Tests/SwiftComplexityCoreTests/SwiftComplexityTests.swift
+++ b/Tests/SwiftComplexityCoreTests/SwiftComplexityTests.swift
@@ -520,6 +520,39 @@ struct SuppressionParserTests {
                 in: trivia, applicableTo: SuppressedMetric.typeLevel) == [.lcom4])
     }
 
+    @Test("coupling token is recognized for type declarations")
+    func couplingToken() {
+        let trivia: Trivia = [.lineComment("// swift-complexity:disable coupling"), .newlines(1)]
+        #expect(
+            SuppressionParser.suppressedMetrics(
+                in: trivia, applicableTo: SuppressedMetric.typeLevel) == [.coupling])
+        // coupling above a function-level declaration suppresses nothing.
+        #expect(
+            SuppressionParser.suppressedMetrics(
+                in: trivia, applicableTo: SuppressedMetric.functionLevel
+            ).isEmpty)
+    }
+
+    @Test("coupling scope narrowed to enum/protocol excludes lcom4 from bare disable")
+    func couplingOnlyScope() {
+        // enum/protocol declarations pass [.coupling] as the applicable set,
+        // so a bare disable must not leak lcom4 into their suppression set.
+        let trivia: Trivia = [.lineComment("// swift-complexity:disable"), .newlines(1)]
+        #expect(
+            SuppressionParser.suppressedMetrics(
+                in: trivia, applicableTo: [.coupling]) == [.coupling])
+    }
+
+    @Test("SuppressedMetric.coupling model invariants")
+    func couplingMetricInvariants() throws {
+        #expect(SuppressedMetric.coupling.rawValue == "coupling")
+        #expect(SuppressedMetric.typeLevel == [.lcom4, .coupling])
+        // The function-level set must stay unchanged by the coupling addition.
+        #expect(SuppressedMetric.functionLevel == [.cyclomatic, .cognitive])
+        let data = try JSONEncoder().encode(SuppressedMetric.coupling)
+        #expect(try JSONDecoder().decode(SuppressedMetric.self, from: data) == .coupling)
+    }
+
     @Test("Unrelated comment is not treated as a directive")
     func unrelatedCommentIgnored() {
         let trivia: Trivia = [.lineComment("// just a regular comment"), .newlines(1)]
@@ -569,8 +602,10 @@ struct NominalTypeDetectorTests {
         // Then
         #expect(types.count == 5)
         // A bare disable above a type suppresses only the type's own metrics,
-        // never its member functions.
-        #expect(suppressed("BareSuppressedClass") == SuppressedMetric.typeLevel)
+        // never its member functions. NominalTypeDetector reports lcom4 only —
+        // ClassCohesion output must not change when new type-level metrics
+        // (e.g. coupling) are added; those are collected separately.
+        #expect(suppressed("BareSuppressedClass") == [.lcom4])
         #expect(suppressed("Lcom4SuppressedStruct") == [.lcom4])
         #expect(suppressed("NotSuppressedActor") == [])
         // A function-level metric name above a type fails closed.

--- a/Tests/SwiftComplexityCoreTests/SwiftComplexityTests.swift
+++ b/Tests/SwiftComplexityCoreTests/SwiftComplexityTests.swift
@@ -54,6 +54,17 @@ struct DataModelTests {
         #expect(function.location.line == 1)
     }
 
+    @Test("NominalType coupling-only cases round-trip and keep raw values")
+    func nominalTypeCouplingCases() throws {
+        // enum/protocol exist for coupling metrics; LCOM4 must never emit them.
+        #expect(NominalType.enum.rawValue == "enum")
+        #expect(NominalType.protocol.rawValue == "protocol")
+        for kind in [NominalType.enum, .protocol] {
+            let data = try JSONEncoder().encode(kind)
+            #expect(try JSONDecoder().decode(NominalType.self, from: data) == kind)
+        }
+    }
+
     @Test("FileSummary with empty functions")
     func fileSummaryEmptyFunctions() {
         // When

--- a/Tests/SwiftComplexityCoreTests/ThresholdConfigurationTests.swift
+++ b/Tests/SwiftComplexityCoreTests/ThresholdConfigurationTests.swift
@@ -231,5 +231,95 @@ struct ThresholdConfigurationTests {
                     fromFileAtPath: "/nonexistent/swift-complexity.yml")
             }
         }
+
+        @Test("Decodes coupling thresholds (fanOut only)")
+        func decodesCouplingFanOutOnly() throws {
+            let yaml = """
+                coupling:
+                  fanOut: 15
+                """
+            let path = try writeTempYAML(yaml)
+            defer { try? FileManager.default.removeItem(atPath: path) }
+
+            let config = try ThresholdConfiguration.load(fromFileAtPath: path)
+            #expect(config.coupling?.fanOut == 15)
+            #expect(config.coupling?.fanIn == nil)
+            // Coupling-only configs must not enable complexity-threshold paths.
+            #expect(config.isEmpty)
+        }
+
+        @Test("Decodes coupling thresholds (both keys) alongside complexity keys")
+        func decodesCouplingBothKeys() throws {
+            let yaml = """
+                defaultThreshold: 10
+                coupling:
+                  fanOut: 15
+                  fanIn: 25
+                """
+            let path = try writeTempYAML(yaml)
+            defer { try? FileManager.default.removeItem(atPath: path) }
+
+            let config = try ThresholdConfiguration.load(fromFileAtPath: path)
+            #expect(config.defaultThreshold == 10)
+            #expect(config.coupling?.fanOut == 15)
+            #expect(config.coupling?.fanIn == 25)
+        }
+
+        @Test("Config without a coupling key stays report-only (backward compatible)")
+        func decodesWithoutCoupling() throws {
+            let yaml = """
+                defaultThreshold: 10
+                """
+            let path = try writeTempYAML(yaml)
+            defer { try? FileManager.default.removeItem(atPath: path) }
+
+            let config = try ThresholdConfiguration.load(fromFileAtPath: path)
+            #expect(config.coupling == nil)
+        }
+    }
+
+    @Suite("couplingViolations")
+    struct CouplingViolationTests {
+        private func coupling(
+            fanIn: Int, fanOut: Int, suppressed: Set<SuppressedMetric>? = nil
+        ) -> TypeCoupling {
+            TypeCoupling(
+                name: "T", kind: .class, fanIn: fanIn, fanOut: fanOut,
+                location: SourceLocation(line: 1, column: 1),
+                suppressedMetrics: suppressed)
+        }
+
+        @Test("fanOut threshold uses >= semantics like the complexity gate")
+        func fanOutGreaterOrEqual() {
+            let config = ThresholdConfiguration(coupling: CouplingThresholds(fanOut: 15))
+            #expect(
+                config.couplingViolations(coupling(fanIn: 0, fanOut: 15))
+                    == [CouplingViolation(metric: .fanOut, value: 15, threshold: 15)])
+            #expect(config.couplingViolations(coupling(fanIn: 0, fanOut: 14)).isEmpty)
+        }
+
+        @Test("fanIn threshold is judged independently of fanOut")
+        func fanInIndependent() {
+            let config = ThresholdConfiguration(
+                coupling: CouplingThresholds(fanOut: 100, fanIn: 5))
+            #expect(
+                config.couplingViolations(coupling(fanIn: 6, fanOut: 1))
+                    == [CouplingViolation(metric: .fanIn, value: 6, threshold: 5)])
+        }
+
+        @Test("Suppressed type produces no violations while values stay reported")
+        func suppressionSkipsJudgment() {
+            let config = ThresholdConfiguration(coupling: CouplingThresholds(fanOut: 1))
+            let type = coupling(fanIn: 0, fanOut: 30, suppressed: [.coupling])
+            #expect(config.couplingViolations(type).isEmpty)
+            // The metric value itself is untouched by suppression.
+            #expect(type.fanOut == 30)
+        }
+
+        @Test("No coupling config means report-only: never a violation")
+        func noConfigNoViolations() {
+            let config = ThresholdConfiguration(defaultThreshold: 10)
+            #expect(config.couplingViolations(coupling(fanIn: 99, fanOut: 99)).isEmpty)
+        }
     }
 }

--- a/Tests/SwiftComplexityCoreTests/TypeRangeCollectorTests.swift
+++ b/Tests/SwiftComplexityCoreTests/TypeRangeCollectorTests.swift
@@ -1,0 +1,163 @@
+import Foundation
+import SwiftParser
+import SwiftSyntax
+import Testing
+
+@testable import SwiftComplexityCore
+
+@Suite("Type range collection", .tags(.unit, .detectors))
+struct TypeRangeCollectorTests {
+
+    private func loadCouplingFixture(_ filename: String) throws -> String {
+        let url = try #require(
+            Bundle.module.url(
+                forResource: filename, withExtension: "swift", subdirectory: "Fixtures"))
+        return try String(contentsOf: url, encoding: .utf8)
+    }
+
+    private func collect(_ source: String) -> TypeRangeIndex {
+        TypeRangeCollector.collect(
+            from: Parser.parse(source: source), filePath: "test.swift")
+    }
+
+    private func entry(_ index: TypeRangeIndex, _ name: String) -> TypeRangeEntry? {
+        index.entries.first { $0.name == name }
+    }
+
+    // MARK: - Collection (fixture: coupling_basic.swift)
+
+    @Test("Collects all five nominal kinds plus extensions")
+    func collectsAllDeclarationKinds() throws {
+        let index = collect(try loadCouplingFixture("coupling_basic"))
+
+        #expect(index.entries.count == 6)
+        #expect(entry(index, "ServiceProtocol")?.declKind == .nominal(.protocol))
+        #expect(entry(index, "Outer")?.declKind == .nominal(.struct))
+        #expect(entry(index, "MyActor")?.declKind == .nominal(.actor))
+        #expect(entry(index, "Payload")?.declKind == .nominal(.enum))
+        // The typealias must not appear: coupling excludes typealiases.
+        #expect(index.entries.allSatisfy { !$0.name.contains("Alias") })
+    }
+
+    @Test("Nested types get dotted names")
+    func nestedTypeNames() throws {
+        let index = collect(try loadCouplingFixture("coupling_basic"))
+        #expect(entry(index, "Outer.Inner")?.declKind == .nominal(.struct))
+    }
+
+    @Test("Extensions resolve to the extended type name")
+    func extensionResolution() throws {
+        let index = collect(try loadCouplingFixture("coupling_basic"))
+        let ext = index.entries.first {
+            if case .ext = $0.declKind { return true }
+            return false
+        }
+        #expect(ext?.declKind == .ext(extendedTypeName: "Outer"))
+        #expect(ext?.resolvedTypeName == "Outer")
+    }
+
+    // MARK: - Suppression (fixture: coupling_suppressed.swift)
+
+    @Test("Type-level suppression is collected per declaration kind")
+    func suppressionPerKind() throws {
+        let index = collect(try loadCouplingFixture("coupling_suppressed"))
+
+        #expect(entry(index, "CouplingSuppressedClass")?.suppressedMetrics == [.coupling])
+        // Bare disable on enum/protocol yields coupling only: lcom4 is not
+        // applicable and must not leak into their sets.
+        #expect(entry(index, "BareSuppressedEnum")?.suppressedMetrics == [.coupling])
+        #expect(entry(index, "BareSuppressedProtocol")?.suppressedMetrics == [.coupling])
+        // Bare disable on a class/struct/actor covers all type-level metrics.
+        #expect(
+            entry(index, "BareSuppressedStruct")?.suppressedMetrics == [.lcom4, .coupling])
+    }
+
+    @Test("Unknown metric name fails closed")
+    func typoFailsClosed() throws {
+        let index = collect(try loadCouplingFixture("coupling_suppressed"))
+        #expect(entry(index, "TypoedClass")?.suppressedMetrics == [])
+    }
+
+    @Test("Suppression on an extension is ignored by design")
+    func extensionSuppressionIgnored() throws {
+        let index = collect(try loadCouplingFixture("coupling_suppressed"))
+        let ext = index.entries.first {
+            if case .ext = $0.declKind { return true }
+            return false
+        }
+        #expect(ext != nil)
+        #expect(ext?.suppressedMetrics == [])
+    }
+
+    // MARK: - Location lookup (inline sources: line numbers under test control)
+
+    @Test("innermostType resolves nesting to the innermost declaration")
+    func innermostNested() {
+        let source = """
+            struct Outer {
+                struct Inner {
+                    let value: Int
+                }
+                let outerValue: Int
+            }
+            """
+        let index = collect(source)
+        // Line 3 is inside Inner; line 5 is inside Outer only.
+        #expect(index.innermostType(line: 3, column: 9)?.name == "Outer.Inner")
+        #expect(index.innermostType(line: 5, column: 5)?.name == "Outer")
+    }
+
+    @Test("innermostType inside an extension resolves to the extended type")
+    func innermostInExtension() {
+        let source = """
+            struct Target {}
+            extension Target {
+                func helper() {}
+            }
+            """
+        let index = collect(source)
+        #expect(index.innermostType(line: 3, column: 10)?.resolvedTypeName == "Target")
+    }
+
+    @Test("Top-level positions and type-free files resolve to nil")
+    func topLevelIsNil() {
+        let source = """
+            import Foundation
+
+            func freeFunction() -> Int { 1 }
+
+            struct Later {}
+            """
+        let index = collect(source)
+        #expect(index.innermostType(line: 3, column: 6) == nil)
+
+        let empty = collect("func onlyFunctions() {}\n")
+        #expect(empty.entries.isEmpty)
+        #expect(empty.innermostType(line: 1, column: 1) == nil)
+    }
+
+    @Test("Range boundaries: declaration start is contained, past the end is not")
+    func rangeBoundaries() {
+        let source = """
+            struct Solo {
+                let x: Int
+            }
+            func after() {}
+            """
+        let index = collect(source)
+        // Column 1 of line 1 is the `struct` keyword itself.
+        #expect(index.innermostType(line: 1, column: 1)?.name == "Solo")
+        // The closing brace line, at its column, still belongs to the type.
+        #expect(index.innermostType(line: 3, column: 1)?.name == "Solo")
+        // The function after the type is outside.
+        #expect(index.innermostType(line: 4, column: 6) == nil)
+    }
+
+    @Test("Two declarations on one line are separated by column")
+    func sameLineDeclarations() {
+        let source = "struct A {}; struct B {}\n"
+        let index = collect(source)
+        #expect(index.innermostType(line: 1, column: 9)?.name == "A")
+        #expect(index.innermostType(line: 1, column: 22)?.name == "B")
+    }
+}

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -8,6 +8,7 @@ This directory contains user-facing documentation for swift-complexity.
 - [Usage Guide](usage.md) - Basic usage examples and CLI options
 - [Output Formats](output-formats.md) - Detailed explanation of output formats
 - [Complexity Metrics](complexity-metrics.md) - Understanding cyclomatic and cognitive complexity
+- [Type Coupling Metrics](coupling-metrics.md) - Fan-in, fan-out, instability, and the hotspot ranking
 - [CI Integration](ci-integration.md) - GitHub Action and Code Scanning setup
 
 ## Quick Start

--- a/docs/user-guide/ci-integration.md
+++ b/docs/user-guide/ci-integration.md
@@ -81,9 +81,14 @@ diff and in the repository's Security tab.
   Code Scanning even when the analysis step fails the build.
 - **Runner support**: macOS (arm64/x86_64) and Linux (x86_64). Linux arm64
   runners are not supported because no binary is published for them.
-- Per-type thresholds, inline suppression comments, and LCOM4 analysis all
-  work in CI exactly as they do locally — see the
-  [Usage Guide](usage.md) for details.
+- **Index-backed analyses (`--lcom4`, `--coupling`) do not work through the
+  action's zero-toolchain path**: they need the index store that only a
+  build of your package produces, and the action runs on bare runners
+  without building anything. To use them in CI, run the plain CLI in a job
+  that executes `swift build` first (see below), passing
+  `--index-store-path .build/debug/index/store`.
+- Per-type thresholds and inline suppression comments work in CI exactly as
+  they do locally — see the [Usage Guide](usage.md) for details.
 
 ## Without the Action (plain CLI)
 

--- a/docs/user-guide/coupling-metrics.md
+++ b/docs/user-guide/coupling-metrics.md
@@ -1,0 +1,132 @@
+# Type Coupling Metrics
+
+swift-complexity measures type-level coupling — how tangled your types are
+with each other — using the same IndexStoreDB semantic analysis that powers
+LCOM4. Together with complexity (readability of one function) and cohesion
+(consistency inside one type), coupling completes the classic
+"high cohesion, low coupling" pair.
+
+## The Metrics
+
+| Metric | Meaning | Reading |
+| ------ | ------- | ------- |
+| **fan-out** (efferent coupling) | How many other project types this type references | High = fragile: changes elsewhere break it |
+| **fan-in** (afferent coupling) | How many other project types reference this type | High = wide blast radius: changing it ripples |
+| **instability** | fan-out / (fan-in + fan-out), in 0...1 | 1.0 = free to change (entry points), 0.0 = must stay stable (core models) |
+
+Instability describes a type's *role*, not a defect. Healthy dependencies
+point from unstable code (CLI, UI) toward stable code (models, protocols) —
+the Stable Dependencies Principle. A type with no project-internal coupling
+at all has undefined instability, reported as `null`/`-`.
+
+## Usage
+
+Coupling analysis reads the index store your build produces:
+
+```bash
+swift build
+swift run swift-complexity Sources --coupling \
+  --index-store-path .build/debug/index/store --recursive
+```
+
+On Linux, `--toolchain-path` is also required (same as `--lcom4`). Both
+index-backed analyses share one index database, so combining
+`--lcom4 --coupling` costs only one database load.
+
+### Hotspots: which violation to fix first
+
+When a complexity threshold is set alongside `--coupling`, the text output
+ends with a hotspot ranking — complexity violations ordered by their
+enclosing type's fan-in, so the most dangerous code surfaces first:
+
+```console
+Hotspots (complexity violations x fan-in):
+| #  | Function             | Type                 | Fan-In | Cyclo | Cogn  |
++----+----------------------+----------------------+--------+-------+-------+
+| 1  | format(_:options:)   | OutputFormatter      | 3      | 12    | 18    |
+```
+
+A complex function inside a high fan-in type is both hard to change and
+depended upon by everything — fix those first.
+
+## Thresholds and Gating
+
+Coupling is **report-only by default**. Unlike cyclomatic complexity's
+established 10/20 convention, there is no standard for "too much fan-out",
+and sensible limits depend on codebase size — so swift-complexity ships no
+default. To gate, set explicit limits in `.swift-complexity.yml`:
+
+```yaml
+coupling:
+  fanOut: 15   # exit code 1 when a type's fan-out reaches 15
+  # fanIn: 25  # available, but start with fanOut (see below)
+```
+
+With a limit configured, violations use the same `>=` semantics as the
+complexity gate and appear in SARIF as `type_fan_out` / `type_fan_in`
+(warning, error at double the threshold).
+
+Prefer `fanOut` gating: a type that reaches into many others is usually a
+refactoring signal by itself. High fan-in alone is often *good* (a stable
+shared model); its risk only materializes combined with complexity, which is
+what the hotspot ranking evaluates.
+
+### Reference values
+
+Measured on real codebases with this feature (no telemetry is ever
+collected — these are one-off local measurements):
+
+| Codebase | Types | Median fan-out | Max fan-out | Attribution |
+| -------- | ----- | -------------- | ----------- | ----------- |
+| Alamofire | 186 | 1 | 48 (`Session`) | 96% |
+| swift-complexity (self) | 77 | 1 | 30 (`OutputFormatter`) | 99% |
+| GeoHashSwift | 8 | 1 | 4 (`GeoHash`) | 100% |
+
+The shape is consistent: most types couple to one or two others (median 1),
+while a handful of hub types carry most of the coupling — those hubs are
+where the fan-out numbers earn their keep.
+
+The stderr diagnostics line reports attribution quality for your run:
+
+```console
+coupling: 5925 refs (2783 project), 99% attributed (containedBy 2769, baseOf 2, location 10), 2 unattributed
+```
+
+## Suppression
+
+Exempt a type from coupling gating with an inline comment on its primary
+declaration (values are still reported; only the judgment is skipped):
+
+```swift
+// swift-complexity:disable coupling
+final class LegacyGodObject { ... }
+```
+
+A bare `// swift-complexity:disable` on a type suppresses every type-level
+metric (LCOM4 and coupling). Comments on `extension` declarations are
+ignored — suppression is scoped to the primary declaration so extensions
+cannot contradict it.
+
+## Semantics Details
+
+- **Population**: only types defined in the analyzed paths count, for both
+  ends of an edge. Standard library and framework references are excluded.
+- **Distinct types**: referencing one type many times counts once.
+- **Self references** never count.
+- **Extensions** attribute their members to the extended type.
+- **Nested types** are independent nodes (reported as `Outer.Inner`);
+  references between nested and outer types count as edges.
+- **Conformances** count as an edge from the conforming type to the
+  protocol. Protocols therefore accumulate fan-in from their conformers —
+  that is the healthy direction (abstractions are the stable side), not a
+  smell.
+- **Typealiases** are excluded in this version; references through an alias
+  are dropped and counted in the diagnostics.
+
+## Requirements and Limitations
+
+- Requires a **built index store** (`swift build` first). Index freshness is
+  your responsibility: analyze after building, not after editing.
+- Not available through the GitHub Action's zero-toolchain path (bare
+  runners have no build). Run it in a job that builds your package — see
+  [CI Integration](ci-integration.md).

--- a/docs/user-guide/output-formats.md
+++ b/docs/user-guide/output-formats.md
@@ -117,6 +117,12 @@ Structured data format for tool integration and programmatic processing.
 }
 ```
 
+With `--lcom4`, each file additionally carries `classCohesions` and
+`cohesionSummary`; with `--coupling`, `typeCouplings` (name, kind, `fanIn`,
+`fanOut`, optional `instability`, location) and `couplingSummary`. All of
+these keys are absent when their analysis is disabled, keeping the schema
+backward compatible.
+
 ### Usage
 
 ```bash
@@ -273,6 +279,12 @@ Each metric violation becomes one SARIF result:
 | `cyclomatic_complexity` | Cyclomatic complexity >= threshold | `warning`, `error` at 2x threshold |
 | `cognitive_complexity` | Cognitive complexity >= threshold | `warning`, `error` at 2x threshold |
 | `lcom4_cohesion` | LCOM4 >= 3 (low cohesion) | `warning`, `error` at LCOM4 >= 5 |
+| `type_fan_out` | Fan-out >= `coupling.fanOut` (config) | `warning`, `error` at 2x threshold |
+| `type_fan_in` | Fan-in >= `coupling.fanIn` (config) | `warning`, `error` at 2x threshold |
+
+Coupling rules fire only when `--coupling` runs with coupling thresholds
+configured in `.swift-complexity.yml`; without them coupling stays
+report-only. See [Type Coupling Metrics](coupling-metrics.md).
 
 Violation detection uses the same `>=` semantics as the exit-code check, so a
 non-empty `results` array always coincides with exit code 1.


### PR DESCRIPTION
Closes #46

## Summary

Adds semantic type-level coupling metrics powered by the IndexStoreDB integration that LCOM4 already uses. Together with complexity (readability) and cohesion (LCOM4), this completes the classic "high cohesion, low coupling" pair — to our knowledge no free Swift tool measures semantic coupling today.

- **fan-out / fan-in / instability** per nominal type (class/struct/enum/actor/protocol)
- **Hotspots**: complexity violations ranked by their enclosing type's fan-in — answers "which violation should I fix first"
- **Report-only by default**: gating (exit code 1 + SARIF `type_fan_out`/`type_fan_in`) activates only when `coupling:` thresholds are set in `.swift-complexity.yml`; no defaults ship because no established convention exists and sensible limits depend on codebase size. A stderr warning flags configured coupling thresholds when `--coupling` is not enabled, so a dropped flag cannot silently disarm the gate
- **Inline suppression**: `// swift-complexity:disable coupling` (type-level, fail-closed)

```bash
swift build
swift-complexity Sources --coupling --index-store-path .build/debug/index/store --recursive
```

## Design highlights

- **Hybrid attribution** (validated by a spike before implementation): one pass over `symbolOccurrences(inFilePath:)`, resolving each reference through a cascade — `containedBy`/`childOf` chains, `extendedBy` for extension members, `baseOf` for inheritance/conformance clauses, and syntax-range location as the last resort (e.g. enum case payload annotations carry no relations). Ambiguous names are dropped rather than guessed, and every reference lands in exactly one diagnostics bucket (invariant-tested).
- **Pure core**: `ReferenceGraphBuilder` consumes plain records, so the whole attribution algorithm is unit-tested without an index store (59 new unit tests). Real-index verification runs as new CI steps on both platforms with structural invariants (entry-point instability == 1.0, pure models fan-out == 0) plus an exit-code gate round trip.
- **Backward compatibility as a test**: output without `--coupling` is locked to golden fixtures generated at the branch point (canonical comparison; key order and Set element order are nondeterministic in JSONEncoder). The comparison runs on macOS only — the goldens are macOS-generated and Foundation's JSON encoding/parsing differs slightly on Linux, where behavior is covered by the CI integration steps instead. All JSON/config additions are additive.
- **Shared index store**: one `IndexStoreDB` serves LCOM4 and coupling (`IndexStoreService`), also fixing two latent issues — the database now waits until fully populated before the first query, and its path is keyed to the store so projects can't share one database.

## Dogfooding

The first self-run flagged the feature's own graph builder (cognitive 36 vs our CI threshold 15), which drove its decomposition into `DefinitionIndex` + cascading resolvers — the tool gated its own implementation.

## Real-world validation (local, no telemetry)

| Codebase | Types | Attribution | Notable |
|----------|-------|-------------|---------|
| Alamofire | 186 | 96% of 9,103 project refs | `Session` fan-out 48 — the known hub |
| swift-complexity | 77 | 99% of 2,783 | `OutputFormatter` fan-out 30 |
| GeoHashSwift | 8 | 100% of 280 | nested `GeoHash.Interval` attributed correctly |

Reference values are documented in the new [coupling-metrics guide](docs/user-guide/coupling-metrics.md) in lieu of default thresholds.

## Out of scope (per requirements)

Module-level coupling / dependency cycles, dead code detection (Periphery's domain), xcode/xml formats for coupling, and MCP exposure.

https://claude.ai/code/session_01N2gw9ApybKyt99cBsbSqvJ

