### PR TITLE
Repair the debug website build environment; document its scope and commit pinning

### DIFF
--- a/.github/workflows/debug-website.yml
+++ b/.github/workflows/debug-website.yml
@@ -1,0 +1,101 @@
+name: Debug Website
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "debug-website/**"
+      - ".github/workflows/debug-website.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "debug-website/**"
+      - ".github/workflows/debug-website.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  backend-image:
+    name: Backend container image
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      # Build the Dockerfile itself rather than running a native swift build:
+      # the image is what Cloudflare Containers deploys, and its toolchain
+      # version and C++ include flags are what drifted from the core package.
+      - name: Build image
+        run: docker build -t swift-complexity-api debug-website/backend/app
+
+      - name: Smoke test the API
+        run: |
+          docker run -d --name api -p 8080:8080 swift-complexity-api
+          for _ in $(seq 1 30); do
+            curl -fsS http://localhost:8080/health > /dev/null && break
+            sleep 1
+          done
+          curl -fsS http://localhost:8080/health | jq -e '.status == "ok"'
+          curl -fsS -X POST http://localhost:8080/api/v1/analyze \
+            -H 'Content-Type: application/json' \
+            -d '{"code":"func f(a: Bool) { if a { print(1) } }","fileName":"x.swift"}' \
+            | jq -e '.result.functions[0].cyclomaticComplexity == 2'
+
+      - name: Show container logs
+        if: always()
+        run: docker logs api || true
+
+  frontend:
+    name: Frontend
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        working-directory: debug-website/frontend
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: debug-website/frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type check
+        run: npm run type-check
+
+      - name: Build
+        run: npm run build
+
+  worker:
+    name: Worker
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        working-directory: debug-website/backend/worker
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: debug-website/backend/worker/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type check
+        run: npm run type-check

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A command-line tool to analyze Swift code complexity and quality metrics using s
 - **Multiple Complexity Metrics**: Supports cyclomatic complexity, cognitive complexity, LCOM4 cohesion, and type coupling analysis
 - **LCOM4 Class Cohesion**: High-precision class cohesion measurement using IndexStore-DB semantic analysis
 - **Type Coupling Metrics**: Semantic fan-in / fan-out / instability per type, plus a hotspot ranking that orders complexity violations by their blast radius ([details](docs/user-guide/coupling-metrics.md))
-- **Web-based Debug Interface**: Interactive browser-based complexity analyzer ([Try it online](https://swift-complexity.fummicc1.dev))
+- **Web-based Debug Interface**: Interactive browser-based analyzer for the syntax-only metrics — cyclomatic, cognitive, and inline suppression ([Try it online](https://swift-complexity.fummicc1.dev)); index-backed metrics stay CLI-only
 - **Xcode Integration**: Seamless integration with Xcode via Build Tool Plugin for complexity feedback during build phase
 - **Xcode Diagnostics**: Display complexity warnings and errors directly in Xcode editor with accurate line numbers
 - **Configurable Thresholds**: Set custom complexity thresholds via Xcode Build Settings or environment variables
@@ -27,6 +27,8 @@ A command-line tool to analyze Swift code complexity and quality metrics using s
 ### Web Interface (Try Online)
 
 Visit [swift-complexity.fummicc1.dev](https://swift-complexity.fummicc1.dev) to analyze Swift code instantly in your browser.
+
+The web interface is a debugging aid for the syntax-based metrics (cyclomatic and cognitive complexity, inline suppression). LCOM4 and type coupling need the index store of a compiled project, so they are available only in the CLI — see [Debug Website](#debug-website) for the full scope.
 
 ![Web Interface](docs/imgs/website.png)
 
@@ -204,7 +206,7 @@ See the [Usage Guide](docs/user-guide/usage.md#per-type-complexity-thresholds) f
 - **[Output Formats](docs/user-guide/output-formats.md)**: Text, JSON, XML, Xcode diagnostics, and SARIF format specifications
 - **[CI Integration](docs/user-guide/ci-integration.md)**: GitHub Action and Code Scanning setup
 - **[Development Guide](docs/development/DEVELOPMENT.md)**: Setup for contributors
-- **[Debug Website](debug-website/)**: Web-based interactive analyzer documentation
+- **[Debug Website](debug-website/)**: Web-based interactive analyzer for the syntax-only metrics (setup, API, and scope)
 
 ## Package Structure
 
@@ -222,6 +224,8 @@ Unified package with multiple components:
 - **Frontend**: Next.js application deployed on Cloudflare Workers
 - **Backend**: Vapor 4 API containerized on Cloudflare Containers.
 - **Live Demo**: [swift-complexity.fummicc1.dev](https://swift-complexity.fummicc1.dev)
+- **Scope**: Intentionally limited to what can be computed from source text alone — cyclomatic and cognitive complexity, `// swift-complexity:disable` suppression, and every CLI output format via the API. It exists to check analysis results quickly, not to replace the CLI.
+- **Not available on the web**: LCOM4 and type coupling (they read the index store that only `swift build` of a whole project produces), `.swift-complexity.yml` per-type thresholds, and the Xcode plugin / CI integrations. See [debug-website/README.md](debug-website/README.md#-scope) for details.
 
 ## Usage Examples
 
@@ -325,7 +329,11 @@ import PackageDescription
 let package = Package(
     name: "YourProject",
     dependencies: [
-        .package(url: "https://github.com/fummicc1/swift-complexity.git", from: "1.4.0")
+        // v1.4.0 — pin the release commit; a version requirement does not resolve (see below)
+        .package(
+            url: "https://github.com/fummicc1/swift-complexity.git",
+            revision: "25f4446f7eb0cb530bebbaaecaef37418c28f8b6"
+        )
     ],
     targets: [
         .target(
@@ -338,12 +346,19 @@ let package = Package(
 )
 ```
 
+Pin the release commit rather than a version: swift-complexity depends on the
+untagged `indexstore-db`, and SwiftPM rejects a version requirement (`from:` /
+`exact:`) on a package with such a dependency. Each release's commit is listed on
+the [Releases](https://github.com/fummicc1/swift-complexity/releases) page.
+
 The consuming package must declare `// swift-tools-version: 6.0` or later;
 SwiftPM skips the plugin's analysis command for older tools versions.
 
 ### Xcode Project Integration
 
-1. Add swift-complexity package to your Xcode project
+1. Add swift-complexity package to your Xcode project with Dependency Rule
+   **Commit** (the release commit above) or **Branch** — a version rule fails to
+   resolve for the reason described above
 2. In Build Phases, add "SwiftComplexityPlugin" to Run Build Tool Plug-ins
 3. Configure threshold in Build Settings (optional)
 

--- a/debug-website/README.md
+++ b/debug-website/README.md
@@ -8,8 +8,33 @@ Web-based debugging interface for [swift-complexity](https://github.com/fummicc1
 - **Real-time Analysis**: Instant complexity calculation for Swift code
 - **Multiple Metrics**: Both cyclomatic and cognitive complexity
 - **Visual Results**: Color-coded complexity scores and summary statistics
-- **Multiple Output Formats**: JSON, XML, Text, and Xcode formats
+- **Multiple Output Formats**: Text, JSON, XML, Xcode, and SARIF via the API
 - **Responsive Design**: Works on desktop and mobile devices
+
+## 🧭 Scope
+
+The website exists to check swift-complexity's analysis results quickly in a browser
+(see [#11](https://github.com/fummicc1/swift-complexity/issues/11)). It deliberately
+covers only the analyses that can be computed from source text alone; the CLI stays
+the reference implementation.
+
+**Supported**
+
+- Cyclomatic and cognitive complexity per function, using the same calculators as the CLI
+- `// swift-complexity:disable` inline suppression, reported as `suppressedMetrics` in the API response
+- Every CLI output format via the API's `format` parameter, plus `threshold` filtering
+
+**Not supported, by design**
+
+- **LCOM4 and type coupling**: both read the index store that only `swift build` of a
+  whole project produces. A pasted snippet has no index, so these stay CLI-only.
+- **`.swift-complexity.yml` per-type thresholds**: the API takes a single `threshold`
+  value; there is no config input.
+- **Xcode Build Tool Plugin and GitHub Action**: separate entry points over the same
+  core, with nothing to run in a browser.
+
+New web features are added only when they fit this rule; anything that needs a build
+or an index belongs to the CLI.
 
 ## 🏗️ Architecture
 
@@ -23,8 +48,8 @@ Web-based debugging interface for [swift-complexity](https://github.com/fummicc1
 
 ### Backend (Vapor)
 - **Framework**: Vapor 4
-- **Language**: Swift 6.1
-- **Core Library**: SwiftComplexityCore
+- **Language**: Swift 6.2
+- **Core Library**: SwiftComplexityCore, pinned to a release commit in `backend/app/Package.swift`
 - **Deployment**: Cloudflare Containers
 
 ## 🚀 Getting Started
@@ -32,7 +57,7 @@ Web-based debugging interface for [swift-complexity](https://github.com/fummicc1
 ### Prerequisites
 
 - Node.js 20+ (for frontend)
-- Swift 6.1+ (for backend)
+- Swift 6.2+ (for backend; required by the swift-complexity core package)
 - Docker (for containerized deployment)
 
 ### Local Development
@@ -40,13 +65,23 @@ Web-based debugging interface for [swift-complexity](https://github.com/fummicc1
 #### Backend
 
 ```bash
-cd debug-website/backend
+cd debug-website/backend/app
 
 # Install dependencies
 swift package resolve
 
 # Run development server
 swift run App serve --hostname 0.0.0.0 --port 8080
+```
+
+On Linux, pass the same C++ include flags the Dockerfile uses, because
+indexstore-db (a SwiftComplexityCore dependency) includes libdispatch headers
+that live under the toolchain's `lib/swift`:
+
+```bash
+swift build \
+  -Xcxx -I<toolchain>/usr/lib/swift \
+  -Xcxx -I<toolchain>/usr/lib/swift/Block
 ```
 
 The backend API will be available at `http://localhost:8080`.
@@ -77,7 +112,7 @@ The frontend will be available at `http://localhost:3000` (npm run dev) or `http
 #### Backend Tests
 
 ```bash
-cd debug-website/backend
+cd debug-website/backend/app
 swift test
 ```
 
@@ -216,7 +251,9 @@ The backend includes a multi-stage Dockerfile optimized for Cloudflare Container
 
 ## 📝 Development Notes
 
-- Backend uses Swift 6.1 with strict concurrency checking
+- Backend uses Swift 6.2 with strict concurrency checking
+- Backend pins swift-complexity to a release commit (`revision:` in `backend/app/Package.swift` — SwiftPM rejects a version requirement because the core depends on the untagged indexstore-db); move the revision after a core release to pick up analyzer changes, then rebuild and redeploy the container
+- `.github/workflows/debug-website.yml` builds the container image, smoke-tests the API, and type-checks the frontend and worker whenever `debug-website/` changes
 - Frontend uses React 19 with Next.js App Router
 - OpenNext adapter (`@opennextjs/cloudflare`) enables Next.js on Cloudflare Workers
 - Image optimization is disabled for Workers compatibility

--- a/debug-website/backend/app/.containerignore
+++ b/debug-website/backend/app/.containerignore
@@ -3,7 +3,6 @@
 *.xcodeproj
 *.xcworkspace
 .swiftpm/
-Package.resolved
 xcuserdata/
 DerivedData/
 .git/

--- a/debug-website/backend/app/.dockerignore
+++ b/debug-website/backend/app/.dockerignore
@@ -5,7 +5,6 @@
 
 # Swift Package Manager
 .swiftpm/
-Package.resolved
 
 # Xcode
 xcuserdata/

--- a/debug-website/backend/app/Dockerfile
+++ b/debug-website/backend/app/Dockerfile
@@ -1,7 +1,7 @@
 # ================================
 # Build stage
 # ================================
-FROM swift:6.1-jammy AS build
+FROM swift:6.2-jammy AS build
 
 # Install OS updates
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true \
@@ -16,11 +16,16 @@ WORKDIR /build
 
 # Copy only the backend app directory
 # The build context should be the backend app directory (. from this Dockerfile)
-# SwiftComplexityCore will be downloaded from GitHub via Package.swift
+# SwiftComplexityCore is fetched from GitHub at the commit pinned in Package.resolved
 COPY . .
 
-# Build with optimizations
-RUN swift build -c release --static-swift-stdlib
+# Build with optimizations.
+# The two -Xcxx flags are required on Linux: indexstore-db (a SwiftComplexityCore
+# dependency) has C++ targets that include libdispatch's dispatch.h and Block.h,
+# which live under the toolchain's lib/swift instead of clang's default search path.
+RUN swift build -c release --static-swift-stdlib \
+      -Xcxx -I/usr/lib/swift \
+      -Xcxx -I/usr/lib/swift/Block
 
 # ================================
 # Run stage

--- a/debug-website/backend/app/Package.resolved
+++ b/debug-website/backend/app/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "211034fb129e767e5019e18ad7be4ea13bb85014e236283f0206fac4fe8c821b",
+  "originHash" : "38e66a606f3961dabb904ed360245be84b11b9fe45e24dc7d857809c0b8cc4c6",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -26,6 +26,24 @@
       "state" : {
         "revision" : "742f624a998cba2a9e653d9b1e91ad3f3a5dff6b",
         "version" : "4.15.2"
+      }
+    },
+    {
+      "identity" : "eventsource",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattt/eventsource.git",
+      "state" : {
+        "revision" : "86b5096ac59ab46e66bd1f6377c604bc1dab0bc2",
+        "version" : "1.5.1"
+      }
+    },
+    {
+      "identity" : "indexstore-db",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/indexstore-db",
+      "state" : {
+        "branch" : "main",
+        "revision" : "539c604659453322c692e57444a3ef051f05cc9a"
       }
     },
     {
@@ -58,10 +76,10 @@
     {
       "identity" : "swift-argument-parser",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-argument-parser",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
       "state" : {
-        "revision" : "cdd0ef3755280949551dc26dee5de9ddeda89f54",
-        "version" : "1.6.2"
+        "revision" : "6a52f3251125d74daf04fcbd5e6f08a75d074382",
+        "version" : "1.8.2"
       }
     },
     {
@@ -110,6 +128,14 @@
       }
     },
     {
+      "identity" : "swift-complexity",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/fummicc1/swift-complexity.git",
+      "state" : {
+        "revision" : "25f4446f7eb0cb530bebbaaecaef37418c28f8b6"
+      }
+    },
+    {
       "identity" : "swift-crypto",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
@@ -143,6 +169,15 @@
       "state" : {
         "revision" : "45eb0224913ea070ec4fba17291b9e7ecf4749ca",
         "version" : "1.5.1"
+      }
+    },
+    {
+      "identity" : "swift-lmdb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-lmdb.git",
+      "state" : {
+        "branch" : "main",
+        "revision" : "a4bc87807721c1fd114bf35464457e2db0d0e6c0"
       }
     },
     {
@@ -218,6 +253,15 @@
       }
     },
     {
+      "identity" : "swift-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/modelcontextprotocol/swift-sdk.git",
+      "state" : {
+        "revision" : "a0ae212ebf6eab5f754c3129608bc5557637e605",
+        "version" : "0.12.1"
+      }
+    },
+    {
       "identity" : "swift-service-context",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-service-context.git",
@@ -238,7 +282,7 @@
     {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-syntax.git",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
       "state" : {
         "revision" : "0687f71944021d616d34d922343dcef086855920",
         "version" : "600.0.1"
@@ -269,6 +313,15 @@
       "state" : {
         "revision" : "8666c92dbbb3c8eefc8008c9c8dcf50bfd302167",
         "version" : "2.16.1"
+      }
+    },
+    {
+      "identity" : "yams",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/Yams.git",
+      "state" : {
+        "revision" : "3d6871d5b4a5cd519adf233fbb576e0a2af71c17",
+        "version" : "5.4.0"
       }
     }
   ],

--- a/debug-website/backend/app/Package.swift
+++ b/debug-website/backend/app/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.1
+// swift-tools-version: 6.2
 import PackageDescription
 
 let package = Package(
@@ -9,7 +9,12 @@ let package = Package(
     dependencies: [
         // Vapor web framework
         .package(url: "https://github.com/vapor/vapor.git", from: "4.99.0"),
-        .package(url: "https://github.com/fummicc1/swift-complexity.git", branch: "main"),
+        // v1.4.0. A version requirement is rejected by SwiftPM because swift-complexity
+        // depends on the untagged indexstore-db, so the release commit is pinned instead.
+        .package(
+            url: "https://github.com/fummicc1/swift-complexity.git",
+            revision: "25f4446f7eb0cb530bebbaaecaef37418c28f8b6"
+        ),
     ],
     targets: [
         .executableTarget(

--- a/debug-website/backend/app/Sources/App/Controllers/AnalyzerController.swift
+++ b/debug-website/backend/app/Sources/App/Controllers/AnalyzerController.swift
@@ -21,7 +21,7 @@ struct AnalyzerController: RouteCollection {
         let sourceFile = Parser.parse(source: request.code)
 
         // Analyze complexity
-        let analyzer = ComplexityAnalyzer()
+        let analyzer = try ComplexityAnalyzer()
         let result = try await analyzer.analyze(
             sourceFile: sourceFile,
             filePath: request.fileName
@@ -54,7 +54,7 @@ struct AnalyzerController: RouteCollection {
     func batchAnalyze(req: Request) async throws -> BatchAnalyzeResponse {
         let request = try req.content.decode(BatchAnalyzeRequest.self)
 
-        let analyzer = ComplexityAnalyzer()
+        let analyzer = try ComplexityAnalyzer()
 
         let results = try await withThrowingTaskGroup(of: ComplexityResult.self) { group in
             for file in request.files {

--- a/debug-website/backend/app/Tests/AppTests/AnalyzerControllerTests.swift
+++ b/debug-website/backend/app/Tests/AppTests/AnalyzerControllerTests.swift
@@ -40,7 +40,7 @@ final class AnalyzerControllerTests: XCTestCase {
 
         try await app.test(.POST, "api/v1/analyze", beforeRequest: { req in
             try req.content.encode(request)
-        }, afterResponse: { res async in
+        }, afterResponse: { res async throws in
             XCTAssertEqual(res.status, .ok)
             let response = try res.content.decode(AnalyzeResponse.self)
             XCTAssertEqual(response.result.functions.count, 1)
@@ -59,7 +59,7 @@ final class AnalyzerControllerTests: XCTestCase {
 
         try await app.test(.POST, "api/v1/analyze", beforeRequest: { req in
             try req.content.encode(request)
-        }, afterResponse: { res async in
+        }, afterResponse: { res async throws in
             XCTAssertEqual(res.status, .ok)
             let response = try res.content.decode(FormatResponse.self)
             XCTAssertTrue(response.formatted.contains("\"filePath\""))
@@ -76,7 +76,7 @@ final class AnalyzerControllerTests: XCTestCase {
 
         try await app.test(.POST, "api/v1/batch-analyze", beforeRequest: { req in
             try req.content.encode(request)
-        }, afterResponse: { res async in
+        }, afterResponse: { res async throws in
             XCTAssertEqual(res.status, .ok)
             let response = try res.content.decode(BatchAnalyzeResponse.self)
             XCTAssertEqual(response.results.count, 2)

--- a/debug-website/frontend/package-lock.json
+++ b/debug-website/frontend/package-lock.json
@@ -8258,10 +8258,33 @@
         "@noble/ciphers": "^1.0.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
+      "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.3",
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/runtime": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.7.1.tgz",
       "integrity": "sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
+      "integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -9473,6 +9496,19 @@
         "monaco-editor": ">= 0.25.0 < 1",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.10.0"
       }
     },
     "node_modules/@next/env": {
@@ -11607,6 +11643,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "dev": true,
@@ -11666,6 +11713,14 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.47.0",
@@ -11925,6 +11980,34 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@unrs/resolver-binding-android-arm-eabi": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
+      "integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-android-arm64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
+      "integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
     "node_modules/@unrs/resolver-binding-darwin-arm64": {
       "version": "1.11.1",
       "cpu": [
@@ -11935,6 +12018,257 @@
       "optional": true,
       "os": [
         "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-x64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
+      "integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-freebsd-x64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
+      "integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
+      "integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
+      "integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
+      "integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
+      "integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
+      "integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
+      "integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
+      "integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
+      "integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
+      "integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
+      "integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
+      "integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^0.2.11"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
+      "integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
+      "integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
+      "integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ]
     },
     "node_modules/abort-controller": {

--- a/docs/user-guide/xcode-plugin.md
+++ b/docs/user-guide/xcode-plugin.md
@@ -10,6 +10,14 @@ same configuration and the same judgment as the CLI and CI.
   or later. SwiftPM skips the analysis for older tools versions because the
   plugin's build command declares no output files.
 - macOS 14 or later (inherited from swift-complexity's platform requirement).
+- Depend on swift-complexity by **commit or branch, not by version**.
+  swift-complexity depends on the untagged `indexstore-db`, and SwiftPM rejects a
+  version requirement (`from:` / `exact:`, or Xcode's "Up to Next Major") on a
+  package with such a dependency:
+  `package 'swift-complexity' is required using a stable-version but
+  'swift-complexity' depends on an unstable-version package 'indexstore-db'`.
+  Each release's commit is listed on the
+  [Releases](https://github.com/fummicc1/swift-complexity/releases) page.
 
 ## Setup
 
@@ -22,7 +30,11 @@ import PackageDescription
 let package = Package(
     name: "YourProject",
     dependencies: [
-        .package(url: "https://github.com/fummicc1/swift-complexity.git", from: "1.4.0")
+        // v1.4.0 — see Requirements for why this is a commit, not a version
+        .package(
+            url: "https://github.com/fummicc1/swift-complexity.git",
+            revision: "25f4446f7eb0cb530bebbaaecaef37418c28f8b6"
+        )
     ],
     targets: [
         .target(
@@ -37,7 +49,8 @@ let package = Package(
 
 ### Xcode Project
 
-1. Add the swift-complexity package to your Xcode project
+1. Add the swift-complexity package to your Xcode project with Dependency Rule
+   **Commit** (the release commit) or **Branch** — see Requirements
 2. In Build Phases, add "SwiftComplexityPlugin" to Run Build Tool Plug-ins
 3. On the first build, Xcode asks you to trust the plugin — choose "Trust & Enable".
    For command-line and CI builds, pass `-skipPackagePluginValidation` to


### PR DESCRIPTION
## Summary

**Debug website scope (docs).** The site is intentionally limited to what can be computed from source text alone (cyclomatic, cognitive, inline suppression, output formats via the API). LCOM4 and type coupling need the index store of a compiled project, so they stay CLI-only. `README.md` and `debug-website/README.md` now say so.

**Backend build environment.** The backend followed the core's `main` branch without a pin while its Dockerfile stayed on `swift:6.1-jammy`; the core has required tools-version 6.2 and depended on indexstore-db since #16. A redeploy would have failed, and nothing in CI would have noticed.

- Pin the v1.4.0 release commit via `revision:` and stop ignoring `Package.resolved` in the image build, so container builds are reproducible
- `swift:6.2-jammy` plus the `-Xcxx -I/usr/lib/swift -I/usr/lib/swift/Block` flags that ci.yml / release.yml already use on Linux
- `try ComplexityAnalyzer()` (the initializer throws since LCOM4) and `async throws` test closures
- Regenerate `frontend/package-lock.json`: it was out of sync with `package.json` and `npm ci` failed (additions only, no version changes)
- New `.github/workflows/debug-website.yml`: builds the Docker image, smoke-tests `/health` and `/api/v1/analyze`, and type-checks the frontend (plus `next build`) and the worker. Path-filtered to `debug-website/**`.

**`from: "1.4.0"` does not resolve (docs fix).** SwiftPM rejects a version requirement on swift-complexity: `package 'swift-complexity' is required using a stable-version but 'swift-complexity' depends on an unstable-version package 'indexstore-db'`. This has been true since #16 because indexstore-db (and its swift-lmdb dependency) are branch-based and untagged. The README plugin section and `docs/user-guide/xcode-plugin.md` now instruct pinning the release commit (or a branch) and explain why.

## Verification

- macOS: `swift build` and `swift test` (4/4) in `debug-website/backend/app`
- `docker build` of the backend image on linux/arm64 (560 s)
- frontend: `npm ci`, `tsc --noEmit`, `next build`; worker: `npm ci`, `tsc --noEmit`
- `actionlint` on the new workflow
- Not verified locally: the container smoke test and the linux/amd64 image — both run in this PR's **Debug Website** workflow

## Follow-ups (not in this PR)

- Decide how to restore version-based dependencies: fork indexstore-db + swift-lmdb with semver tags, or vendor indexstore-db (issue candidate)
- The release commit SHA in the two docs must be updated after each release, or a stable branch could be published by release.yml
- After merge, redeploy the container (`wrangler deploy --env production` in `debug-website/backend/worker`) so the live site runs the 1.4.0 core

https://claude.ai/code/session_01N2gw9ApybKyt99cBsbSqvJ
