### PR TITLE
chore: Bump version to 1.3.0

### DIFF
--- a/Sources/SwiftComplexityCore/Version.swift
+++ b/Sources/SwiftComplexityCore/Version.swift
@@ -3,5 +3,5 @@
 /// Referenced by the CLI (`--version`), the MCP server handshake, and the
 /// SARIF `tool.driver.version` field so a release bump happens in one place.
 public enum SwiftComplexityVersion {
-    public static let current = "1.2.1"
+    public static let current = "1.3.0"
 }


### PR DESCRIPTION
Release preparation for v1.3.0 (type coupling metrics, #47).

- [x] Version.swift bumped to 1.3.0 (the v1.2.0 lesson: this constant is the release checklist item that got missed once)
- SARIF `tool.driver.version`, `--version`, and the MCP handshake all read this constant

After merge: tag `v1.3.0` -> release workflow (binaries, Homebrew, moving `v1` tag).

https://claude.ai/code/session_01N2gw9ApybKyt99cBsbSqvJ