### PR TITLE
Plugin discovers .swift-complexity.yml; align xcode diagnostics with exit-code semantics

### DIFF
--- a/Plugins/SwiftComplexityPlugin/Plugin.swift
+++ b/Plugins/SwiftComplexityPlugin/Plugin.swift
@@ -1,11 +1,51 @@
 import Foundation
 import PackagePlugin
 
+/// Locates the shared configuration file and decides threshold arguments so
+/// that plugin builds resolve thresholds exactly like direct CLI runs.
+enum ConfigDiscovery {
+    /// Keep candidates and their order in sync with
+    /// `ThresholdConfiguration.discover` in SwiftComplexityCore, which plugin
+    /// targets cannot import.
+    static let configFileNames = [".swift-complexity.yml", ".swift-complexity.yaml"]
+
+    static func configFile(inRoot root: URL) -> URL? {
+        for name in configFileNames {
+            let candidate = root.appendingPathComponent(name)
+            if FileManager.default.fileExists(atPath: candidate.path) {
+                return candidate
+            }
+        }
+        return nil
+    }
+
+    /// An explicit `SWIFT_COMPLEXITY_THRESHOLD` always wins; otherwise a
+    /// discovered config file resolves thresholds on its own, and the
+    /// historical default of 10 applies only when neither exists.
+    static func thresholdArguments(configFound: Bool, environmentThreshold: String?) -> [String] {
+        if let environmentThreshold, !environmentThreshold.isEmpty {
+            return ["--threshold", environmentThreshold]
+        }
+        return configFound ? [] : ["--threshold", "10"]
+    }
+
+    static func arguments(configURL: URL?, environmentThreshold: String?) -> [String] {
+        var arguments: [String] = []
+        if let configURL {
+            arguments.append(contentsOf: ["--config", configURL.path])
+        }
+        arguments.append(
+            contentsOf: thresholdArguments(
+                configFound: configURL != nil, environmentThreshold: environmentThreshold))
+        return arguments
+    }
+}
+
 @main
 struct SwiftComplexityPlugin: BuildToolPlugin {
     /// Main entry point for the build tool plugin
     func createBuildCommands(context: PluginContext, target: Target) async throws -> [Command] {
-        // Get the SwiftComplexityCLI executable  
+        // Get the SwiftComplexityCLI executable
         let swiftComplexityTool = try context.tool(named: "SwiftComplexityCLI")
 
         // Only process source targets
@@ -21,18 +61,28 @@ struct SwiftComplexityPlugin: BuildToolPlugin {
             return []
         }
 
-        // Build command arguments  
+        let configURL = ConfigDiscovery.configFile(inRoot: context.package.directoryURL)
+
+        // Build command arguments
         var arguments: [String] = [
             "--format", "xcode",  // Use Xcode diagnostics format
             "--recursive",
         ]
-
-        // Add threshold from environment or default
-        let threshold = ProcessInfo.processInfo.environment["SWIFT_COMPLEXITY_THRESHOLD"] ?? "10"
-        arguments.append(contentsOf: ["--threshold", threshold])
+        arguments.append(
+            contentsOf: ConfigDiscovery.arguments(
+                configURL: configURL,
+                environmentThreshold: ProcessInfo.processInfo
+                    .environment["SWIFT_COMPLEXITY_THRESHOLD"]))
 
         // Add target directory instead of individual files to utilize recursive option
         arguments.append(sourceTarget.directoryURL.path)
+
+        // Declaring the config file as an input re-runs the analysis when it
+        // changes and grants the sandboxed command read access to it.
+        var commandInputFiles = inputFiles.map { $0.url }
+        if let configURL {
+            commandInputFiles.append(configURL)
+        }
 
         // Create the build command
         // Note: prebuildCommand cannot use executables built from source
@@ -40,7 +90,7 @@ struct SwiftComplexityPlugin: BuildToolPlugin {
             displayName: "Analyzing Swift complexity for \(target.name)",
             executable: swiftComplexityTool.url,
             arguments: arguments,
-            inputFiles: inputFiles.map { $0.url },
+            inputFiles: commandInputFiles,
             outputFiles: []  // No output files as we're using stdout for diagnostics
         )
 
@@ -68,25 +118,36 @@ struct SwiftComplexityPlugin: BuildToolPlugin {
                 return []
             }
 
+            let configURL = ConfigDiscovery.configFile(
+                inRoot: context.xcodeProject.directoryURL)
+
             // Build command arguments
             var arguments: [String] = [
-                "--format", "xcode",  // Use Xcode diagnostics format
+                "--format", "xcode"  // Use Xcode diagnostics format
             ]
-
-            // Add threshold from Xcode build settings or default
-            let threshold = ProcessInfo.processInfo.environment["SWIFT_COMPLEXITY_THRESHOLD"] ?? "10"
-            arguments.append(contentsOf: ["--threshold", threshold])
+            arguments.append(
+                contentsOf: ConfigDiscovery.arguments(
+                    configURL: configURL,
+                    environmentThreshold: ProcessInfo.processInfo
+                        .environment["SWIFT_COMPLEXITY_THRESHOLD"]))
 
             // Add input file paths
             arguments.append(contentsOf: inputFiles.map { $0.url.path })
 
+            // Declaring the config file as an input re-runs the analysis when
+            // it changes and grants the sandboxed command read access to it.
+            var commandInputFiles = inputFiles.map { $0.url }
+            if let configURL {
+                commandInputFiles.append(configURL)
+            }
+
             // Create the build command
-            // Note: prebuildCommand cannot use executables built from source  
+            // Note: prebuildCommand cannot use executables built from source
             let command = Command.buildCommand(
                 displayName: "Analyzing Swift complexity for Xcode target \(target.displayName)",
                 executable: swiftComplexityTool.url,
                 arguments: arguments,
-                inputFiles: inputFiles.map { $0.url },
+                inputFiles: commandInputFiles,
                 outputFiles: []  // No output files as we're using stdout for diagnostics
             )
 

--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ import PackageDescription
 let package = Package(
     name: "YourProject",
     dependencies: [
-        .package(url: "https://github.com/fummicc1/swift-complexity.git", from: "1.0.0")
+        .package(url: "https://github.com/fummicc1/swift-complexity.git", from: "1.4.0")
     ],
     targets: [
         .target(
@@ -338,6 +338,9 @@ let package = Package(
 )
 ```
 
+The consuming package must declare `// swift-tools-version: 6.0` or later;
+SwiftPM skips the plugin's analysis command for older tools versions.
+
 ### Xcode Project Integration
 
 1. Add swift-complexity package to your Xcode project
@@ -346,21 +349,28 @@ let package = Package(
 
 ### Configuration
 
-**Xcode Build Settings:**
+The plugin discovers `.swift-complexity.yml` (or `.yaml`) automatically — at the
+package root for SwiftPM builds, or next to `.xcodeproj` for Xcode project
+builds — so plugin builds resolve per-type rules and `defaultThreshold` exactly
+like CLI and CI runs. Editing the file re-triggers the analysis.
 
-- Key: `SWIFT_COMPLEXITY_THRESHOLD`
-- Value: `15` (or any number, defaults to 10)
+Threshold precedence:
 
-**Environment Variable (SPM):**
+| `SWIFT_COMPLEXITY_THRESHOLD` env | Config file | Effective behavior |
+| --- | --- | --- |
+| set | any | `--threshold <env>` as fallback; per-type rules still win |
+| not set | present | The config alone decides |
+| not set | absent | `--threshold 10` (historical default) |
 
-- `SWIFT_COMPLEXITY_THRESHOLD=15`
+See the [Xcode Build Tool Plugin guide](docs/user-guide/xcode-plugin.md) for
+details and limitations (coupling/LCOM4 gates run in CI only).
 
 ### Features
 
 - **Real-time feedback**: Complexity warnings appear directly in Xcode editor
 - **Accurate positioning**: Errors show at exact function locations
 - **Build integration**: Builds fail when thresholds are exceeded
-- **Configurable per target**: Different thresholds for different modules
+- **Shared configuration**: The same `.swift-complexity.yml` drives CLI, CI, and Xcode
 
 ![Xcode Output](docs/imgs/xcode-output.png)
 

--- a/Sources/SwiftComplexityCore/Output/OutputFormatter.swift
+++ b/Sources/SwiftComplexityCore/Output/OutputFormatter.swift
@@ -427,8 +427,8 @@ public class OutputFormatter {
         let cyclomatic = function.cyclomaticComplexity
         let cognitive = function.cognitiveComplexity
 
-        let cyclomaticExceeds = !function.isSuppressed(.cyclomatic) && cyclomatic > threshold
-        let cognitiveExceeds = !function.isSuppressed(.cognitive) && cognitive > threshold
+        let cyclomaticExceeds = !function.isSuppressed(.cyclomatic) && cyclomatic >= threshold
+        let cognitiveExceeds = !function.isSuppressed(.cognitive) && cognitive >= threshold
 
         guard cyclomaticExceeds || cognitiveExceeds else { return nil }
 

--- a/Tests/SwiftComplexityCLITests/SwiftComplexityCLITests.swift
+++ b/Tests/SwiftComplexityCLITests/SwiftComplexityCLITests.swift
@@ -209,3 +209,121 @@ struct CLIConfigOptionTests {
         #expect(command.reportSuppressions == true)
     }
 }
+
+// MARK: - Config Execution Tests
+
+@Suite("CLI Config Execution", .tags(.cli, .integration))
+struct CLIConfigExecutionTests {
+
+    /// Writes a config file and a source file into a scratch directory and
+    /// hands both paths to `body`. The directory is removed afterwards.
+    private func withFixture(
+        yaml: String,
+        source: String,
+        _ body: (_ sourcePath: String, _ configPath: String) async throws -> Void
+    ) async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("swift-complexity-tests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let configURL = directory.appendingPathComponent(".swift-complexity.yml")
+        let sourceURL = directory.appendingPathComponent("Fixture.swift")
+        try yaml.write(to: configURL, atomically: true, encoding: .utf8)
+        try source.write(to: sourceURL, atomically: true, encoding: .utf8)
+
+        try await body(sourceURL.path, configURL.path)
+    }
+
+    /// Cyclomatic complexity of the generated method is 1 + `branches`.
+    private func source(typeName: String, branches: Int) -> String {
+        let ifs = (0..<branches)
+            .map { "        if flags[\($0)] { count += 1 }" }
+            .joined(separator: "\n")
+        return """
+            struct \(typeName) {
+                func find(flags: [Bool]) -> Int {
+                    var count = 0
+            \(ifs)
+                    return count
+                }
+            }
+            """
+    }
+
+    @Test("A rule threshold gates inclusively through the CLI")
+    func ruleThresholdGatesAtBoundary() async throws {
+        let yaml = """
+            rules:
+              - suffix: Repository
+                threshold: 5
+            """
+        // 4 branches -> cyclomatic 5, exactly on the rule threshold
+        try await withFixture(yaml: yaml, source: source(typeName: "UserRepository", branches: 4)) {
+            sourcePath, configPath in
+            let command = try ComplexityCommand.parse([sourcePath, "--config", configPath])
+            await #expect(throws: ExitCode.self) {
+                try await command.run()
+            }
+        }
+    }
+
+    @Test("Complexity below the rule threshold exits normally")
+    func ruleThresholdPassesBelowBoundary() async throws {
+        let yaml = """
+            rules:
+              - suffix: Repository
+                threshold: 5
+            """
+        try await withFixture(yaml: yaml, source: source(typeName: "UserRepository", branches: 3)) {
+            sourcePath, configPath in
+            let command = try ComplexityCommand.parse([sourcePath, "--config", configPath])
+            try await command.run()
+        }
+    }
+
+    @Test("--threshold overrides the config defaultThreshold as fallback")
+    func thresholdFlagOverridesConfigDefault() async throws {
+        let yaml = "defaultThreshold: 5"
+        // 6 branches -> cyclomatic 7: violates the config default of 5 but
+        // passes once --threshold 10 takes over as the fallback
+        try await withFixture(yaml: yaml, source: source(typeName: "SomeService", branches: 6)) {
+            sourcePath, configPath in
+            let gated = try ComplexityCommand.parse([sourcePath, "--config", configPath])
+            await #expect(throws: ExitCode.self) {
+                try await gated.run()
+            }
+
+            let overridden = try ComplexityCommand.parse([
+                sourcePath, "--config", configPath, "--threshold", "10",
+            ])
+            try await overridden.run()
+        }
+    }
+
+    @Test("Malformed YAML fails the run")
+    func malformedConfigFails() async throws {
+        let yaml = """
+            rules:
+              - suffix: Repository
+                 threshold: [broken
+            """
+        try await withFixture(yaml: yaml, source: source(typeName: "UserRepository", branches: 1)) {
+            sourcePath, configPath in
+            let command = try ComplexityCommand.parse([sourcePath, "--config", configPath])
+            await #expect(throws: ExitCode.self) {
+                try await command.run()
+            }
+        }
+    }
+
+    @Test("A missing config path fails the run")
+    func missingConfigPathFails() async throws {
+        let command = try ComplexityCommand.parse([
+            "Sources", "--config", "/nonexistent/swift-complexity-missing.yml",
+        ])
+        await #expect(throws: ExitCode.self) {
+            try await command.run()
+        }
+    }
+}

--- a/Tests/SwiftComplexityCoreTests/SwiftComplexityTests.swift
+++ b/Tests/SwiftComplexityCoreTests/SwiftComplexityTests.swift
@@ -788,6 +788,248 @@ struct OutputFormatterTests {
         #expect(output.isEmpty)
     }
 
+    @Test("Xcode diagnostics flag cyclomatic complexity equal to the threshold")
+    func xcodeDiagnosticsCyclomaticAtThreshold() {
+        // Given - the exit-code gate flags "value >= threshold", so the boundary
+        // must yield a visible diagnostic instead of a silent build failure
+        let functions = [
+            FunctionComplexity(
+                name: "atCyclomaticBoundary", signature: "func atCyclomaticBoundary()",
+                cyclomaticComplexity: 10, cognitiveComplexity: 1,
+                location: SourceLocation(line: 3, column: 1))
+        ]
+        let result = ComplexityResult(filePath: "test.swift", functions: functions)
+        let formatter = OutputFormatter()
+
+        // When
+        let output = formatter.format(
+            results: [result], format: .xcode, options: OutputOptions(threshold: 10))
+
+        // Then
+        #expect(output.contains("warning:"))
+        #expect(output.contains("'atCyclomaticBoundary'"))
+    }
+
+    @Test("Xcode diagnostics flag cognitive complexity equal to the threshold")
+    func xcodeDiagnosticsCognitiveAtThreshold() {
+        // Given
+        let functions = [
+            FunctionComplexity(
+                name: "atCognitiveBoundary", signature: "func atCognitiveBoundary()",
+                cyclomaticComplexity: 1, cognitiveComplexity: 10,
+                location: SourceLocation(line: 3, column: 1))
+        ]
+        let result = ComplexityResult(filePath: "test.swift", functions: functions)
+        let formatter = OutputFormatter()
+
+        // When
+        let output = formatter.format(
+            results: [result], format: .xcode, options: OutputOptions(threshold: 10))
+
+        // Then
+        #expect(output.contains("warning:"))
+        #expect(output.contains("'atCognitiveBoundary'"))
+    }
+
+    @Test("Xcode diagnostics stay silent below the threshold")
+    func xcodeDiagnosticsBelowThreshold() {
+        // Given
+        let functions = [
+            FunctionComplexity(
+                name: "belowBoundary", signature: "func belowBoundary()",
+                cyclomaticComplexity: 9, cognitiveComplexity: 9,
+                location: SourceLocation(line: 3, column: 1))
+        ]
+        let result = ComplexityResult(filePath: "test.swift", functions: functions)
+        let formatter = OutputFormatter()
+
+        // When
+        let output = formatter.format(
+            results: [result], format: .xcode, options: OutputOptions(threshold: 10))
+
+        // Then
+        #expect(output.isEmpty)
+    }
+
+    @Test("Xcode diagnostics keep flagging complexity above the threshold")
+    func xcodeDiagnosticsAboveThreshold() {
+        // Given
+        let functions = [
+            FunctionComplexity(
+                name: "aboveBoundary", signature: "func aboveBoundary()",
+                cyclomaticComplexity: 15, cognitiveComplexity: 3,
+                location: SourceLocation(line: 3, column: 1))
+        ]
+        let result = ComplexityResult(filePath: "test.swift", functions: functions)
+        let formatter = OutputFormatter()
+
+        // When
+        let output = formatter.format(
+            results: [result], format: .xcode, options: OutputOptions(threshold: 10))
+
+        // Then
+        #expect(output.contains("warning:"))
+        #expect(output.contains("'aboveBoundary'"))
+    }
+
+    @Test("Xcode diagnostics respect suppression at the threshold boundary")
+    func xcodeDiagnosticsSuppressedAtThreshold() {
+        // Given - cyclomatic sits exactly on the threshold but is suppressed
+        let functions = [
+            FunctionComplexity(
+                name: "suppressedBoundary", signature: "func suppressedBoundary()",
+                cyclomaticComplexity: 10, cognitiveComplexity: 1,
+                location: SourceLocation(line: 3, column: 1),
+                suppressedMetrics: [.cyclomatic])
+        ]
+        let result = ComplexityResult(filePath: "test.swift", functions: functions)
+        let formatter = OutputFormatter()
+
+        // When
+        let output = formatter.format(
+            results: [result], format: .xcode, options: OutputOptions(threshold: 10))
+
+        // Then
+        #expect(output.isEmpty)
+    }
+
+    @Test("Xcode severity stays warning at exactly twice the threshold")
+    func xcodeDiagnosticsSeverityAtTwiceThreshold() {
+        // Given - the error escalation rule is "> threshold * 2" and is
+        // deliberately untouched by the >= alignment of the base check
+        let functions = [
+            FunctionComplexity(
+                name: "twiceThreshold", signature: "func twiceThreshold()",
+                cyclomaticComplexity: 20, cognitiveComplexity: 1,
+                location: SourceLocation(line: 3, column: 1))
+        ]
+        let result = ComplexityResult(filePath: "test.swift", functions: functions)
+        let formatter = OutputFormatter()
+
+        // When
+        let output = formatter.format(
+            results: [result], format: .xcode, options: OutputOptions(threshold: 10))
+
+        // Then
+        #expect(output.contains("warning:"))
+        #expect(!output.contains("error:"))
+    }
+
+    @Test("Xcode severity escalates to error beyond twice the threshold")
+    func xcodeDiagnosticsSeverityBeyondTwiceThreshold() {
+        // Given
+        let functions = [
+            FunctionComplexity(
+                name: "beyondTwiceThreshold", signature: "func beyondTwiceThreshold()",
+                cyclomaticComplexity: 21, cognitiveComplexity: 1,
+                location: SourceLocation(line: 3, column: 1))
+        ]
+        let result = ComplexityResult(filePath: "test.swift", functions: functions)
+        let formatter = OutputFormatter()
+
+        // When
+        let output = formatter.format(
+            results: [result], format: .xcode, options: OutputOptions(threshold: 10))
+
+        // Then
+        #expect(output.contains("error:"))
+    }
+
+    @Test("Xcode diagnostics honor the minimum threshold of one")
+    func xcodeDiagnosticsMinimumThreshold() {
+        // Given
+        let functions = [
+            FunctionComplexity(
+                name: "minimal", signature: "func minimal()",
+                cyclomaticComplexity: 1, cognitiveComplexity: 0,
+                location: SourceLocation(line: 3, column: 1))
+        ]
+        let result = ComplexityResult(filePath: "test.swift", functions: functions)
+        let formatter = OutputFormatter()
+
+        // When
+        let output = formatter.format(
+            results: [result], format: .xcode, options: OutputOptions(threshold: 1))
+
+        // Then
+        #expect(output.contains("warning:"))
+    }
+
+    @Test("Xcode diagnostics apply per-type rule thresholds inclusively")
+    func xcodeDiagnosticsPerTypeRuleAtThreshold() {
+        // Given - a rule threshold of 5 must flag a matched type's function
+        // whose complexity is exactly 5
+        let configuration = ThresholdConfiguration(
+            rules: [ThresholdRule(suffix: "Repository", threshold: 5)])
+        let functions = [
+            FunctionComplexity(
+                name: "atRuleBoundary", signature: "func atRuleBoundary()",
+                cyclomaticComplexity: 5, cognitiveComplexity: 0,
+                location: SourceLocation(line: 3, column: 1),
+                enclosingTypeName: "UserRepository")
+        ]
+        let result = ComplexityResult(filePath: "test.swift", functions: functions)
+        let formatter = OutputFormatter()
+
+        // When
+        let output = formatter.format(
+            results: [result], format: .xcode,
+            options: OutputOptions(thresholdConfiguration: configuration))
+
+        // Then
+        #expect(output.contains("warning:"))
+        #expect(output.contains("'atRuleBoundary'"))
+    }
+
+    @Test("Xcode diagnostics agree with isExceeded for every function")
+    func xcodeDiagnosticsMatchIsExceeded() {
+        // Given - the invariant behind CLI/CI/Xcode alignment: a function fails
+        // the exit-code gate exactly when a diagnostic line is emitted for it
+        let configuration = ThresholdConfiguration(
+            defaultThreshold: 8,
+            rules: [ThresholdRule(suffix: "Repository", threshold: 5)])
+        let location = SourceLocation(line: 1, column: 1)
+        let functions = [
+            FunctionComplexity(
+                name: "repoAtRule", signature: "func repoAtRule()",
+                cyclomaticComplexity: 5, cognitiveComplexity: 0, location: location,
+                enclosingTypeName: "UserRepository"),
+            FunctionComplexity(
+                name: "repoBelowRule", signature: "func repoBelowRule()",
+                cyclomaticComplexity: 4, cognitiveComplexity: 0, location: location,
+                enclosingTypeName: "UserRepository"),
+            FunctionComplexity(
+                name: "serviceAtDefault", signature: "func serviceAtDefault()",
+                cyclomaticComplexity: 8, cognitiveComplexity: 0, location: location,
+                enclosingTypeName: "SomeService"),
+            FunctionComplexity(
+                name: "serviceBelowDefault", signature: "func serviceBelowDefault()",
+                cyclomaticComplexity: 7, cognitiveComplexity: 0, location: location,
+                enclosingTypeName: "SomeService"),
+            FunctionComplexity(
+                name: "freeAtDefault", signature: "func freeAtDefault()",
+                cyclomaticComplexity: 1, cognitiveComplexity: 8, location: location),
+            FunctionComplexity(
+                name: "freeBelowDefault", signature: "func freeBelowDefault()",
+                cyclomaticComplexity: 1, cognitiveComplexity: 1, location: location),
+        ]
+        let result = ComplexityResult(filePath: "test.swift", functions: functions)
+        let formatter = OutputFormatter()
+
+        // When
+        let output = formatter.format(
+            results: [result], format: .xcode,
+            options: OutputOptions(thresholdConfiguration: configuration))
+
+        // Then
+        for function in functions {
+            #expect(
+                output.contains("'\(function.name)'")
+                    == configuration.isExceeded(function, fallback: nil),
+                "\(function.name) must appear in xcode output exactly when it fails the gate")
+        }
+    }
+
     @Test("SARIF format reports one result per violated metric")
     func sarifFormat() throws {
         // Given

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -10,6 +10,7 @@ This directory contains user-facing documentation for swift-complexity.
 - [Complexity Metrics](complexity-metrics.md) - Understanding cyclomatic and cognitive complexity
 - [Type Coupling Metrics](coupling-metrics.md) - Fan-in, fan-out, instability, and the hotspot ranking
 - [CI Integration](ci-integration.md) - GitHub Action and Code Scanning setup
+- [Xcode Build Tool Plugin](xcode-plugin.md) - In-editor diagnostics on every build
 
 ## Quick Start
 

--- a/docs/user-guide/xcode-plugin.md
+++ b/docs/user-guide/xcode-plugin.md
@@ -1,0 +1,83 @@
+# Xcode Build Tool Plugin
+
+`SwiftComplexityPlugin` runs the complexity analysis on every build and surfaces
+violations as warnings and errors directly in Xcode's issue navigator, using the
+same configuration and the same judgment as the CLI and CI.
+
+## Requirements
+
+- The package that applies the plugin must declare `// swift-tools-version: 6.0`
+  or later. SwiftPM skips the analysis for older tools versions because the
+  plugin's build command declares no output files.
+- macOS 14 or later (inherited from swift-complexity's platform requirement).
+
+## Setup
+
+### Swift Package Manager
+
+```swift
+// swift-tools-version: 6.2
+import PackageDescription
+
+let package = Package(
+    name: "YourProject",
+    dependencies: [
+        .package(url: "https://github.com/fummicc1/swift-complexity.git", from: "1.4.0")
+    ],
+    targets: [
+        .target(
+            name: "YourTarget",
+            plugins: [
+                .plugin(name: "SwiftComplexityPlugin", package: "swift-complexity")
+            ]
+        )
+    ]
+)
+```
+
+### Xcode Project
+
+1. Add the swift-complexity package to your Xcode project
+2. In Build Phases, add "SwiftComplexityPlugin" to Run Build Tool Plug-ins
+
+## Configuration
+
+### `.swift-complexity.yml` discovery
+
+The plugin looks for `.swift-complexity.yml` (then `.swift-complexity.yaml`) and
+passes it to the analysis, so plugin builds resolve thresholds exactly like
+`swift-complexity --config` runs:
+
+- **SwiftPM builds**: at the package root (next to `Package.swift`)
+- **Xcode project builds**: at the project root (next to `.xcodeproj`)
+
+Editing the file re-triggers the analysis on the next build.
+
+```yaml
+defaultThreshold: 10
+rules:
+  - suffix: Repository
+    threshold: 8
+```
+
+### Threshold precedence
+
+| `SWIFT_COMPLEXITY_THRESHOLD` env | Config file | Effective behavior |
+| --- | --- | --- |
+| set | any | `--threshold <env>` — overrides the config's `defaultThreshold` for types no rule matches; per-type rules still win |
+| not set | present | The config alone decides (`rules`, then `defaultThreshold`) |
+| not set | absent | `--threshold 10` (historical default) |
+
+A function is flagged when its cyclomatic or cognitive complexity **reaches** the
+resolved threshold (`value >= threshold`), identically in the CLI exit code, SARIF,
+and Xcode diagnostics. Warnings escalate to errors above twice the threshold.
+
+## Limitations
+
+- **Coupling and LCOM4 gates do not run in plugin builds** — they need an index
+  store, which is not available inside a build tool command. Run them in CI
+  instead (see [CI Integration](ci-integration.md)). If your config contains a
+  `coupling:` block, the analysis prints a note to the build log saying the
+  coupling gate is not active in this run; this is expected.
+- Builds fail (`exit 1`) when a threshold violation exists, matching the CLI's
+  gating behavior.

--- a/docs/user-guide/xcode-plugin.md
+++ b/docs/user-guide/xcode-plugin.md
@@ -39,6 +39,9 @@ let package = Package(
 
 1. Add the swift-complexity package to your Xcode project
 2. In Build Phases, add "SwiftComplexityPlugin" to Run Build Tool Plug-ins
+3. On the first build, Xcode asks you to trust the plugin — choose "Trust & Enable".
+   For command-line and CI builds, pass `-skipPackagePluginValidation` to
+   `xcodebuild`, otherwise the build stops at "Validate plug-in".
 
 ## Configuration
 


### PR DESCRIPTION
## Summary

Roadmap Outcome 5 (unified configuration): the Build Tool Plugin now discovers `.swift-complexity.yml` and hands it to the CLI, so SwiftPM/Xcode builds report the same violation set as direct CLI runs and CI.

- **Plugin config discovery**: `.swift-complexity.yml` / `.yaml` is discovered at the package root (SwiftPM) or project root (Xcode) and passed via `--config`. The file is declared as a command input, so edits re-trigger analysis and the sandboxed command may read it.
- **Threshold precedence**: an explicit `SWIFT_COMPLEXITY_THRESHOLD` env var still wins as the fallback threshold; with a config present and no env var, threshold resolution is left entirely to the config (matching CLI semantics); with neither, the historical `--threshold 10` default keeps old behavior.
- **`>=` alignment**: the xcode format required a strict `>` while the exit-code gate, filtering, and SARIF all use `>=`. A function sitting exactly on the threshold failed the build with no visible diagnostic. The xcode check now uses `>=`; an invariant test pins "a function appears in xcode output exactly when it fails the gate".
- **Docs**: README plugin section rewritten; new `docs/user-guide/xcode-plugin.md` (incl. the Xcode "Trust & Enable" / `-skipPackagePluginValidation` step).

## Behavior changes

1. With a config file present and no env var, the plugin no longer passes `--threshold 10`; types matched by no rule are judged by the config's `defaultThreshold` (or not at all if absent).
2. Boundary functions (complexity == threshold) now produce xcode diagnostics.

## Notes

- Pre-existing limitation, now documented: SwiftPM skips output-less build commands for consumers below swift-tools-version 6.0, so the plugin has never run for 5.x consumers. The plugin product also requires macOS 14 on the consumer. A real tools-5.5 / macOS 11 library (SimpleRoulette) needed both bumped to adopt the plugin — candidate follow-up: declare a dummy output file to lift the tools-version half.
- Coupling/LCOM4 gates still run in CI only (index store unavailable in build commands); a config with `coupling:` produces an informational note in the build log.

## Test plan

- 15 new automated tests (formatter boundary/severity/suppression/invariant + CLI precedence and failure paths); 192 total pass.
- Manual E2E on a fixture package (tools 6.2): no-yml backward compat, boundary rule parity with direct CLI (byte-identical diagnostic, exit 1), env override, yml edit re-analysis, malformed yml failure, coupling note. All pass.
- **Real-project verification (SimpleRoulette, consuming this branch via git)**:
  - SwiftPM route: `swift build` emits the same 3 diagnostics as the direct CLI byte-for-byte, including a boundary function at a per-type rule threshold, and exits 1.
  - Xcode project route (`XcodeBuildToolPlugin`, `Examples/DemoApp.xcodeproj`, macOS target): the plugin discovers the yml next to `.xcodeproj`, flags `ContentView.body` at the boundary (`Cyclomatic: 3, Threshold: 3`), and the failing command is the Xcode-target analysis with no other errors. In the same build, the SimpleRoulette package target resolved its own package-root yml independently — both roots, both configs correct.

https://claude.ai/code/session_01N2gw9ApybKyt99cBsbSqvJ