### PR TITLE
chore: Bump version to 1.4.0

### DIFF
--- a/Sources/SwiftComplexityCore/Version.swift
+++ b/Sources/SwiftComplexityCore/Version.swift
@@ -3,5 +3,5 @@
 /// Referenced by the CLI (`--version`), the MCP server handshake, and the
 /// SARIF `tool.driver.version` field so a release bump happens in one place.
 public enum SwiftComplexityVersion {
-    public static let current = "1.3.0"
+    public static let current = "1.4.0"
 }


### PR DESCRIPTION
## Summary

Bump `SwiftComplexityVersion.current` to 1.4.0 ahead of tagging `v1.4.0`.

This release ships #49: the Build Tool Plugin discovers `.swift-complexity.yml` (SwiftPM package root / Xcode project root) and the xcode diagnostics threshold check is aligned to `>=` with the exit-code gate.

## Release notes (for the GitHub Release body)

**Added**
- The Xcode/SwiftPM Build Tool Plugin discovers `.swift-complexity.yml` / `.yaml` at the package root (SwiftPM) or project root (Xcode) and passes it to the analysis, so plugin builds resolve per-type rules and `defaultThreshold` exactly like CLI and CI runs. Editing the file re-triggers analysis.
- New user guide page: `docs/user-guide/xcode-plugin.md` (setup, threshold precedence, plugin trust step, limitations).

**Changed (behavior)**
- With a config file present and no `SWIFT_COMPLEXITY_THRESHOLD`, the plugin no longer passes `--threshold 10`; threshold resolution is left to the config.
- Xcode-format diagnostics now flag `complexity >= threshold` (was `>`), matching the exit code, filtering, and SARIF. Functions sitting exactly on the threshold now show a diagnostic instead of silently failing the build.

**Notes**
- Consumers of the plugin must use swift-tools-version 6.0+ (SwiftPM skips output-less build commands on older tools versions — pre-existing, now documented) and macOS 14+.
- Coupling/LCOM4 gates still run in CI only.

https://claude.ai/code/session_01N2gw9ApybKyt99cBsbSqvJ