### PR TITLE
Put indexstore-db behind an opt-in IndexStore trait

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Build package (macOS)
         if: runner.os == 'macOS'
-        run: swift build --configuration release
+        run: swift build --configuration release --traits IndexStore
 
       - name: Build package (Linux)
         if: runner.os == 'Linux'
@@ -83,19 +83,24 @@ jobs:
           # --static-swift-stdlib matches the release build so static linking
           # breakage is caught on every PR, not at release time
           swift build --configuration release --static-swift-stdlib \
+            --traits IndexStore \
             -Xcxx -I${TOOLCHAIN_USR}/lib/swift \
             -Xcxx -I${TOOLCHAIN_USR}/lib/swift/Block
 
       - name: Run tests (macOS)
         if: runner.os == 'macOS'
-        run: swift test
+        env:
+          SWIFT_COMPLEXITY_EXPECT_INDEXSTORE_TRAIT: "1"
+        run: swift test --traits IndexStore
 
       - name: Run tests (Linux)
         if: runner.os == 'Linux'
+        env:
+          SWIFT_COMPLEXITY_EXPECT_INDEXSTORE_TRAIT: "1"
         run: |
           SWIFTLY_HOME="${HOME}/.local/share/swiftly"
           TOOLCHAIN_USR=$(ls -d ${SWIFTLY_HOME}/toolchains/*/usr 2>/dev/null | head -1)
-          swift test \
+          swift test --traits IndexStore \
             -Xcxx -I${TOOLCHAIN_USR}/lib/swift \
             -Xcxx -I${TOOLCHAIN_USR}/lib/swift/Block
 
@@ -103,7 +108,7 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           # Build with debug configuration to generate IndexStore
-          swift build
+          swift build --traits IndexStore
           # Run LCOM4 analysis using compiled binary directly
           .build/debug/SwiftComplexityCLI Sources --lcom4 \
             --index-store-path .build/debug/index/store \
@@ -118,7 +123,7 @@ jobs:
           TOOLCHAIN_USR="${TOOLCHAIN}/usr"
           echo "Using toolchain: ${TOOLCHAIN}"
           # Build with debug configuration to generate IndexStore
-          swift build \
+          swift build --traits IndexStore \
             -Xcxx -I${TOOLCHAIN_USR}/lib/swift \
             -Xcxx -I${TOOLCHAIN_USR}/lib/swift/Block
           # Run LCOM4 analysis using compiled binary directly (avoids rebuild)
@@ -173,6 +178,57 @@ jobs:
           jq -e '[.files[].typeCouplings[]?] | any(.name == "SuppressedMetric" and .fanOut == 0 and .fanIn >= 5)' coupling-report.json
           jq -e '[.files[].typeCouplings[]?] | any(.name == "OutputFormatter" and .fanOut >= 15)' coupling-report.json
           grep -q "coupling:" coupling-diag.txt
+
+  default-traits:
+    name: Default traits (SPI parity)
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-15, ubuntu-22.04]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup Xcode
+        if: runner.os == 'macOS'
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "26.1"
+
+      - name: Setup Swift
+        run: |
+          if [[ "$RUNNER_OS" == "Linux" ]]; then
+            sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev pkg-config python3-lldb-13
+            curl -O https://download.swift.org/swiftly/linux/swiftly-$(uname -m).tar.gz
+            tar zxf swiftly-$(uname -m).tar.gz
+            ./swiftly init --verbose --assume-yes --skip-install
+            . ~/.local/share/swiftly/env.sh
+            swiftly install 6.2
+            echo "$(dirname $(which swift))" >> $GITHUB_PATH
+          fi
+          swift --version
+
+      # Exactly what Swift Package Index and a consumer's plain `swift build`
+      # run: no traits, no -Xcxx include flags. This is the job that keeps
+      # the Linux/Wasm compatibility badges green.
+      - name: Build with default traits
+        run: swift build
+
+      - name: Test with default traits
+        run: swift test
+
+      - name: Index-backed flags fail with a rebuild hint
+        run: |
+          set +e
+          OUTPUT=$(.build/debug/SwiftComplexityCLI Sources --lcom4 \
+            --index-store-path .build/debug/index/store 2>&1)
+          STATUS=$?
+          set -e
+          echo "$OUTPUT"
+          test "$STATUS" -ne 0
+          echo "$OUTPUT" | grep -q -- "--traits IndexStore"
 
   action-test:
     name: Action Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,9 +210,7 @@ jobs:
           fi
           swift --version
 
-      # Exactly what Swift Package Index and a consumer's plain `swift build`
-      # run: no traits, no -Xcxx include flags. This is the job that keeps
-      # the Linux/Wasm compatibility badges green.
+      # Mirrors what Swift Package Index runs (no traits, no -Xcxx); adding either here would hide the badge regressions this job exists to catch
       - name: Build with default traits
         run: swift build
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,9 +85,11 @@ jobs:
           swift --version
 
       - name: Build and test
+        env:
+          SWIFT_COMPLEXITY_EXPECT_INDEXSTORE_TRAIT: "1"
         run: |
-          swift build --configuration release
-          swift test
+          swift build --configuration release --traits IndexStore
+          swift test --traits IndexStore
 
   build-artifacts:
     name: Build Release Artifacts
@@ -140,13 +142,18 @@ jobs:
 
       - name: Build for ${{ matrix.platform }}-${{ matrix.arch }}
         run: |
+          # --traits IndexStore: release binaries always ship LCOM4/coupling;
+          # the trait is off by default only so the package builds on
+          # platforms where indexstore-db cannot.
           if [ "${{ matrix.platform }}" = "macos" ]; then
             swift build \
               --configuration release \
+              --traits IndexStore \
               --arch ${{ matrix.arch }} \
               --product SwiftComplexityCLI
             swift build \
               --configuration release \
+              --traits IndexStore \
               --arch ${{ matrix.arch }} \
               --product SwiftComplexityMCP
           else
@@ -158,12 +165,14 @@ jobs:
             TOOLCHAIN_USR=$(ls -d ${SWIFTLY_HOME}/toolchains/*/usr 2>/dev/null | head -1)
             swift build \
               --configuration release \
+              --traits IndexStore \
               --static-swift-stdlib \
               --product SwiftComplexityCLI \
               -Xcxx -I${TOOLCHAIN_USR}/lib/swift \
               -Xcxx -I${TOOLCHAIN_USR}/lib/swift/Block
             swift build \
               --configuration release \
+              --traits IndexStore \
               --static-swift-stdlib \
               --product SwiftComplexityMCP \
               -Xcxx -I${TOOLCHAIN_USR}/lib/swift \
@@ -352,7 +361,8 @@ jobs:
           git clone https://github.com/${{ github.repository }}.git
           cd swift-complexity
           git checkout v${VERSION}
-          swift build -c release
+          # --traits IndexStore enables LCOM4 and coupling (off by default)
+          swift build -c release --traits IndexStore
           \`\`\`
 
           ## Verification

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,9 +142,7 @@ jobs:
 
       - name: Build for ${{ matrix.platform }}-${{ matrix.arch }}
         run: |
-          # --traits IndexStore: release binaries always ship LCOM4/coupling;
-          # the trait is off by default only so the package builds on
-          # platforms where indexstore-db cannot.
+          # Release binaries must ship LCOM4/coupling; the trait is off by default only for platforms where indexstore-db cannot build
           if [ "${{ matrix.platform }}" = "macos" ]; then
             swift build \
               --configuration release \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,13 +97,13 @@ swift-complexity is a CLI tool that analyzes Swift code complexity using SwiftSy
 - Focus on "why" rather than "what"
 - Auto-formatting via lefthook swift-format
 
-### Testing
+### Testing Rules
 
 - Always create tests for new features
 - Place fixture files in `Tests/SwiftComplexityCoreTests/Fixtures/`
 - Document expected values in comments
 
-### Code Quality
+### Code Quality Rules
 
 - Auto-apply swift-format (pre-commit)
 - Minimize public API surface

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,13 +10,15 @@ swift-complexity is a CLI tool that analyzes Swift code complexity using SwiftSy
 
 ### Build & Run
 
-- `swift build` - Build the executable
+- `swift build` - Build with default traits (syntax-based metrics only; this is what Swift Package Index and consumers run)
+- `swift build --traits IndexStore` - Build with LCOM4 / coupling (pulls in indexstore-db; release binaries use this)
 - `swift run swift-complexity` - Run the CLI tool  
 - `swift run swift-complexity -- --help` - Show CLI help (note the `--` separator)
 
 ### Testing
 
-- `swift test` - Run all tests
+- `swift test` - Run all default-trait tests
+- `swift test --traits IndexStore` - Also run the index-backed suites (must be run from the CLI; Xcode's test action ignores traits)
 - `swift test --filter <test-name>` - Run specific test
 - `swift test --parallel` - Run tests in parallel
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "4f208c076367e5adc1699a6b28ed552dbc0543544bf0ac788ef8a5c910539317",
+  "originHash" : "fdd42d36229efe69fb6daa073bf33703ba4b83319e29f64dd3de0ffe82feb48e",
   "pins" : [
     {
       "identity" : "eventsource",

--- a/Package.swift
+++ b/Package.swift
@@ -27,6 +27,14 @@ let package = Package(
       targets: ["SwiftComplexityPlugin"]
     ),
   ],
+  traits: [
+    // Off by default: Swift Package Index, Wasm, and a plain `swift build` on Linux
+    // cannot pass the libdispatch include flags indexstore-db needs to compile.
+    .trait(
+      name: "IndexStore",
+      description: "Index-backed analyses (LCOM4 cohesion, type coupling) via IndexStoreDB"
+    )
+  ],
   dependencies: [
     .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "600.0.0"),
     .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
@@ -44,7 +52,9 @@ let package = Package(
         .product(name: "SwiftSyntax", package: "swift-syntax"),
         .product(name: "SwiftParser", package: "swift-syntax"),
         // IndexStore-DB integration (for LCOM4 semantic analysis)
-        .product(name: "IndexStoreDB", package: "indexstore-db"),
+        .product(
+          name: "IndexStoreDB", package: "indexstore-db",
+          condition: .when(traits: ["IndexStore"])),
         // YAML decoding for per-type threshold configuration
         .product(name: "Yams", package: "Yams"),
       ],
@@ -64,6 +74,9 @@ let package = Package(
         "SwiftComplexityCore",
         .product(name: "SwiftSyntax", package: "swift-syntax"),
         .product(name: "SwiftParser", package: "swift-syntax"),
+        .product(
+          name: "IndexStoreDB", package: "indexstore-db",
+          condition: .when(traits: ["IndexStore"])),
       ],
       path: "Tests/SwiftComplexityCoreTests",
       resources: [

--- a/Package.swift
+++ b/Package.swift
@@ -28,8 +28,6 @@ let package = Package(
     ),
   ],
   traits: [
-    // Off by default: Swift Package Index, Wasm, and a plain `swift build` on Linux
-    // cannot pass the libdispatch include flags indexstore-db needs to compile.
     .trait(
       name: "IndexStore",
       description: "Index-backed analyses (LCOM4 cohesion, type coupling) via IndexStoreDB"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A command-line tool to analyze Swift code complexity and quality metrics using s
 - **Multiple Output Formats**: Text, JSON, XML, Xcode diagnostics, and SARIF output for different use cases
 - **Flexible Analysis**: Single files, directories, or recursive directory analysis
 - **Swift Syntax Based**: Uses `swift-syntax` for accurate Swift code parsing
-- **Cross-Platform Support**: CLI works on macOS and Linux, library works on iOS 13+.
+- **Cross-Platform Support**: CLI works on macOS and Linux, library works on iOS 13+. Index-backed metrics (LCOM4, coupling) live behind the opt-in `IndexStore` SwiftPM trait, so the package itself builds wherever swift-syntax does; release binaries ship with the trait enabled.
 - **MCP Server**: Expose complexity analysis as tools for LLM agents (Claude Code, etc.) via Model Context Protocol
 - **Claude Plugin**: Ready-to-use Claude Code plugin with MCP server and analysis skill
 - **Extensible Architecture**: Designed to support additional quality metrics in the future
@@ -214,7 +214,7 @@ Unified package with multiple components:
 
 ### Core Package
 
-- **SwiftComplexityCore**: Core analysis library (supports macOS 14+, iOS 13+)
+- **SwiftComplexityCore**: Core analysis library (supports macOS 14+, iOS 13+). Add `traits: ["IndexStore"]` to your `.package(...)` declaration to include LCOM4 and coupling analysis
 - **SwiftComplexityCLI**: Command-line interface
 - **SwiftComplexityMCP**: MCP server for LLM agent integration
 - **SwiftComplexityPlugin**: Xcode Build Tool Plugin
@@ -451,8 +451,9 @@ and `lcom4_cohesion`) with `warning` level, escalating to `error` at twice the t
 - Swift 6.2+
 - macOS 14+, iOS 13+, or Linux
 
-### LCOM4 Feature (Optional)
+### Index-Backed Metrics: LCOM4 and Coupling (Optional)
 
+- **Building from source**: pass `--traits IndexStore` (`swift build --traits IndexStore`). The trait is off by default because its `indexstore-db` dependency does not build on every platform; without it, `--lcom4` and `--coupling` exit with a rebuild hint. Homebrew, GitHub Releases, and the GitHub Action ship binaries with the trait enabled
 - **macOS 14+**: Xcode toolchain is auto-detected
 - **Linux**: Requires `--toolchain-path` option pointing to Swift toolchain
 - Project must be buildable with `swift build`
@@ -463,7 +464,7 @@ and `lcom4_cohesion`) with `warning` level, escalating to `error` at twice the t
 ```bash
 # Using Swiftly-installed toolchain
 TOOLCHAIN=~/.local/share/swiftly/toolchains/swift-6.2.2-RELEASE
-swift build \
+swift build --traits IndexStore \
   -Xcxx -I${TOOLCHAIN}/usr/lib/swift \
   -Xcxx -I${TOOLCHAIN}/usr/lib/swift/Block
 .build/debug/SwiftComplexityCLI Sources --lcom4 \

--- a/Sources/SwiftComplexityCLI/ComplexityCommand.swift
+++ b/Sources/SwiftComplexityCLI/ComplexityCommand.swift
@@ -248,22 +248,30 @@ public struct ComplexityCommand: AsyncParsableCommand {
         let indexBackedFlag: String? = lcom4 ? "--lcom4" : (coupling ? "--coupling" : nil)
         guard let flag = indexBackedFlag else { return }
 
-        if indexStorePath == nil {
-            print("Error: \(flag) requires --index-store-path option.")
+        #if !IndexStore
+            print("Error: \(flag) is not available in this build.")
             print(
-                "Example: swift-complexity Sources \(flag) --index-store-path .build/debug/index/store"
+                "Rebuild with 'swift build --traits IndexStore' or install a release binary (Homebrew, GitHub Releases)."
             )
             throw ExitCode.failure
-        }
-
-        #if os(Linux)
-            if toolchainPath == nil {
-                print("Error: \(flag) requires --toolchain-path option on Linux.")
+        #else
+            if indexStorePath == nil {
+                print("Error: \(flag) requires --index-store-path option.")
                 print(
-                    "Example: swift-complexity Sources \(flag) --index-store-path .build/debug/index/store --toolchain-path ~/.local/share/swiftly/toolchains/swift-6.2"
+                    "Example: swift-complexity Sources \(flag) --index-store-path .build/debug/index/store"
                 )
                 throw ExitCode.failure
             }
+
+            #if os(Linux)
+                if toolchainPath == nil {
+                    print("Error: \(flag) requires --toolchain-path option on Linux.")
+                    print(
+                        "Example: swift-complexity Sources \(flag) --index-store-path .build/debug/index/store --toolchain-path ~/.local/share/swiftly/toolchains/swift-6.2"
+                    )
+                    throw ExitCode.failure
+                }
+            #endif
         #endif
     }
 

--- a/Sources/SwiftComplexityCore/Analysis/ComplexityAnalyzer.swift
+++ b/Sources/SwiftComplexityCore/Analysis/ComplexityAnalyzer.swift
@@ -10,13 +10,16 @@ public actor ComplexityAnalyzer: ComplexityAnalyzing {
     private let cognitiveCalculator: CognitiveComplexityCalculator
     private let functionDetector: FunctionDetector
     private let nominalTypeDetector: NominalTypeDetector
-    private let lcomCalculator: SemanticLCOMCalculator?
     private let enableLCOM4: Bool
 
-    /// The index store opened for this analyzer, shared with other
-    /// index-backed passes (coupling) so the database is populated once.
-    /// Immutable and Sendable, so cross-actor access needs no await.
-    let sharedIndexStore: SharedIndexStore?
+    #if IndexStore
+        private let lcomCalculator: SemanticLCOMCalculator?
+
+        /// The index store opened for this analyzer, shared with other
+        /// index-backed passes (coupling) so the database is populated once.
+        /// Immutable and Sendable, so cross-actor access needs no await.
+        let sharedIndexStore: SharedIndexStore?
+    #endif
 
     /// Initialize the analyzer
     /// - Parameters:
@@ -36,14 +39,21 @@ public actor ComplexityAnalyzer: ComplexityAnalyzing {
 
         // LCOM4: High-accuracy (90-95%) semantic analysis with IndexStore-DB integration
         if let indexStorePath = indexStorePath {
-            let store = try IndexStoreService.open(
-                indexStorePath: indexStorePath, toolchainPath: toolchainPath)
-            self.sharedIndexStore = store
-            self.lcomCalculator = lcom4Enabled ? SemanticLCOMCalculator(indexStore: store) : nil
-            self.enableLCOM4 = lcom4Enabled
+            #if IndexStore
+                let store = try IndexStoreService.open(
+                    indexStorePath: indexStorePath, toolchainPath: toolchainPath)
+                self.sharedIndexStore = store
+                self.lcomCalculator =
+                    lcom4Enabled ? SemanticLCOMCalculator(indexStore: store) : nil
+                self.enableLCOM4 = lcom4Enabled
+            #else
+                throw IndexStoreError.unavailableInThisBuild
+            #endif
         } else {
-            self.sharedIndexStore = nil
-            self.lcomCalculator = nil
+            #if IndexStore
+                self.sharedIndexStore = nil
+                self.lcomCalculator = nil
+            #endif
             self.enableLCOM4 = false
         }
     }
@@ -76,43 +86,45 @@ public actor ComplexityAnalyzer: ComplexityAnalyzing {
         // LCOM4 calculation (only if enabled)
         var classCohesions: [ClassCohesion]? = nil
 
-        if enableLCOM4, let lcomCalculator = lcomCalculator {
-            let nominalTypes = nominalTypeDetector.detectTypes(in: sourceFile)
-            var cohesions: [ClassCohesion] = []
+        #if IndexStore
+            if enableLCOM4, let lcomCalculator = lcomCalculator {
+                let nominalTypes = nominalTypeDetector.detectTypes(in: sourceFile)
+                var cohesions: [ClassCohesion] = []
 
-            for detectedType in nominalTypes {
-                let lcom4Value = try await lcomCalculator.calculate(for: detectedType)
+                for detectedType in nominalTypes {
+                    let lcom4Value = try await lcomCalculator.calculate(for: detectedType)
 
-                // Calculate member counts
-                let (methods, properties) = extractMemberCounts(from: detectedType.members)
+                    // Calculate member counts
+                    let (methods, properties) = extractMemberCounts(from: detectedType.members)
 
-                // Convert NominalTypeKind to NominalType
-                let nominalType: NominalType
-                switch detectedType.type {
-                case .class:
-                    nominalType = .class
-                case .struct:
-                    nominalType = .struct
-                case .actor:
-                    nominalType = .actor
+                    // Convert NominalTypeKind to NominalType
+                    let nominalType: NominalType
+                    switch detectedType.type {
+                    case .class:
+                        nominalType = .class
+                    case .struct:
+                        nominalType = .struct
+                    case .actor:
+                        nominalType = .actor
+                    }
+
+                    let cohesion = ClassCohesion(
+                        name: detectedType.name,
+                        type: nominalType,
+                        lcom4: lcom4Value,
+                        methodCount: methods,
+                        propertyCount: properties,
+                        location: detectedType.location,
+                        suppressedMetrics: detectedType.suppressedMetrics.isEmpty
+                            ? nil : detectedType.suppressedMetrics
+                    )
+
+                    cohesions.append(cohesion)
                 }
 
-                let cohesion = ClassCohesion(
-                    name: detectedType.name,
-                    type: nominalType,
-                    lcom4: lcom4Value,
-                    methodCount: methods,
-                    propertyCount: properties,
-                    location: detectedType.location,
-                    suppressedMetrics: detectedType.suppressedMetrics.isEmpty
-                        ? nil : detectedType.suppressedMetrics
-                )
-
-                cohesions.append(cohesion)
+                classCohesions = cohesions.isEmpty ? nil : cohesions
             }
-
-            classCohesions = cohesions.isEmpty ? nil : cohesions
-        }
+        #endif
 
         return ComplexityResult(
             filePath: filePath,

--- a/Sources/SwiftComplexityCore/Analysis/IndexStoreService.swift
+++ b/Sources/SwiftComplexityCore/Analysis/IndexStoreService.swift
@@ -1,5 +1,8 @@
 import Foundation
-import IndexStoreDB
+
+#if IndexStore
+    import IndexStoreDB
+#endif
 
 // MARK: - Errors
 
@@ -10,9 +13,15 @@ enum IndexStoreError: LocalizedError {
     case libIndexStoreNotFound(searchedPath: String)
     case toolchainRequired
     case initializationFailed(underlying: Error)
+    case unavailableInThisBuild
 
     var errorDescription: String? {
         switch self {
+        case .unavailableInThisBuild:
+            return """
+                Index-backed analysis (LCOM4, coupling) is not included in this build.
+                Rebuild with 'swift build --traits IndexStore' or install a release binary.
+                """
         case .indexStoreNotFound(let indexStorePath):
             return """
                 Index store not found at '\(indexStorePath)'.
@@ -32,131 +41,136 @@ enum IndexStoreError: LocalizedError {
     }
 }
 
-// MARK: - Shared store handle
+#if IndexStore
 
-/// A single opened IndexStoreDB shared between index-backed calculators so
-/// the database is populated once per run (opening costs seconds).
-///
-/// `@unchecked Sendable`: IndexStoreDB is a class without a Sendable
-/// annotation, but its query API is documented thread-safe (SourceKit-LSP
-/// issues concurrent queries against one instance); this wrapper only ever
-/// exposes it immutably.
-struct SharedIndexStore: @unchecked Sendable {
-    let database: IndexStoreDB
-    let storePath: URL
-}
+    // MARK: - Shared store handle
 
-// MARK: - Opening
-
-/// Opens IndexStoreDB instances. Centralizes libIndexStore discovery and the
-/// database configuration for every index-backed analysis.
-enum IndexStoreService {
-
-    static func open(indexStorePath: URL, toolchainPath: URL? = nil) throws -> SharedIndexStore {
-        guard FileManager.default.fileExists(atPath: indexStorePath.path) else {
-            throw IndexStoreError.indexStoreNotFound(indexStorePath: indexStorePath.path)
-        }
-
-        let libIndexStorePath = try findLibIndexStore(toolchainPath: toolchainPath)
-
-        do {
-            // The database path is keyed to the store path so repeated runs
-            // reuse the populated database per project without ever mixing
-            // different projects' indexes in one database.
-            //
-            // waitUntilDoneInitializing guarantees queries see the fully
-            // populated database; a one-shot CLI has no later delegate event
-            // to await, so returning earlier would race the first query.
-            let database = try IndexStoreDB(
-                storePath: indexStorePath.path,
-                databasePath: NSTemporaryDirectory()
-                    + "swift-complexity-index-\(stableHash(of: indexStorePath.path)).db",
-                library: IndexStoreLibrary(dylibPath: libIndexStorePath),
-                waitUntilDoneInitializing: true
-            )
-            return SharedIndexStore(database: database, storePath: indexStorePath)
-        } catch {
-            throw IndexStoreError.initializationFailed(underlying: error)
-        }
+    /// A single opened IndexStoreDB shared between index-backed calculators so
+    /// the database is populated once per run (opening costs seconds).
+    ///
+    /// `@unchecked Sendable`: IndexStoreDB is a class without a Sendable
+    /// annotation, but its query API is documented thread-safe (SourceKit-LSP
+    /// issues concurrent queries against one instance); this wrapper only ever
+    /// exposes it immutably.
+    struct SharedIndexStore: @unchecked Sendable {
+        let database: IndexStoreDB
+        let storePath: URL
     }
 
-    /// FNV-1a, chosen over `Hashable.hashValue` because the database path
-    /// must stay identical across processes (hashValue is seeded per run).
-    private static func stableHash(of string: String) -> String {
-        var hash: UInt64 = 0xcbf2_9ce4_8422_2325
-        for byte in string.utf8 {
-            hash ^= UInt64(byte)
-            hash = hash &* 0x0000_0100_0000_01B3
-        }
-        return String(hash, radix: 16)
-    }
+    // MARK: - Opening
 
-    // MARK: - libIndexStore discovery
+    /// Opens IndexStoreDB instances. Centralizes libIndexStore discovery and the
+    /// database configuration for every index-backed analysis.
+    enum IndexStoreService {
 
-    /// Searches for the libIndexStore dynamic library.
-    /// - Parameter toolchainPath: Optional toolchain path (e.g.
-    ///   `~/.local/share/swiftly/toolchains/swift-6.2`). On macOS, `nil`
-    ///   auto-detects the Xcode toolchain. On Linux, this is required.
-    private static func findLibIndexStore(toolchainPath: URL?) throws -> String {
-        #if os(Linux)
-            let libName = "libIndexStore.so"
-        #else
-            let libName = "libIndexStore.dylib"
-        #endif
-
-        // Expected structure: <toolchainPath>/usr/lib/libIndexStore.{so,dylib}
-        if let toolchainPath = toolchainPath {
-            let libPath =
-                toolchainPath
-                .appendingPathComponent("usr")
-                .appendingPathComponent("lib")
-                .appendingPathComponent(libName)
-            guard FileManager.default.fileExists(atPath: libPath.path) else {
-                throw IndexStoreError.libIndexStoreNotFound(searchedPath: libPath.path)
+        static func open(indexStorePath: URL, toolchainPath: URL? = nil) throws -> SharedIndexStore
+        {
+            guard FileManager.default.fileExists(atPath: indexStorePath.path) else {
+                throw IndexStoreError.indexStoreNotFound(indexStorePath: indexStorePath.path)
             }
-            return libPath.path
+
+            let libIndexStorePath = try findLibIndexStore(toolchainPath: toolchainPath)
+
+            do {
+                // The database path is keyed to the store path so repeated runs
+                // reuse the populated database per project without ever mixing
+                // different projects' indexes in one database.
+                //
+                // waitUntilDoneInitializing guarantees queries see the fully
+                // populated database; a one-shot CLI has no later delegate event
+                // to await, so returning earlier would race the first query.
+                let database = try IndexStoreDB(
+                    storePath: indexStorePath.path,
+                    databasePath: NSTemporaryDirectory()
+                        + "swift-complexity-index-\(stableHash(of: indexStorePath.path)).db",
+                    library: IndexStoreLibrary(dylibPath: libIndexStorePath),
+                    waitUntilDoneInitializing: true
+                )
+                return SharedIndexStore(database: database, storePath: indexStorePath)
+            } catch {
+                throw IndexStoreError.initializationFailed(underlying: error)
+            }
+        }
+
+        /// FNV-1a, chosen over `Hashable.hashValue` because the database path
+        /// must stay identical across processes (hashValue is seeded per run).
+        private static func stableHash(of string: String) -> String {
+            var hash: UInt64 = 0xcbf2_9ce4_8422_2325
+            for byte in string.utf8 {
+                hash ^= UInt64(byte)
+                hash = hash &* 0x0000_0100_0000_01B3
+            }
+            return String(hash, radix: 16)
+        }
+
+        // MARK: - libIndexStore discovery
+
+        /// Searches for the libIndexStore dynamic library.
+        /// - Parameter toolchainPath: Optional toolchain path (e.g.
+        ///   `~/.local/share/swiftly/toolchains/swift-6.2`). On macOS, `nil`
+        ///   auto-detects the Xcode toolchain. On Linux, this is required.
+        private static func findLibIndexStore(toolchainPath: URL?) throws -> String {
+            #if os(Linux)
+                let libName = "libIndexStore.so"
+            #else
+                let libName = "libIndexStore.dylib"
+            #endif
+
+            // Expected structure: <toolchainPath>/usr/lib/libIndexStore.{so,dylib}
+            if let toolchainPath = toolchainPath {
+                let libPath =
+                    toolchainPath
+                    .appendingPathComponent("usr")
+                    .appendingPathComponent("lib")
+                    .appendingPathComponent(libName)
+                guard FileManager.default.fileExists(atPath: libPath.path) else {
+                    throw IndexStoreError.libIndexStoreNotFound(searchedPath: libPath.path)
+                }
+                return libPath.path
+            }
+
+            #if os(macOS)
+                return try findLibIndexStoreFromXcode()
+            #else
+                throw IndexStoreError.toolchainRequired
+            #endif
         }
 
         #if os(macOS)
-            return try findLibIndexStoreFromXcode()
-        #else
-            throw IndexStoreError.toolchainRequired
+            /// Auto-detects libIndexStore from the active Xcode toolchain.
+            private static func findLibIndexStoreFromXcode() throws -> String {
+                let process = Process()
+                process.executableURL = URL(fileURLWithPath: "/usr/bin/xcrun")
+                process.arguments = ["--show-sdk-path"]
+
+                let pipe = Pipe()
+                process.standardOutput = pipe
+                process.standardError = pipe
+
+                try process.run()
+                process.waitUntilExit()
+
+                let data = pipe.fileHandleForReading.readDataToEndOfFile()
+                guard
+                    let sdkPath = String(data: data, encoding: .utf8)?.trimmingCharacters(
+                        in: .whitespacesAndNewlines)
+                else {
+                    throw IndexStoreError.toolchainRequired
+                }
+
+                // /Applications/Xcode.app/.../SDKs/MacOSX.sdk
+                // -> /Applications/Xcode.app/.../Toolchains/XcodeDefault.xctoolchain/usr/lib/libIndexStore.dylib
+                let xcodeAppPath = sdkPath.components(separatedBy: "/Platforms/").first ?? ""
+                let libPath =
+                    "\(xcodeAppPath)/Toolchains/XcodeDefault.xctoolchain/usr/lib/libIndexStore.dylib"
+
+                guard FileManager.default.fileExists(atPath: libPath) else {
+                    throw IndexStoreError.libIndexStoreNotFound(searchedPath: libPath)
+                }
+
+                return libPath
+            }
         #endif
     }
 
-    #if os(macOS)
-        /// Auto-detects libIndexStore from the active Xcode toolchain.
-        private static func findLibIndexStoreFromXcode() throws -> String {
-            let process = Process()
-            process.executableURL = URL(fileURLWithPath: "/usr/bin/xcrun")
-            process.arguments = ["--show-sdk-path"]
-
-            let pipe = Pipe()
-            process.standardOutput = pipe
-            process.standardError = pipe
-
-            try process.run()
-            process.waitUntilExit()
-
-            let data = pipe.fileHandleForReading.readDataToEndOfFile()
-            guard
-                let sdkPath = String(data: data, encoding: .utf8)?.trimmingCharacters(
-                    in: .whitespacesAndNewlines)
-            else {
-                throw IndexStoreError.toolchainRequired
-            }
-
-            // /Applications/Xcode.app/.../SDKs/MacOSX.sdk
-            // -> /Applications/Xcode.app/.../Toolchains/XcodeDefault.xctoolchain/usr/lib/libIndexStore.dylib
-            let xcodeAppPath = sdkPath.components(separatedBy: "/Platforms/").first ?? ""
-            let libPath =
-                "\(xcodeAppPath)/Toolchains/XcodeDefault.xctoolchain/usr/lib/libIndexStore.dylib"
-
-            guard FileManager.default.fileExists(atPath: libPath) else {
-                throw IndexStoreError.libIndexStoreNotFound(searchedPath: libPath)
-            }
-
-            return libPath
-        }
-    #endif
-}
+#endif

--- a/Sources/SwiftComplexityCore/Analysis/NominalTypeDetector.swift
+++ b/Sources/SwiftComplexityCore/Analysis/NominalTypeDetector.swift
@@ -1,5 +1,4 @@
 import Foundation
-import IndexStoreDB
 import SwiftSyntax
 
 /// Nominal Type kind for LCOM4 cohesion analysis (class/struct/actor)
@@ -12,14 +11,6 @@ enum NominalTypeKind {
     case `class`
     case `struct`
     case actor
-
-    var symbolKind: IndexSymbolKind {
-        switch self {
-        case .class: return .class
-        case .struct: return .struct
-        case .actor: return .class  // actor is also handled as IndexSymbolKind.class
-        }
-    }
 }
 
 /// Information about detected Nominal Type

--- a/Sources/SwiftComplexityCore/Analysis/ReferenceGraph.swift
+++ b/Sources/SwiftComplexityCore/Analysis/ReferenceGraph.swift
@@ -1,301 +1,280 @@
-import Foundation
-import IndexStoreDB
+#if IndexStore
+    import Foundation
+    import IndexStoreDB
 
-// MARK: - Pure input records
+    // MARK: - Pure input records
 
-/// One relation attached to an index occurrence.
-struct RecordRelation: Sendable {
-    let usr: String
-    let kind: IndexSymbolKind
-    let roles: SymbolRole
-}
-
-/// A pure-data projection of `SymbolOccurrence`.
-///
-/// The graph builder consumes these instead of IndexStoreDB types that
-/// require a live store, so the whole attribution algorithm is unit-testable
-/// with hand-written records (relation shapes were verified against a real
-/// index in the coupling spike).
-struct IndexOccurrenceRecord: Sendable {
-    let usr: String
-    let name: String
-    let kind: IndexSymbolKind
-    let file: String
-    let line: Int
-    let column: Int
-    let roles: SymbolRole
-    let relations: [RecordRelation]
-}
-
-// MARK: - Outputs
-
-/// Type-to-type reference graph over project-internal nominal types.
-struct ReferenceGraph: Sendable {
-    struct Node: Sendable {
+    /// One relation attached to an index occurrence.
+    struct RecordRelation: Sendable {
         let usr: String
-        /// Dotted display name from syntax when available (e.g. "Outer.Inner"),
-        /// otherwise the index symbol name.
+        let kind: IndexSymbolKind
+        let roles: SymbolRole
+    }
+
+    /// A pure-data projection of `SymbolOccurrence`.
+    ///
+    /// The graph builder consumes these instead of IndexStoreDB types that
+    /// require a live store, so the whole attribution algorithm is unit-testable
+    /// with hand-written records (relation shapes were verified against a real
+    /// index in the coupling spike).
+    struct IndexOccurrenceRecord: Sendable {
+        let usr: String
         let name: String
-        /// Syntax-derived kind when available: the index reports actors as
-        /// classes, so syntax wins.
-        let kind: NominalType
+        let kind: IndexSymbolKind
         let file: String
-        let location: SourceLocation
-        let suppressedMetrics: Set<SuppressedMetric>
+        let line: Int
+        let column: Int
+        let roles: SymbolRole
+        let relations: [RecordRelation]
     }
 
-    /// Project-internal types only, keyed by USR.
-    let nodes: [String: Node]
-    let outEdges: [String: Set<String>]
-    let inEdges: [String: Set<String>]
+    // MARK: - Outputs
 
-    func fanOut(of usr: String) -> Int { outEdges[usr]?.count ?? 0 }
-    func fanIn(of usr: String) -> Int { inEdges[usr]?.count ?? 0 }
-}
+    /// Type-to-type reference graph over project-internal nominal types.
+    struct ReferenceGraph: Sendable {
+        struct Node: Sendable {
+            let usr: String
+            /// Dotted display name from syntax when available (e.g. "Outer.Inner"),
+            /// otherwise the index symbol name.
+            let name: String
+            /// Syntax-derived kind when available: the index reports actors as
+            /// classes, so syntax wins.
+            let kind: NominalType
+            let file: String
+            let location: SourceLocation
+            let suppressedMetrics: Set<SuppressedMetric>
+        }
 
-/// Attribution accounting for one coupling run. Every reference lands in
-/// exactly one attributed/dropped bucket, so:
-/// refsTotal == attributedByContainedBy + attributedByBaseOf
-///            + attributedByLocation + droppedNonProjectSymbol
-///            + droppedTypealias + droppedUnattributable.
-/// Self-references are attributed but produce no edge; they are additionally
-/// counted in `selfReferencesSkipped`.
-///
-/// Public so the CLI can report attribution quality to stderr; construction
-/// and mutation stay internal to the analysis.
-public struct CouplingDiagnostics: Sendable, Equatable {
-    public internal(set) var refsTotal = 0
-    public internal(set) var attributedByContainedBy = 0
-    public internal(set) var attributedByBaseOf = 0
-    public internal(set) var attributedByLocation = 0
-    public internal(set) var droppedNonProjectSymbol = 0
-    public internal(set) var droppedTypealias = 0
-    public internal(set) var droppedUnattributable = 0
-    public internal(set) var selfReferencesSkipped = 0
+        /// Project-internal types only, keyed by USR.
+        let nodes: [String: Node]
+        let outEdges: [String: Set<String>]
+        let inEdges: [String: Set<String>]
 
-    /// References that resolved to a source type (self-references included).
-    public var attributedTotal: Int {
-        attributedByContainedBy + attributedByBaseOf + attributedByLocation
+        func fanOut(of usr: String) -> Int { outEdges[usr]?.count ?? 0 }
+        func fanIn(of usr: String) -> Int { inEdges[usr]?.count ?? 0 }
     }
-}
 
-// MARK: - Definition index (pass 1)
+    // MARK: - Definition index (pass 1)
 
-/// Definitions, parent chains, and extension resolution collected in one pass
-/// over the occurrences.
-private struct DefinitionIndex {
-    /// Index kinds that appear as nominal type definitions. Actors are
-    /// indexed as classes; the syntax side corrects the display kind.
-    static let typeKinds: Set<IndexSymbolKind> = [.class, .struct, .enum, .protocol]
+    /// Definitions, parent chains, and extension resolution collected in one pass
+    /// over the occurrences.
+    private struct DefinitionIndex {
+        /// Index kinds that appear as nominal type definitions. Actors are
+        /// indexed as classes; the syntax side corrects the display kind.
+        static let typeKinds: Set<IndexSymbolKind> = [.class, .struct, .enum, .protocol]
 
-    private(set) var defs: [String: IndexOccurrenceRecord] = [:]
-    private(set) var parentOf: [String: String] = [:]
-    private(set) var extensionToType: [String: String] = [:]
-    private(set) var typeUSRs: Set<String> = []
+        private(set) var defs: [String: IndexOccurrenceRecord] = [:]
+        private(set) var parentOf: [String: String] = [:]
+        private(set) var extensionToType: [String: String] = [:]
+        private(set) var typeUSRs: Set<String> = []
 
-    init(occurrences: [IndexOccurrenceRecord]) {
-        for record in occurrences {
-            if record.roles.contains(.definition) {
-                defs[record.usr] = record
-                if Self.typeKinds.contains(record.kind) {
-                    typeUSRs.insert(record.usr)
+        init(occurrences: [IndexOccurrenceRecord]) {
+            for record in occurrences {
+                if record.roles.contains(.definition) {
+                    defs[record.usr] = record
+                    if Self.typeKinds.contains(record.kind) {
+                        typeUSRs.insert(record.usr)
+                    }
+                    if let parent = record.relations.first(where: { $0.roles.contains(.childOf) }) {
+                        parentOf[record.usr] = parent.usr
+                    }
                 }
-                if let parent = record.relations.first(where: { $0.roles.contains(.childOf) }) {
-                    parentOf[record.usr] = parent.usr
+                // The reference to `Foo` in `extension Foo` carries an
+                // `extendedBy` relation pointing at the extension symbol.
+                if let extRelation = record.relations.first(where: {
+                    $0.roles.contains(.extendedBy)
+                }
+                ) {
+                    extensionToType[extRelation.usr] = record.usr
                 }
             }
-            // The reference to `Foo` in `extension Foo` carries an
-            // `extendedBy` relation pointing at the extension symbol.
-            if let extRelation = record.relations.first(where: { $0.roles.contains(.extendedBy) }
-            ) {
-                extensionToType[extRelation.usr] = record.usr
+        }
+
+        /// Walks a symbol up to its owning nominal type: extensions resolve to
+        /// the extended type, members resolve through childOf parents. The depth
+        /// cap turns corrupt parent cycles into a dropped ref instead of a hang.
+        func ownerType(of usr: String) -> String? {
+            var current = usr
+            for _ in 0..<16 {
+                if let extended = extensionToType[current] {
+                    current = extended
+                    continue
+                }
+                guard defs[current] != nil else { return nil }
+                if typeUSRs.contains(current) { return current }
+                guard let parent = parentOf[current] else { return nil }
+                current = parent
             }
+            return nil
         }
     }
 
-    /// Walks a symbol up to its owning nominal type: extensions resolve to
-    /// the extended type, members resolve through childOf parents. The depth
-    /// cap turns corrupt parent cycles into a dropped ref instead of a hang.
-    func ownerType(of usr: String) -> String? {
-        var current = usr
-        for _ in 0..<16 {
-            if let extended = extensionToType[current] {
-                current = extended
-                continue
+    // MARK: - Builder
+
+    /// Builds the type reference graph from index occurrences plus per-file
+    /// syntax ranges. Pure: no IndexStoreDB queries happen here.
+    enum ReferenceGraphBuilder {
+
+        static func build(
+            occurrences: [IndexOccurrenceRecord],
+            typeRanges: [String: TypeRangeIndex]
+        ) -> (graph: ReferenceGraph, diagnostics: CouplingDiagnostics) {
+            let index = DefinitionIndex(occurrences: occurrences)
+            let nodes = buildNodes(index: index, typeRanges: typeRanges)
+
+            var diagnostics = CouplingDiagnostics()
+            var outEdges: [String: Set<String>] = [:]
+            var inEdges: [String: Set<String>] = [:]
+
+            for record in occurrences
+            where record.roles.contains(.reference) || record.roles.contains(.call) {
+                diagnostics.refsTotal += 1
+                guard
+                    let edge = resolveEdge(
+                        for: record, index: index, nodes: nodes,
+                        typeRanges: typeRanges, diagnostics: &diagnostics)
+                else { continue }
+
+                if edge.source == edge.target {
+                    diagnostics.selfReferencesSkipped += 1
+                    continue
+                }
+                outEdges[edge.source, default: []].insert(edge.target)
+                inEdges[edge.target, default: []].insert(edge.source)
             }
-            guard defs[current] != nil else { return nil }
-            if typeUSRs.contains(current) { return current }
-            guard let parent = parentOf[current] else { return nil }
-            current = parent
+
+            let graph = ReferenceGraph(nodes: nodes, outEdges: outEdges, inEdges: inEdges)
+            return (graph, diagnostics)
         }
-        return nil
-    }
-}
 
-// MARK: - Builder
+        // MARK: Node metadata
 
-/// Builds the type reference graph from index occurrences plus per-file
-/// syntax ranges. Pure: no IndexStoreDB queries happen here.
-enum ReferenceGraphBuilder {
+        /// Joins index definitions with syntax ranges for dotted names, actor
+        /// kinds, and suppression.
+        private static func buildNodes(
+            index: DefinitionIndex, typeRanges: [String: TypeRangeIndex]
+        ) -> [String: ReferenceGraph.Node] {
+            var nodes: [String: ReferenceGraph.Node] = [:]
+            for usr in index.typeUSRs {
+                guard let def = index.defs[usr] else { continue }
+                let entry = typeRanges[def.file]?.innermostType(line: def.line, column: def.column)
 
-    static func build(
-        occurrences: [IndexOccurrenceRecord],
-        typeRanges: [String: TypeRangeIndex]
-    ) -> (graph: ReferenceGraph, diagnostics: CouplingDiagnostics) {
-        let index = DefinitionIndex(occurrences: occurrences)
-        let nodes = buildNodes(index: index, typeRanges: typeRanges)
+                let kind: NominalType
+                if case .nominal(let syntaxKind)? = entry?.declKind {
+                    kind = syntaxKind
+                } else {
+                    kind = fallbackKind(for: def.kind)
+                }
 
-        var diagnostics = CouplingDiagnostics()
-        var outEdges: [String: Set<String>] = [:]
-        var inEdges: [String: Set<String>] = [:]
+                nodes[usr] = ReferenceGraph.Node(
+                    usr: usr,
+                    name: entry?.name ?? def.name,
+                    kind: kind,
+                    file: def.file,
+                    location: SourceLocation(line: def.line, column: def.column),
+                    suppressedMetrics: entry.map(\.suppressedMetrics) ?? []
+                )
+            }
+            return nodes
+        }
 
-        for record in occurrences
-        where record.roles.contains(.reference) || record.roles.contains(.call) {
-            diagnostics.refsTotal += 1
+        private static func fallbackKind(for indexKind: IndexSymbolKind) -> NominalType {
+            switch indexKind {
+            case .struct: return .struct
+            case .enum: return .enum
+            case .protocol: return .protocol
+            default: return .class
+            }
+        }
+
+        // MARK: Edge resolution (pass 2)
+
+        /// Resolves one reference into a source/target type pair, or records why
+        /// it was dropped.
+        private static func resolveEdge(
+            for record: IndexOccurrenceRecord,
+            index: DefinitionIndex,
+            nodes: [String: ReferenceGraph.Node],
+            typeRanges: [String: TypeRangeIndex],
+            diagnostics: inout CouplingDiagnostics
+        ) -> (source: String, target: String)? {
+            // Typealias references are excluded from coupling: resolving through
+            // the alias would need semantic type information the index does not
+            // expose directly.
+            if record.kind == .typealias {
+                diagnostics.droppedTypealias += 1
+                return nil
+            }
+            guard index.defs[record.usr] != nil else {
+                diagnostics.droppedNonProjectSymbol += 1
+                return nil
+            }
+            guard let target = index.ownerType(of: record.usr) else {
+                diagnostics.droppedUnattributable += 1
+                return nil
+            }
             guard
-                let edge = resolveEdge(
+                let source = resolveSource(
                     for: record, index: index, nodes: nodes,
                     typeRanges: typeRanges, diagnostics: &diagnostics)
-            else { continue }
-
-            if edge.source == edge.target {
-                diagnostics.selfReferencesSkipped += 1
-                continue
+            else {
+                diagnostics.droppedUnattributable += 1
+                return nil
             }
-            outEdges[edge.source, default: []].insert(edge.target)
-            inEdges[edge.target, default: []].insert(edge.source)
+            return (source, target)
         }
 
-        let graph = ReferenceGraph(nodes: nodes, outEdges: outEdges, inEdges: inEdges)
-        return (graph, diagnostics)
-    }
-
-    // MARK: Node metadata
-
-    /// Joins index definitions with syntax ranges for dotted names, actor
-    /// kinds, and suppression.
-    private static func buildNodes(
-        index: DefinitionIndex, typeRanges: [String: TypeRangeIndex]
-    ) -> [String: ReferenceGraph.Node] {
-        var nodes: [String: ReferenceGraph.Node] = [:]
-        for usr in index.typeUSRs {
-            guard let def = index.defs[usr] else { continue }
-            let entry = typeRanges[def.file]?.innermostType(line: def.line, column: def.column)
-
-            let kind: NominalType
-            if case .nominal(let syntaxKind)? = entry?.declKind {
-                kind = syntaxKind
-            } else {
-                kind = fallbackKind(for: def.kind)
+        /// Resolves who holds a reference. Attribution cascades from the most to
+        /// the least semantic evidence:
+        /// 1. containedBy - the reference sits inside a declaration.
+        /// 2. baseOf - inheritance/conformance clauses carry only this relation,
+        ///    pointing at the inheriting type.
+        /// 3. Syntax location - e.g. enum case payload annotations carry no
+        ///    relations at all.
+        private static func resolveSource(
+            for record: IndexOccurrenceRecord,
+            index: DefinitionIndex,
+            nodes: [String: ReferenceGraph.Node],
+            typeRanges: [String: TypeRangeIndex],
+            diagnostics: inout CouplingDiagnostics
+        ) -> String? {
+            if let container = record.relations.first(where: { $0.roles.contains(.containedBy) }),
+                let resolved = index.ownerType(of: container.usr)
+            {
+                diagnostics.attributedByContainedBy += 1
+                return resolved
             }
-
-            nodes[usr] = ReferenceGraph.Node(
-                usr: usr,
-                name: entry?.name ?? def.name,
-                kind: kind,
-                file: def.file,
-                location: SourceLocation(line: def.line, column: def.column),
-                suppressedMetrics: entry.map(\.suppressedMetrics) ?? []
-            )
-        }
-        return nodes
-    }
-
-    private static func fallbackKind(for indexKind: IndexSymbolKind) -> NominalType {
-        switch indexKind {
-        case .struct: return .struct
-        case .enum: return .enum
-        case .protocol: return .protocol
-        default: return .class
-        }
-    }
-
-    // MARK: Edge resolution (pass 2)
-
-    /// Resolves one reference into a source/target type pair, or records why
-    /// it was dropped.
-    private static func resolveEdge(
-        for record: IndexOccurrenceRecord,
-        index: DefinitionIndex,
-        nodes: [String: ReferenceGraph.Node],
-        typeRanges: [String: TypeRangeIndex],
-        diagnostics: inout CouplingDiagnostics
-    ) -> (source: String, target: String)? {
-        // Typealias references are excluded from coupling: resolving through
-        // the alias would need semantic type information the index does not
-        // expose directly.
-        if record.kind == .typealias {
-            diagnostics.droppedTypealias += 1
+            if let base = record.relations.first(where: { $0.roles.contains(.baseOf) }),
+                let resolved = index.ownerType(of: base.usr)
+            {
+                diagnostics.attributedByBaseOf += 1
+                return resolved
+            }
+            if let entry = typeRanges[record.file]?.innermostType(
+                line: record.line, column: record.column),
+                let resolved = typeUSR(
+                    named: entry.resolvedTypeName, inFile: record.file, nodes: nodes)
+            {
+                diagnostics.attributedByLocation += 1
+                return resolved
+            }
             return nil
         }
-        guard index.defs[record.usr] != nil else {
-            diagnostics.droppedNonProjectSymbol += 1
-            return nil
-        }
-        guard let target = index.ownerType(of: record.usr) else {
-            diagnostics.droppedUnattributable += 1
-            return nil
-        }
-        guard
-            let source = resolveSource(
-                for: record, index: index, nodes: nodes,
-                typeRanges: typeRanges, diagnostics: &diagnostics)
-        else {
-            diagnostics.droppedUnattributable += 1
-            return nil
-        }
-        return (source, target)
-    }
 
-    /// Resolves who holds a reference. Attribution cascades from the most to
-    /// the least semantic evidence:
-    /// 1. containedBy - the reference sits inside a declaration.
-    /// 2. baseOf - inheritance/conformance clauses carry only this relation,
-    ///    pointing at the inheriting type.
-    /// 3. Syntax location - e.g. enum case payload annotations carry no
-    ///    relations at all.
-    private static func resolveSource(
-        for record: IndexOccurrenceRecord,
-        index: DefinitionIndex,
-        nodes: [String: ReferenceGraph.Node],
-        typeRanges: [String: TypeRangeIndex],
-        diagnostics: inout CouplingDiagnostics
-    ) -> String? {
-        if let container = record.relations.first(where: { $0.roles.contains(.containedBy) }),
-            let resolved = index.ownerType(of: container.usr)
-        {
-            diagnostics.attributedByContainedBy += 1
-            return resolved
+        /// Maps a syntax type name back to a USR. Exact name matches win over
+        /// dotted-suffix matches, same-file candidates win over other files, and
+        /// an ambiguous name resolves to nil rather than guessing a wrong edge.
+        private static func typeUSR(
+            named name: String, inFile file: String, nodes: [String: ReferenceGraph.Node]
+        ) -> String? {
+            let exact = nodes.values.filter { $0.name == name }
+            let candidates =
+                exact.isEmpty
+                ? nodes.values.filter { $0.name.hasSuffix(".\(name)") }
+                : exact
+            let sameFile = candidates.filter { $0.file == file }
+            if sameFile.count == 1 { return sameFile[0].usr }
+            return candidates.count == 1 ? candidates.first?.usr : nil
         }
-        if let base = record.relations.first(where: { $0.roles.contains(.baseOf) }),
-            let resolved = index.ownerType(of: base.usr)
-        {
-            diagnostics.attributedByBaseOf += 1
-            return resolved
-        }
-        if let entry = typeRanges[record.file]?.innermostType(
-            line: record.line, column: record.column),
-            let resolved = typeUSR(named: entry.resolvedTypeName, inFile: record.file, nodes: nodes)
-        {
-            diagnostics.attributedByLocation += 1
-            return resolved
-        }
-        return nil
     }
-
-    /// Maps a syntax type name back to a USR. Exact name matches win over
-    /// dotted-suffix matches, same-file candidates win over other files, and
-    /// an ambiguous name resolves to nil rather than guessing a wrong edge.
-    private static func typeUSR(
-        named name: String, inFile file: String, nodes: [String: ReferenceGraph.Node]
-    ) -> String? {
-        let exact = nodes.values.filter { $0.name == name }
-        let candidates =
-            exact.isEmpty
-            ? nodes.values.filter { $0.name.hasSuffix(".\(name)") }
-            : exact
-        let sameFile = candidates.filter { $0.file == file }
-        if sameFile.count == 1 { return sameFile[0].usr }
-        return candidates.count == 1 ? candidates.first?.usr : nil
-    }
-}
+#endif

--- a/Sources/SwiftComplexityCore/Analysis/SemanticLCOMCalculator.swift
+++ b/Sources/SwiftComplexityCore/Analysis/SemanticLCOMCalculator.swift
@@ -1,487 +1,500 @@
-import Foundation
-import IndexStoreDB
-import SwiftSyntax
+#if IndexStore
+    import Foundation
+    import IndexStoreDB
+    import SwiftSyntax
 
-// MARK: - Error Types
-
-enum LCOMError: LocalizedError {
-    case noMembersFound(className: String)
-    case parsingFailed(className: String, underlying: Error)
-    case symbolNotFound(symbolName: String, usr: String?)
-    case queryTimeout(query: String)
-
-    var errorDescription: String? {
-        switch self {
-        case .noMembersFound(let className):
-            return "No members found in class '\(className)'"
-        case .parsingFailed(let className, let error):
-            return "Failed to parse class '\(className)': \(error.localizedDescription)"
-        case .symbolNotFound(let symbolName, let usr):
-            let usrInfo = usr.map { " (USR: \($0))" } ?? ""
-            return "Symbol '\(symbolName)' not found in index\(usrInfo)"
-        case .queryTimeout(let query):
-            return "IndexStoreDB query timed out: \(query)"
-        }
-    }
-}
-
-// MARK: - Union-Find Data Structure
-
-/// Union-Find for efficient connected component counting
-class UnionFind {
-    private var parent: [String: String] = [:]
-    private var rank: [String: Int] = [:]
-
-    init(elements: [String]) {
-        for element in elements {
-            parent[element] = element
-            rank[element] = 0
+    extension NominalTypeKind {
+        var symbolKind: IndexSymbolKind {
+            switch self {
+            case .class: return .class
+            case .struct: return .struct
+            case .actor: return .class  // actor is also handled as IndexSymbolKind.class
+            }
         }
     }
 
-    /// Finds the root of an element (with path compression)
-    func find(_ element: String) -> String {
-        guard let p = parent[element] else { return element }
-        if p != element {
-            parent[element] = find(p)  // Path compression
-        }
-        return parent[element]!
-    }
+    // MARK: - Error Types
 
-    /// Merges two elements into the same set
-    func union(_ a: String, _ b: String) {
-        let rootA = find(a)
-        let rootB = find(b)
+    enum LCOMError: LocalizedError {
+        case noMembersFound(className: String)
+        case parsingFailed(className: String, underlying: Error)
+        case symbolNotFound(symbolName: String, usr: String?)
+        case queryTimeout(query: String)
 
-        if rootA == rootB { return }
-
-        let rankA = rank[rootA] ?? 0
-        let rankB = rank[rootB] ?? 0
-
-        if rankA < rankB {
-            parent[rootA] = rootB
-        } else if rankA > rankB {
-            parent[rootB] = rootA
-        } else {
-            parent[rootB] = rootA
-            rank[rootA] = rankA + 1
+        var errorDescription: String? {
+            switch self {
+            case .noMembersFound(let className):
+                return "No members found in class '\(className)'"
+            case .parsingFailed(let className, let error):
+                return "Failed to parse class '\(className)': \(error.localizedDescription)"
+            case .symbolNotFound(let symbolName, let usr):
+                let usrInfo = usr.map { " (USR: \($0))" } ?? ""
+                return "Symbol '\(symbolName)' not found in index\(usrInfo)"
+            case .queryTimeout(let query):
+                return "IndexStoreDB query timed out: \(query)"
+            }
         }
     }
 
-    /// Calculates the number of connected components
-    func componentCount() -> Int {
-        var roots = Set<String>()
-        for element in parent.keys {
-            roots.insert(find(element))
+    // MARK: - Union-Find Data Structure
+
+    /// Union-Find for efficient connected component counting
+    class UnionFind {
+        private var parent: [String: String] = [:]
+        private var rank: [String: Int] = [:]
+
+        init(elements: [String]) {
+            for element in elements {
+                parent[element] = element
+                rank[element] = 0
+            }
         }
-        return roots.count
+
+        /// Finds the root of an element (with path compression)
+        func find(_ element: String) -> String {
+            guard let p = parent[element] else { return element }
+            if p != element {
+                parent[element] = find(p)  // Path compression
+            }
+            return parent[element]!
+        }
+
+        /// Merges two elements into the same set
+        func union(_ a: String, _ b: String) {
+            let rootA = find(a)
+            let rootB = find(b)
+
+            if rootA == rootB { return }
+
+            let rankA = rank[rootA] ?? 0
+            let rankB = rank[rootB] ?? 0
+
+            if rankA < rankB {
+                parent[rootA] = rootB
+            } else if rankA > rankB {
+                parent[rootB] = rootA
+            } else {
+                parent[rootB] = rootA
+                rank[rootA] = rankA + 1
+            }
+        }
+
+        /// Calculates the number of connected components
+        func componentCount() -> Int {
+            var roots = Set<String>()
+            for element in parent.keys {
+                roots.insert(find(element))
+            }
+            return roots.count
+        }
     }
-}
 
-// MARK: - Semantic LCOM Calculator
+    // MARK: - Semantic LCOM Calculator
 
-/// LCOM4 calculation engine with IndexStore-DB integration (high accuracy: 90-95%)
-actor SemanticLCOMCalculator {
-    private let indexStoreDB: IndexStoreDB
-    private let indexStorePath: URL
+    /// LCOM4 calculation engine with IndexStore-DB integration (high accuracy: 90-95%)
+    actor SemanticLCOMCalculator {
+        private let indexStoreDB: IndexStoreDB
+        private let indexStorePath: URL
 
-    /// Initialize with an already opened index store, shared with other
-    /// index-backed calculators so the database is populated only once.
-    init(indexStore: SharedIndexStore) {
-        self.indexStoreDB = indexStore.database
-        self.indexStorePath = indexStore.storePath
-    }
+        /// Initialize with an already opened index store, shared with other
+        /// index-backed calculators so the database is populated only once.
+        init(indexStore: SharedIndexStore) {
+            self.indexStoreDB = indexStore.database
+            self.indexStorePath = indexStore.storePath
+        }
 
-    /// Initialize with explicit IndexStore path
-    /// - Parameters:
-    ///   - indexStorePath: Direct path to the IndexStore (e.g., .build/debug/index/store)
-    ///   - toolchainPath: Optional Swift toolchain path (e.g., /path/to/toolchain/usr).
-    ///                    On macOS, if nil, Xcode toolchain is auto-detected.
-    ///                    On Linux, this is required.
-    init(indexStorePath: URL, toolchainPath: URL? = nil) throws {
-        let store = try IndexStoreService.open(
-            indexStorePath: indexStorePath, toolchainPath: toolchainPath)
-        self.indexStoreDB = store.database
-        self.indexStorePath = store.storePath
-    }
+        /// Initialize with explicit IndexStore path
+        /// - Parameters:
+        ///   - indexStorePath: Direct path to the IndexStore (e.g., .build/debug/index/store)
+        ///   - toolchainPath: Optional Swift toolchain path (e.g., /path/to/toolchain/usr).
+        ///                    On macOS, if nil, Xcode toolchain is auto-detected.
+        ///                    On Linux, this is required.
+        init(indexStorePath: URL, toolchainPath: URL? = nil) throws {
+            let store = try IndexStoreService.open(
+                indexStorePath: indexStorePath, toolchainPath: toolchainPath)
+            self.indexStoreDB = store.database
+            self.indexStorePath = store.storePath
+        }
 
-    /// Calculates LCOM4 value for Nominal Type (class/struct/actor)
-    func calculate(for detectedType: DetectedNominal) async throws -> Int {
-        // 1. Get USR from DetectedNominal
-        guard
-            let classUSR = try await findUSR(
-                for: detectedType.name,
-                kind: detectedType.type.symbolKind
+        /// Calculates LCOM4 value for Nominal Type (class/struct/actor)
+        func calculate(for detectedType: DetectedNominal) async throws -> Int {
+            // 1. Get USR from DetectedNominal
+            guard
+                let classUSR = try await findUSR(
+                    for: detectedType.name,
+                    kind: detectedType.type.symbolKind
+                )
+            else {
+                // Fall back to basic syntax analysis if symbol not found
+                return calculateFromSyntax(for: detectedType)
+            }
+
+            // 2. Get members (methods and properties)
+            let members = try await queryMembers(of: classUSR)
+
+            let methods = members.filter {
+                $0.symbol.kind == .instanceMethod || $0.symbol.kind == .constructor
+            }
+            let properties = members.filter { $0.symbol.kind == .instanceProperty }
+
+            // Early returns
+            if methods.isEmpty { return 0 }
+            if methods.count == 1 { return properties.isEmpty ? 0 : 1 }
+            if properties.isEmpty { return 0 }
+
+            // 3. Detect properties accessed by each method
+            var methodToProperties: [String: Set<String>] = [:]
+
+            for method in methods {
+                let accessedProperties = try await findAccessedProperties(
+                    methodUSR: method.symbol.usr,
+                    properties: properties
+                )
+                methodToProperties[method.symbol.name] = accessedProperties
+            }
+
+            // 4. Detect method call relationships
+            var methodCalls: [(String, String)] = []
+
+            for method in methods {
+                let calledMethods = try await findCalledMethods(
+                    methodUSR: method.symbol.usr,
+                    allMethods: methods
+                )
+                for called in calledMethods {
+                    methodCalls.append((method.symbol.name, called))
+                }
+            }
+
+            // 5. Calculate connected components using Union-Find
+            return calculateConnectedComponents(
+                methods: methods.map(\.symbol.name),
+                methodToProperties: methodToProperties,
+                methodCalls: methodCalls
             )
-        else {
-            // Fall back to basic syntax analysis if symbol not found
-            return calculateFromSyntax(for: detectedType)
         }
 
-        // 2. Get members (methods and properties)
-        let members = try await queryMembers(of: classUSR)
+        // MARK: - IndexStore-DB Integration
 
-        let methods = members.filter {
-            $0.symbol.kind == .instanceMethod || $0.symbol.kind == .constructor
+        /// Searches for USR of class/struct/actor
+        private func findUSR(for name: String, kind: IndexSymbolKind) async throws -> String? {
+            return try await withCheckedThrowingContinuation { continuation in
+                var foundUSR: String? = nil
+
+                indexStoreDB.forEachCanonicalSymbolOccurrence(
+                    containing: name,
+                    anchorStart: false,
+                    anchorEnd: false,
+                    subsequence: false,
+                    ignoreCase: false
+                ) { occurrence in
+                    if occurrence.symbol.name == name && occurrence.symbol.kind == kind {
+                        foundUSR = occurrence.symbol.usr
+                        return false  // Stop search
+                    }
+                    return true  // Continue search
+                }
+
+                continuation.resume(returning: foundUSR)
+            }
         }
-        let properties = members.filter { $0.symbol.kind == .instanceProperty }
 
-        // Early returns
-        if methods.isEmpty { return 0 }
-        if methods.count == 1 { return properties.isEmpty ? 0 : 1 }
-        if properties.isEmpty { return 0 }
+        /// Gets members of class/struct/actor
+        private func queryMembers(of classUSR: String) async throws -> [SymbolOccurrence] {
+            var members: [SymbolOccurrence] = []
 
-        // 3. Detect properties accessed by each method
-        var methodToProperties: [String: Set<String>] = [:]
+            try await withCheckedThrowingContinuation {
+                (continuation: CheckedContinuation<Void, Error>) in
+                indexStoreDB.forEachRelatedSymbolOccurrence(
+                    byUSR: classUSR,
+                    roles: .childOf
+                ) { occurrence in
+                    members.append(occurrence)
+                    return true  // Continue search
+                }
+                continuation.resume()
+            }
 
-        for method in methods {
-            let accessedProperties = try await findAccessedProperties(
-                methodUSR: method.symbol.usr,
+            return members
+        }
+
+        /// Detects properties accessed by a method
+        private func findAccessedProperties(
+            methodUSR: String,
+            properties: [SymbolOccurrence]
+        ) async throws -> Set<String> {
+            var accessedProperties: Set<String> = []
+
+            for property in properties {
+                // Search for references to property
+                let hasReference = try await withCheckedThrowingContinuation {
+                    (continuation: CheckedContinuation<Bool, Error>) in
+                    var found = false
+
+                    indexStoreDB.forEachSymbolOccurrence(
+                        byUSR: property.symbol.usr,
+                        roles: .reference
+                    ) { occurrence in
+                        // Check if reference is within the method
+                        if occurrence.relations.contains(where: {
+                            $0.symbol.usr == methodUSR && $0.roles.contains(.containedBy)
+                        }) {
+                            found = true
+                            return false  // Stop search
+                        }
+                        return true  // Continue search
+                    }
+
+                    continuation.resume(returning: found)
+                }
+
+                if hasReference {
+                    accessedProperties.insert(property.symbol.name)
+                }
+            }
+
+            return accessedProperties
+        }
+
+        /// Detects other methods called by a method
+        private func findCalledMethods(
+            methodUSR: String,
+            allMethods: [SymbolOccurrence]
+        ) async throws -> Set<String> {
+            var calledMethods: Set<String> = []
+
+            for targetMethod in allMethods {
+                if targetMethod.symbol.usr == methodUSR { continue }
+
+                // Search for method calls
+                let isCalled = try await withCheckedThrowingContinuation {
+                    (continuation: CheckedContinuation<Bool, Error>) in
+                    var found = false
+
+                    indexStoreDB.forEachSymbolOccurrence(
+                        byUSR: targetMethod.symbol.usr,
+                        roles: .call
+                    ) { occurrence in
+                        // Check if caller is the target method
+                        if occurrence.relations.contains(where: {
+                            $0.symbol.usr == methodUSR && $0.roles.contains(.containedBy)
+                        }) {
+                            found = true
+                            return false  // Stop search
+                        }
+                        return true  // Continue search
+                    }
+
+                    continuation.resume(returning: found)
+                }
+
+                if isCalled {
+                    calledMethods.insert(targetMethod.symbol.name)
+                }
+            }
+
+            return calledMethods
+        }
+
+        // MARK: - Connected Components Calculation
+
+        /// Calculates connected components using Union-Find
+        private func calculateConnectedComponents(
+            methods: [String],
+            methodToProperties: [String: Set<String>],
+            methodCalls: [(String, String)]
+        ) -> Int {
+            let uf = UnionFind(elements: methods)
+
+            // Edge 1: Shared property access
+            for (methodA, propertiesA) in methodToProperties {
+                for (methodB, propertiesB) in methodToProperties {
+                    if methodA == methodB { continue }
+                    if !propertiesA.intersection(propertiesB).isEmpty {
+                        uf.union(methodA, methodB)
+                    }
+                }
+            }
+
+            // Edge 2: Method call relationships
+            for (caller, callee) in methodCalls {
+                uf.union(caller, callee)
+            }
+
+            return uf.componentCount()
+        }
+
+        // MARK: - Syntax Fallback
+
+        /// Basic syntax analysis when symbol not found in IndexStore-DB
+        private func calculateFromSyntax(for detectedType: DetectedNominal) -> Int {
+            let (methods, properties) = extractMembersFromSyntax(detectedType.members)
+
+            if methods.isEmpty { return 0 }
+            if methods.count == 1 { return properties.isEmpty ? 0 : 1 }
+            if properties.isEmpty { return 0 }
+
+            let methodToProperties = extractPropertyAccessFromSyntax(
+                methods: methods,
                 properties: properties
             )
-            methodToProperties[method.symbol.name] = accessedProperties
-        }
 
-        // 4. Detect method call relationships
-        var methodCalls: [(String, String)] = []
+            let methodCalls = extractMethodCallsFromSyntax(methods: methods)
 
-        for method in methods {
-            let calledMethods = try await findCalledMethods(
-                methodUSR: method.symbol.usr,
-                allMethods: methods
+            return calculateConnectedComponents(
+                methods: methods.map(\.name),
+                methodToProperties: methodToProperties,
+                methodCalls: methodCalls
             )
-            for called in calledMethods {
-                methodCalls.append((method.symbol.name, called))
-            }
         }
 
-        // 5. Calculate connected components using Union-Find
-        return calculateConnectedComponents(
-            methods: methods.map(\.symbol.name),
-            methodToProperties: methodToProperties,
-            methodCalls: methodCalls
-        )
-    }
+        private func extractMembersFromSyntax(
+            _ members: MemberBlockItemListSyntax
+        ) -> (methods: [(name: String, body: CodeBlockSyntax?)], properties: [String]) {
+            var methods: [(name: String, body: CodeBlockSyntax?)] = []
+            var properties: [String] = []
 
-    // MARK: - IndexStore-DB Integration
-
-    /// Searches for USR of class/struct/actor
-    private func findUSR(for name: String, kind: IndexSymbolKind) async throws -> String? {
-        return try await withCheckedThrowingContinuation { continuation in
-            var foundUSR: String? = nil
-
-            indexStoreDB.forEachCanonicalSymbolOccurrence(
-                containing: name,
-                anchorStart: false,
-                anchorEnd: false,
-                subsequence: false,
-                ignoreCase: false
-            ) { occurrence in
-                if occurrence.symbol.name == name && occurrence.symbol.kind == kind {
-                    foundUSR = occurrence.symbol.usr
-                    return false  // Stop search
+            for member in members {
+                if let method = extractMethod(from: member.decl) {
+                    methods.append(method)
                 }
-                return true  // Continue search
+                properties.append(contentsOf: extractStoredProperties(from: member.decl))
             }
 
-            continuation.resume(returning: foundUSR)
+            return (methods, properties)
         }
-    }
 
-    /// Gets members of class/struct/actor
-    private func queryMembers(of classUSR: String) async throws -> [SymbolOccurrence] {
-        var members: [SymbolOccurrence] = []
+        /// Checks for static modifier
+        private func isStatic(_ modifiers: DeclModifierListSyntax) -> Bool {
+            modifiers.contains { $0.name.text == "static" }
+        }
 
-        try await withCheckedThrowingContinuation {
-            (continuation: CheckedContinuation<Void, Error>) in
-            indexStoreDB.forEachRelatedSymbolOccurrence(
-                byUSR: classUSR,
-                roles: .childOf
-            ) { occurrence in
-                members.append(occurrence)
-                return true  // Continue search
+        /// Extracts method (function, init, deinit) from DeclSyntax
+        private func extractMethod(from decl: DeclSyntax) -> (name: String, body: CodeBlockSyntax?)?
+        {
+            if let functionDecl = decl.as(FunctionDeclSyntax.self) {
+                guard !isStatic(functionDecl.modifiers) else { return nil }
+                return (name: functionDecl.name.text, body: functionDecl.body)
+            } else if let initDecl = decl.as(InitializerDeclSyntax.self) {
+                return (name: "init", body: initDecl.body)
+            } else if let deinitDecl = decl.as(DeinitializerDeclSyntax.self) {
+                return (name: "deinit", body: deinitDecl.body)
             }
-            continuation.resume()
+            return nil
         }
 
-        return members
+        /// Extracts stored properties from DeclSyntax
+        private func extractStoredProperties(from decl: DeclSyntax) -> [String] {
+            guard let variableDecl = decl.as(VariableDeclSyntax.self),
+                !isStatic(variableDecl.modifiers)
+            else { return [] }
+
+            return variableDecl.bindings.compactMap { binding in
+                guard let pattern = binding.pattern.as(IdentifierPatternSyntax.self),
+                    binding.accessorBlock == nil
+                else { return nil }
+                return pattern.identifier.text
+            }
+        }
+
+        private func extractPropertyAccessFromSyntax(
+            methods: [(name: String, body: CodeBlockSyntax?)],
+            properties: [String]
+        ) -> [String: Set<String>] {
+            var methodToProperties: [String: Set<String>] = [:]
+
+            for method in methods {
+                guard let body = method.body else { continue }
+
+                var accessedProperties = Set<String>()
+                let visitor = PropertyAccessVisitor(properties: properties)
+                visitor.walk(body)
+                accessedProperties.formUnion(visitor.accessedProperties)
+
+                methodToProperties[method.name] = accessedProperties
+            }
+
+            return methodToProperties
+        }
+
+        private func extractMethodCallsFromSyntax(
+            methods: [(name: String, body: CodeBlockSyntax?)]
+        ) -> [(String, String)] {
+            var methodCalls: [(String, String)] = []
+            let methodNames = Set(methods.map(\.name))
+
+            for method in methods {
+                guard let body = method.body else { continue }
+
+                let visitor = MethodCallVisitor(methodNames: methodNames)
+                visitor.walk(body)
+
+                for calledMethod in visitor.calledMethods {
+                    methodCalls.append((method.name, calledMethod))
+                }
+            }
+
+            return methodCalls
+        }
+
     }
 
-    /// Detects properties accessed by a method
-    private func findAccessedProperties(
-        methodUSR: String,
-        properties: [SymbolOccurrence]
-    ) async throws -> Set<String> {
+    // MARK: - Syntax Visitors (Fallback)
+
+    /// Visitor for detecting property access
+    private class PropertyAccessVisitor: SyntaxVisitor {
+        let properties: [String]
         var accessedProperties: Set<String> = []
 
-        for property in properties {
-            // Search for references to property
-            let hasReference = try await withCheckedThrowingContinuation {
-                (continuation: CheckedContinuation<Bool, Error>) in
-                var found = false
-
-                indexStoreDB.forEachSymbolOccurrence(
-                    byUSR: property.symbol.usr,
-                    roles: .reference
-                ) { occurrence in
-                    // Check if reference is within the method
-                    if occurrence.relations.contains(where: {
-                        $0.symbol.usr == methodUSR && $0.roles.contains(.containedBy)
-                    }) {
-                        found = true
-                        return false  // Stop search
-                    }
-                    return true  // Continue search
-                }
-
-                continuation.resume(returning: found)
-            }
-
-            if hasReference {
-                accessedProperties.insert(property.symbol.name)
-            }
+        init(properties: [String]) {
+            self.properties = properties
+            super.init(viewMode: .sourceAccurate)
         }
 
-        return accessedProperties
+        override func visit(_ node: MemberAccessExprSyntax) -> SyntaxVisitorContinueKind {
+            if let base = node.base?.as(DeclReferenceExprSyntax.self),
+                base.baseName.text == "self"
+            {
+                let memberName = node.declName.baseName.text
+                if properties.contains(memberName) {
+                    accessedProperties.insert(memberName)
+                }
+            }
+            return .visitChildren
+        }
+
+        override func visit(_ node: DeclReferenceExprSyntax) -> SyntaxVisitorContinueKind {
+            let name = node.baseName.text
+            if properties.contains(name) {
+                accessedProperties.insert(name)
+            }
+            return .visitChildren
+        }
     }
 
-    /// Detects other methods called by a method
-    private func findCalledMethods(
-        methodUSR: String,
-        allMethods: [SymbolOccurrence]
-    ) async throws -> Set<String> {
+    /// Visitor for detecting method calls
+    private class MethodCallVisitor: SyntaxVisitor {
+        let methodNames: Set<String>
         var calledMethods: Set<String> = []
 
-        for targetMethod in allMethods {
-            if targetMethod.symbol.usr == methodUSR { continue }
-
-            // Search for method calls
-            let isCalled = try await withCheckedThrowingContinuation {
-                (continuation: CheckedContinuation<Bool, Error>) in
-                var found = false
-
-                indexStoreDB.forEachSymbolOccurrence(
-                    byUSR: targetMethod.symbol.usr,
-                    roles: .call
-                ) { occurrence in
-                    // Check if caller is the target method
-                    if occurrence.relations.contains(where: {
-                        $0.symbol.usr == methodUSR && $0.roles.contains(.containedBy)
-                    }) {
-                        found = true
-                        return false  // Stop search
-                    }
-                    return true  // Continue search
-                }
-
-                continuation.resume(returning: found)
-            }
-
-            if isCalled {
-                calledMethods.insert(targetMethod.symbol.name)
-            }
+        init(methodNames: Set<String>) {
+            self.methodNames = methodNames
+            super.init(viewMode: .sourceAccurate)
         }
 
-        return calledMethods
-    }
-
-    // MARK: - Connected Components Calculation
-
-    /// Calculates connected components using Union-Find
-    private func calculateConnectedComponents(
-        methods: [String],
-        methodToProperties: [String: Set<String>],
-        methodCalls: [(String, String)]
-    ) -> Int {
-        let uf = UnionFind(elements: methods)
-
-        // Edge 1: Shared property access
-        for (methodA, propertiesA) in methodToProperties {
-            for (methodB, propertiesB) in methodToProperties {
-                if methodA == methodB { continue }
-                if !propertiesA.intersection(propertiesB).isEmpty {
-                    uf.union(methodA, methodB)
+        override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
+            if let memberAccess = node.calledExpression.as(MemberAccessExprSyntax.self) {
+                let methodName = memberAccess.declName.baseName.text
+                if methodNames.contains(methodName) {
+                    calledMethods.insert(methodName)
+                }
+            } else if let declRef = node.calledExpression.as(DeclReferenceExprSyntax.self) {
+                let methodName = declRef.baseName.text
+                if methodNames.contains(methodName) {
+                    calledMethods.insert(methodName)
                 }
             }
-        }
-
-        // Edge 2: Method call relationships
-        for (caller, callee) in methodCalls {
-            uf.union(caller, callee)
-        }
-
-        return uf.componentCount()
-    }
-
-    // MARK: - Syntax Fallback
-
-    /// Basic syntax analysis when symbol not found in IndexStore-DB
-    private func calculateFromSyntax(for detectedType: DetectedNominal) -> Int {
-        let (methods, properties) = extractMembersFromSyntax(detectedType.members)
-
-        if methods.isEmpty { return 0 }
-        if methods.count == 1 { return properties.isEmpty ? 0 : 1 }
-        if properties.isEmpty { return 0 }
-
-        let methodToProperties = extractPropertyAccessFromSyntax(
-            methods: methods,
-            properties: properties
-        )
-
-        let methodCalls = extractMethodCallsFromSyntax(methods: methods)
-
-        return calculateConnectedComponents(
-            methods: methods.map(\.name),
-            methodToProperties: methodToProperties,
-            methodCalls: methodCalls
-        )
-    }
-
-    private func extractMembersFromSyntax(
-        _ members: MemberBlockItemListSyntax
-    ) -> (methods: [(name: String, body: CodeBlockSyntax?)], properties: [String]) {
-        var methods: [(name: String, body: CodeBlockSyntax?)] = []
-        var properties: [String] = []
-
-        for member in members {
-            if let method = extractMethod(from: member.decl) {
-                methods.append(method)
-            }
-            properties.append(contentsOf: extractStoredProperties(from: member.decl))
-        }
-
-        return (methods, properties)
-    }
-
-    /// Checks for static modifier
-    private func isStatic(_ modifiers: DeclModifierListSyntax) -> Bool {
-        modifiers.contains { $0.name.text == "static" }
-    }
-
-    /// Extracts method (function, init, deinit) from DeclSyntax
-    private func extractMethod(from decl: DeclSyntax) -> (name: String, body: CodeBlockSyntax?)? {
-        if let functionDecl = decl.as(FunctionDeclSyntax.self) {
-            guard !isStatic(functionDecl.modifiers) else { return nil }
-            return (name: functionDecl.name.text, body: functionDecl.body)
-        } else if let initDecl = decl.as(InitializerDeclSyntax.self) {
-            return (name: "init", body: initDecl.body)
-        } else if let deinitDecl = decl.as(DeinitializerDeclSyntax.self) {
-            return (name: "deinit", body: deinitDecl.body)
-        }
-        return nil
-    }
-
-    /// Extracts stored properties from DeclSyntax
-    private func extractStoredProperties(from decl: DeclSyntax) -> [String] {
-        guard let variableDecl = decl.as(VariableDeclSyntax.self),
-            !isStatic(variableDecl.modifiers)
-        else { return [] }
-
-        return variableDecl.bindings.compactMap { binding in
-            guard let pattern = binding.pattern.as(IdentifierPatternSyntax.self),
-                binding.accessorBlock == nil
-            else { return nil }
-            return pattern.identifier.text
+            return .visitChildren
         }
     }
-
-    private func extractPropertyAccessFromSyntax(
-        methods: [(name: String, body: CodeBlockSyntax?)],
-        properties: [String]
-    ) -> [String: Set<String>] {
-        var methodToProperties: [String: Set<String>] = [:]
-
-        for method in methods {
-            guard let body = method.body else { continue }
-
-            var accessedProperties = Set<String>()
-            let visitor = PropertyAccessVisitor(properties: properties)
-            visitor.walk(body)
-            accessedProperties.formUnion(visitor.accessedProperties)
-
-            methodToProperties[method.name] = accessedProperties
-        }
-
-        return methodToProperties
-    }
-
-    private func extractMethodCallsFromSyntax(
-        methods: [(name: String, body: CodeBlockSyntax?)]
-    ) -> [(String, String)] {
-        var methodCalls: [(String, String)] = []
-        let methodNames = Set(methods.map(\.name))
-
-        for method in methods {
-            guard let body = method.body else { continue }
-
-            let visitor = MethodCallVisitor(methodNames: methodNames)
-            visitor.walk(body)
-
-            for calledMethod in visitor.calledMethods {
-                methodCalls.append((method.name, calledMethod))
-            }
-        }
-
-        return methodCalls
-    }
-
-}
-
-// MARK: - Syntax Visitors (Fallback)
-
-/// Visitor for detecting property access
-private class PropertyAccessVisitor: SyntaxVisitor {
-    let properties: [String]
-    var accessedProperties: Set<String> = []
-
-    init(properties: [String]) {
-        self.properties = properties
-        super.init(viewMode: .sourceAccurate)
-    }
-
-    override func visit(_ node: MemberAccessExprSyntax) -> SyntaxVisitorContinueKind {
-        if let base = node.base?.as(DeclReferenceExprSyntax.self),
-            base.baseName.text == "self"
-        {
-            let memberName = node.declName.baseName.text
-            if properties.contains(memberName) {
-                accessedProperties.insert(memberName)
-            }
-        }
-        return .visitChildren
-    }
-
-    override func visit(_ node: DeclReferenceExprSyntax) -> SyntaxVisitorContinueKind {
-        let name = node.baseName.text
-        if properties.contains(name) {
-            accessedProperties.insert(name)
-        }
-        return .visitChildren
-    }
-}
-
-/// Visitor for detecting method calls
-private class MethodCallVisitor: SyntaxVisitor {
-    let methodNames: Set<String>
-    var calledMethods: Set<String> = []
-
-    init(methodNames: Set<String>) {
-        self.methodNames = methodNames
-        super.init(viewMode: .sourceAccurate)
-    }
-
-    override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
-        if let memberAccess = node.calledExpression.as(MemberAccessExprSyntax.self) {
-            let methodName = memberAccess.declName.baseName.text
-            if methodNames.contains(methodName) {
-                calledMethods.insert(methodName)
-            }
-        } else if let declRef = node.calledExpression.as(DeclReferenceExprSyntax.self) {
-            let methodName = declRef.baseName.text
-            if methodNames.contains(methodName) {
-                calledMethods.insert(methodName)
-            }
-        }
-        return .visitChildren
-    }
-}
+#endif

--- a/Sources/SwiftComplexityCore/Analysis/TypeCouplingCalculator.swift
+++ b/Sources/SwiftComplexityCore/Analysis/TypeCouplingCalculator.swift
@@ -1,74 +1,76 @@
-import Foundation
-import IndexStoreDB
+#if IndexStore
+    import Foundation
+    import IndexStoreDB
 
-/// Computes type-level coupling in one whole-project pass.
-///
-/// A thin adapter: scans the index occurrences of every analyzed file,
-/// projects them into pure records, and delegates all attribution logic to
-/// `ReferenceGraphBuilder` (which is what the unit tests cover).
-actor TypeCouplingCalculator {
-    private let indexStore: SharedIndexStore
+    /// Computes type-level coupling in one whole-project pass.
+    ///
+    /// A thin adapter: scans the index occurrences of every analyzed file,
+    /// projects them into pure records, and delegates all attribution logic to
+    /// `ReferenceGraphBuilder` (which is what the unit tests cover).
+    actor TypeCouplingCalculator {
+        private let indexStore: SharedIndexStore
 
-    init(indexStore: SharedIndexStore) {
-        self.indexStore = indexStore
-    }
+        init(indexStore: SharedIndexStore) {
+            self.indexStore = indexStore
+        }
 
-    /// - Parameters:
-    ///   - analyzedFiles: All Swift files in this run; defines the
-    ///     project-internal type population.
-    ///   - typeRanges: Per-file syntax ranges from `TypeRangeCollector`.
-    /// - Returns: Couplings grouped by the file defining each type (sorted by
-    ///   location for deterministic output), plus attribution accounting.
-    func calculate(
-        analyzedFiles: [String],
-        typeRanges: [String: TypeRangeIndex]
-    ) -> (byFile: [String: [TypeCoupling]], diagnostics: CouplingDiagnostics) {
-        var records: [IndexOccurrenceRecord] = []
-        for file in analyzedFiles {
-            for occurrence in indexStore.database.symbolOccurrences(inFilePath: file) {
-                records.append(
-                    IndexOccurrenceRecord(
-                        usr: occurrence.symbol.usr,
-                        name: occurrence.symbol.name,
-                        kind: occurrence.symbol.kind,
-                        // The query path, not occurrence.location.path: it is
-                        // guaranteed to match typeRanges keys and the result
-                        // file paths.
-                        file: file,
-                        line: occurrence.location.line,
-                        column: occurrence.location.utf8Column,
-                        roles: occurrence.roles,
-                        relations: occurrence.relations.map {
-                            RecordRelation(
-                                usr: $0.symbol.usr, kind: $0.symbol.kind, roles: $0.roles)
-                        }
+        /// - Parameters:
+        ///   - analyzedFiles: All Swift files in this run; defines the
+        ///     project-internal type population.
+        ///   - typeRanges: Per-file syntax ranges from `TypeRangeCollector`.
+        /// - Returns: Couplings grouped by the file defining each type (sorted by
+        ///   location for deterministic output), plus attribution accounting.
+        func calculate(
+            analyzedFiles: [String],
+            typeRanges: [String: TypeRangeIndex]
+        ) -> (byFile: [String: [TypeCoupling]], diagnostics: CouplingDiagnostics) {
+            var records: [IndexOccurrenceRecord] = []
+            for file in analyzedFiles {
+                for occurrence in indexStore.database.symbolOccurrences(inFilePath: file) {
+                    records.append(
+                        IndexOccurrenceRecord(
+                            usr: occurrence.symbol.usr,
+                            name: occurrence.symbol.name,
+                            kind: occurrence.symbol.kind,
+                            // The query path, not occurrence.location.path: it is
+                            // guaranteed to match typeRanges keys and the result
+                            // file paths.
+                            file: file,
+                            line: occurrence.location.line,
+                            column: occurrence.location.utf8Column,
+                            roles: occurrence.roles,
+                            relations: occurrence.relations.map {
+                                RecordRelation(
+                                    usr: $0.symbol.usr, kind: $0.symbol.kind, roles: $0.roles)
+                            }
+                        ))
+                }
+            }
+
+            let (graph, diagnostics) = ReferenceGraphBuilder.build(
+                occurrences: records, typeRanges: typeRanges)
+
+            var byFile: [String: [TypeCoupling]] = [:]
+            for node in graph.nodes.values {
+                byFile[node.file, default: []].append(
+                    TypeCoupling(
+                        name: node.name,
+                        kind: node.kind,
+                        fanIn: graph.fanIn(of: node.usr),
+                        fanOut: graph.fanOut(of: node.usr),
+                        location: node.location,
+                        suppressedMetrics: node.suppressedMetrics.isEmpty
+                            ? nil : node.suppressedMetrics
                     ))
             }
-        }
-
-        let (graph, diagnostics) = ReferenceGraphBuilder.build(
-            occurrences: records, typeRanges: typeRanges)
-
-        var byFile: [String: [TypeCoupling]] = [:]
-        for node in graph.nodes.values {
-            byFile[node.file, default: []].append(
-                TypeCoupling(
-                    name: node.name,
-                    kind: node.kind,
-                    fanIn: graph.fanIn(of: node.usr),
-                    fanOut: graph.fanOut(of: node.usr),
-                    location: node.location,
-                    suppressedMetrics: node.suppressedMetrics.isEmpty
-                        ? nil : node.suppressedMetrics
-                ))
-        }
-        for (file, couplings) in byFile {
-            byFile[file] = couplings.sorted {
-                ($0.location.line, $0.location.column, $0.name)
-                    < ($1.location.line, $1.location.column, $1.name)
+            for (file, couplings) in byFile {
+                byFile[file] = couplings.sorted {
+                    ($0.location.line, $0.location.column, $0.name)
+                        < ($1.location.line, $1.location.column, $1.name)
+                }
             }
-        }
 
-        return (byFile, diagnostics)
+            return (byFile, diagnostics)
+        }
     }
-}
+#endif

--- a/Sources/SwiftComplexityCore/Models/TypeCoupling.swift
+++ b/Sources/SwiftComplexityCore/Models/TypeCoupling.swift
@@ -67,6 +67,32 @@ extension TypeCoupling: CustomStringConvertible {
     }
 }
 
+/// Attribution accounting for one coupling run. Every reference lands in
+/// exactly one attributed/dropped bucket, so:
+/// refsTotal == attributedByContainedBy + attributedByBaseOf
+///            + attributedByLocation + droppedNonProjectSymbol
+///            + droppedTypealias + droppedUnattributable.
+/// Self-references are attributed but produce no edge; they are additionally
+/// counted in `selfReferencesSkipped`.
+///
+/// Public so the CLI can report attribution quality to stderr; construction
+/// and mutation stay internal to the analysis.
+public struct CouplingDiagnostics: Sendable, Equatable {
+    public internal(set) var refsTotal = 0
+    public internal(set) var attributedByContainedBy = 0
+    public internal(set) var attributedByBaseOf = 0
+    public internal(set) var attributedByLocation = 0
+    public internal(set) var droppedNonProjectSymbol = 0
+    public internal(set) var droppedTypealias = 0
+    public internal(set) var droppedUnattributable = 0
+    public internal(set) var selfReferencesSkipped = 0
+
+    /// References that resolved to a source type (self-references included).
+    public var attributedTotal: Int {
+        attributedByContainedBy + attributedByBaseOf + attributedByLocation
+    }
+}
+
 /// Aggregated coupling statistics for one file's types.
 public struct CouplingSummary: Codable, Sendable {
     public let totalTypes: Int

--- a/Sources/SwiftComplexityCore/Processing/FileProcessor.swift
+++ b/Sources/SwiftComplexityCore/Processing/FileProcessor.swift
@@ -139,18 +139,22 @@ public actor FileProcessor: FileProcessing {
         analyzedFiles: [String],
         typeRanges: [String: TypeRangeIndex]
     ) async throws -> [ComplexityResult] {
-        guard let indexStore = analyzer.sharedIndexStore else {
+        #if IndexStore
+            guard let indexStore = analyzer.sharedIndexStore else {
+                throw FileProcessorError.indexStoreRequired
+            }
+
+            let calculator = TypeCouplingCalculator(indexStore: indexStore)
+            let (byFile, diagnostics) = await calculator.calculate(
+                analyzedFiles: analyzedFiles, typeRanges: typeRanges)
+            lastCouplingDiagnostics = diagnostics
+
+            // Every result gains coupling fields; an empty array (not nil) marks
+            // "coupling ran, this file defines no types".
+            return results.map { $0.attaching(typeCouplings: byFile[$0.filePath] ?? []) }
+        #else
             throw FileProcessorError.indexStoreRequired
-        }
-
-        let calculator = TypeCouplingCalculator(indexStore: indexStore)
-        let (byFile, diagnostics) = await calculator.calculate(
-            analyzedFiles: analyzedFiles, typeRanges: typeRanges)
-        lastCouplingDiagnostics = diagnostics
-
-        // Every result gains coupling fields; an empty array (not nil) marks
-        // "coupling ran, this file defines no types".
-        return results.map { $0.attaching(typeCouplings: byFile[$0.filePath] ?? []) }
+        #endif
     }
 
     private func collectSwiftFiles(from paths: [String], options: ProcessingOptions) async throws

--- a/Sources/SwiftComplexityMCP/ToolDefinitions.swift
+++ b/Sources/SwiftComplexityMCP/ToolDefinitions.swift
@@ -67,7 +67,8 @@ enum ToolDefinitions {
                 "index_store_path": .object([
                     "type": .string("string"),
                     "description": .string(
-                        "IndexStore path for LCOM4 analysis (required when lcom4 is true)"),
+                        "IndexStore path for LCOM4 analysis (required when lcom4 is true; needs a release binary or a build with --traits IndexStore)"
+                    ),
                 ]),
                 "toolchain_path": .object([
                     "type": .string("string"),

--- a/Tests/SwiftComplexityCLITests/SwiftComplexityCLITests.swift
+++ b/Tests/SwiftComplexityCLITests/SwiftComplexityCLITests.swift
@@ -111,6 +111,21 @@ struct CLIValidationTests {
         }
     }
 
+    #if !IndexStore
+        @Test("Index-backed flags fail fast when built without the IndexStore trait")
+        func indexBackedFlagsUnavailableWithoutTrait() async throws {
+            for flag in ["--lcom4", "--coupling"] {
+                let parsed = try ComplexityCommand.parse([
+                    "Sources", flag, "--index-store-path", ".build/debug/index/store",
+                ])
+                await #expect(throws: ExitCode.self) {
+                    var command = parsed
+                    try await command.run()
+                }
+            }
+        }
+    #endif
+
     @Test("Mutually exclusive flags validation concept")
     func mutuallyExclusiveFlagsValidation() {
         // This test validates the concept of mutually exclusive flags

--- a/Tests/SwiftComplexityCoreTests/GoldenCompatibilityTests.swift
+++ b/Tests/SwiftComplexityCoreTests/GoldenCompatibilityTests.swift
@@ -155,32 +155,35 @@ import Testing
             try expectMatchesGolden(output, "complexity_plain")
         }
 
-        @Test("LCOM4 JSON output matches the pre-coupling golden")
-        func lcom4OutputMatchesGolden() async throws {
-            // The store only needs to exist: fixture types are not indexed, so
-            // LCOM4 resolves through the deterministic syntax fallback — exactly
-            // how the golden was generated. `swift test` always builds first, so
-            // the debug index store is present in every supported flow.
-            let indexStore =
-                repoRoot
-                .appendingPathComponent(".build")
-                .appendingPathComponent("debug")
-                .appendingPathComponent("index")
-                .appendingPathComponent("store")
-            try #require(
-                FileManager.default.fileExists(atPath: indexStore.path),
-                "debug index store missing — run via `swift test` (not a bare Xcode test action)")
+        #if IndexStore
+            @Test("LCOM4 JSON output matches the pre-coupling golden")
+            func lcom4OutputMatchesGolden() async throws {
+                // The store only needs to exist: fixture types are not indexed, so
+                // LCOM4 resolves through the deterministic syntax fallback — exactly
+                // how the golden was generated. `swift test` always builds first, so
+                // the debug index store is present in every supported flow.
+                let indexStore =
+                    repoRoot
+                    .appendingPathComponent(".build")
+                    .appendingPathComponent("debug")
+                    .appendingPathComponent("index")
+                    .appendingPathComponent("store")
+                try #require(
+                    FileManager.default.fileExists(atPath: indexStore.path),
+                    "debug index store missing — run via `swift test` (not a bare Xcode test action)"
+                )
 
-            let analyzer = try ComplexityAnalyzer(indexStorePath: indexStore)
-            let processor = FileProcessor(analyzer: analyzer)
-            let results = try await processor.processFiles(
-                at: fixturePaths(), options: ProcessingOptions())
+                let analyzer = try ComplexityAnalyzer(indexStorePath: indexStore)
+                let processor = FileProcessor(analyzer: analyzer)
+                let results = try await processor.processFiles(
+                    at: fixturePaths(), options: ProcessingOptions())
 
-            let output = OutputFormatter().format(
-                results: results, format: .json, options: OutputOptions(showLCOM4: true))
+                let output = OutputFormatter().format(
+                    results: results, format: .json, options: OutputOptions(showLCOM4: true))
 
-            try expectMatchesGolden(output, "complexity_lcom4")
-        }
+                try expectMatchesGolden(output, "complexity_lcom4")
+            }
+        #endif
     }
 
 #endif

--- a/Tests/SwiftComplexityCoreTests/IndexStoreTraitTests.swift
+++ b/Tests/SwiftComplexityCoreTests/IndexStoreTraitTests.swift
@@ -6,9 +6,7 @@ import Testing
 @Suite("IndexStore trait")
 struct IndexStoreTraitTests {
 
-    /// CI exports this in every `--traits IndexStore` step. If the trait ever
-    /// stops reaching the test module, the index-backed suites are compiled
-    /// out silently; this turns that into a failure instead of a green run.
+    /// CI sets this env var in every --traits IndexStore step; without this check a trait that stops reaching the test module would silently compile the index suites out
     @Test("Trait reaches the test module when CI expects it")
     func traitReachesTests() {
         guard ProcessInfo.processInfo.environment["SWIFT_COMPLEXITY_EXPECT_INDEXSTORE_TRAIT"] != nil

--- a/Tests/SwiftComplexityCoreTests/IndexStoreTraitTests.swift
+++ b/Tests/SwiftComplexityCoreTests/IndexStoreTraitTests.swift
@@ -1,0 +1,38 @@
+import Foundation
+import Testing
+
+@testable import SwiftComplexityCore
+
+@Suite("IndexStore trait")
+struct IndexStoreTraitTests {
+
+    /// CI exports this in every `--traits IndexStore` step. If the trait ever
+    /// stops reaching the test module, the index-backed suites are compiled
+    /// out silently; this turns that into a failure instead of a green run.
+    @Test("Trait reaches the test module when CI expects it")
+    func traitReachesTests() {
+        guard ProcessInfo.processInfo.environment["SWIFT_COMPLEXITY_EXPECT_INDEXSTORE_TRAIT"] != nil
+        else { return }
+        #if !IndexStore
+            Issue.record(
+                "SWIFT_COMPLEXITY_EXPECT_INDEXSTORE_TRAIT is set but IndexStore is not compiled in")
+        #endif
+    }
+
+    #if !IndexStore
+        @Test("Opening an index store without the trait fails with a rebuild hint")
+        func analyzerRejectsIndexStoreWithoutTrait() {
+            let anyExistingPath = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+            #expect(throws: IndexStoreError.self) {
+                try ComplexityAnalyzer(indexStorePath: anyExistingPath)
+            }
+            do {
+                _ = try ComplexityAnalyzer(indexStorePath: anyExistingPath)
+            } catch let error as IndexStoreError {
+                #expect(error.localizedDescription.contains("--traits IndexStore"))
+            } catch {
+                Issue.record("Unexpected error type: \(error)")
+            }
+        }
+    #endif
+}

--- a/Tests/SwiftComplexityCoreTests/ReferenceGraphBuilderTests.swift
+++ b/Tests/SwiftComplexityCoreTests/ReferenceGraphBuilderTests.swift
@@ -1,435 +1,439 @@
-import Foundation
-import IndexStoreDB
-import Testing
+#if IndexStore
+    import Foundation
+    import IndexStoreDB
+    import Testing
 
-@testable import SwiftComplexityCore
+    @testable import SwiftComplexityCore
 
-/// Unit tests for the pure attribution algorithm. Records are hand-written
-/// stand-ins for IndexStoreDB occurrences; their relation shapes mirror what
-/// the coupling spike observed against a real index store.
-@Suite("Reference graph builder", .tags(.unit, .calculators))
-struct ReferenceGraphBuilderTests {
+    /// Unit tests for the pure attribution algorithm. Records are hand-written
+    /// stand-ins for IndexStoreDB occurrences; their relation shapes mirror what
+    /// the coupling spike observed against a real index store.
+    @Suite("Reference graph builder", .tags(.unit, .calculators))
+    struct ReferenceGraphBuilderTests {
 
-    // MARK: - Record helpers
+        // MARK: - Record helpers
 
-    private func def(
-        _ usr: String, _ name: String, _ kind: IndexSymbolKind,
-        file: String = "A.swift", at position: (line: Int, column: Int) = (1, 1),
-        childOf parent: String? = nil
-    ) -> IndexOccurrenceRecord {
-        IndexOccurrenceRecord(
-            usr: usr, name: name, kind: kind,
-            file: file, line: position.line, column: position.column,
-            roles: .definition,
-            relations: parent.map {
-                [RecordRelation(usr: $0, kind: .struct, roles: .childOf)]
-            } ?? [])
-    }
-
-    private func ref(
-        _ usr: String, kind: IndexSymbolKind = .struct,
-        file: String = "A.swift", at position: (line: Int, column: Int) = (50, 1),
-        containedBy container: String? = nil,
-        extendedBy extensionUSR: String? = nil,
-        baseOf conformer: String? = nil
-    ) -> IndexOccurrenceRecord {
-        var relations: [RecordRelation] = []
-        if let container {
-            relations.append(
-                RecordRelation(usr: container, kind: .instanceMethod, roles: .containedBy))
+        private func def(
+            _ usr: String, _ name: String, _ kind: IndexSymbolKind,
+            file: String = "A.swift", at position: (line: Int, column: Int) = (1, 1),
+            childOf parent: String? = nil
+        ) -> IndexOccurrenceRecord {
+            IndexOccurrenceRecord(
+                usr: usr, name: name, kind: kind,
+                file: file, line: position.line, column: position.column,
+                roles: .definition,
+                relations: parent.map {
+                    [RecordRelation(usr: $0, kind: .struct, roles: .childOf)]
+                } ?? [])
         }
-        if let extensionUSR {
-            relations.append(
-                RecordRelation(usr: extensionUSR, kind: .extension, roles: .extendedBy))
+
+        private func ref(
+            _ usr: String, kind: IndexSymbolKind = .struct,
+            file: String = "A.swift", at position: (line: Int, column: Int) = (50, 1),
+            containedBy container: String? = nil,
+            extendedBy extensionUSR: String? = nil,
+            baseOf conformer: String? = nil
+        ) -> IndexOccurrenceRecord {
+            var relations: [RecordRelation] = []
+            if let container {
+                relations.append(
+                    RecordRelation(usr: container, kind: .instanceMethod, roles: .containedBy))
+            }
+            if let extensionUSR {
+                relations.append(
+                    RecordRelation(usr: extensionUSR, kind: .extension, roles: .extendedBy))
+            }
+            if let conformer {
+                relations.append(
+                    RecordRelation(usr: conformer, kind: .struct, roles: .baseOf))
+            }
+            return IndexOccurrenceRecord(
+                usr: usr, name: usr, kind: kind,
+                file: file, line: position.line, column: position.column,
+                roles: .reference, relations: relations)
         }
-        if let conformer {
-            relations.append(
-                RecordRelation(usr: conformer, kind: .struct, roles: .baseOf))
+
+        /// A range index whose single entry spans the given lines of `file`.
+        private func rangeIndex(
+            _ name: String, kind: NominalType = .enum,
+            lines: ClosedRange<Int>
+        ) -> TypeRangeIndex {
+            TypeRangeIndex(entries: [
+                TypeRangeEntry(
+                    name: name, declKind: .nominal(kind),
+                    startLine: lines.lowerBound, startColumn: 1,
+                    endLine: lines.upperBound, endColumn: 80,
+                    suppressedMetrics: [])
+            ])
         }
-        return IndexOccurrenceRecord(
-            usr: usr, name: usr, kind: kind,
-            file: file, line: position.line, column: position.column,
-            roles: .reference, relations: relations)
-    }
 
-    /// A range index whose single entry spans the given lines of `file`.
-    private func rangeIndex(
-        _ name: String, kind: NominalType = .enum,
-        lines: ClosedRange<Int>
-    ) -> TypeRangeIndex {
-        TypeRangeIndex(entries: [
-            TypeRangeEntry(
-                name: name, declKind: .nominal(kind),
-                startLine: lines.lowerBound, startColumn: 1,
-                endLine: lines.upperBound, endColumn: 80,
-                suppressedMetrics: [])
-        ])
-    }
+        private func build(
+            _ occurrences: [IndexOccurrenceRecord],
+            typeRanges: [String: TypeRangeIndex] = [:]
+        ) -> (graph: ReferenceGraph, diagnostics: CouplingDiagnostics) {
+            ReferenceGraphBuilder.build(occurrences: occurrences, typeRanges: typeRanges)
+        }
 
-    private func build(
-        _ occurrences: [IndexOccurrenceRecord],
-        typeRanges: [String: TypeRangeIndex] = [:]
-    ) -> (graph: ReferenceGraph, diagnostics: CouplingDiagnostics) {
-        ReferenceGraphBuilder.build(occurrences: occurrences, typeRanges: typeRanges)
-    }
-
-    /// The standard two-type scenario: A.method references B.
-    private var basicScenario: [IndexOccurrenceRecord] {
-        [
-            def("s:A", "A", .struct),
-            def("s:A.m", "m()", .instanceMethod, childOf: "s:A"),
-            def("s:B", "B", .struct, at: (10, 1)),
-            ref("s:B", containedBy: "s:A.m"),
-        ]
-    }
-
-    // MARK: - Core attribution
-
-    @Test("Reference inside a method becomes an edge from the owning type")
-    func containedByAttribution() {
-        let (graph, diagnostics) = build(basicScenario)
-        #expect(graph.outEdges["s:A"] == ["s:B"])
-        #expect(graph.inEdges["s:B"] == ["s:A"])
-        #expect(diagnostics.attributedByContainedBy == 1)
-    }
-
-    @Test("Multi-hop childOf chains resolve to the innermost owning type")
-    func childOfChainResolution() {
-        // A reference contained by an accessor-like symbol nested under a
-        // method nested under the type.
-        let records = [
-            def("s:A", "A", .struct),
-            def("s:A.m", "m()", .instanceMethod, childOf: "s:A"),
-            def("s:A.m.acc", "get", .function, childOf: "s:A.m"),
-            def("s:B", "B", .struct, at: (10, 1)),
-            ref("s:B", containedBy: "s:A.m.acc"),
-        ]
-        let (graph, _) = build(records)
-        #expect(graph.outEdges["s:A"] == ["s:B"])
-    }
-
-    @Test("Members defined in extensions attribute to the extended type")
-    func extensionAttribution() {
-        let records = [
-            def("s:Foo", "Foo", .struct),
-            def("s:e:Foo", "Foo", .extension, at: (20, 1)),
-            // The `Foo` reference in `extension Foo` registers the mapping.
-            ref("s:Foo", at: (20, 11), extendedBy: "s:e:Foo"),
-            def("s:Foo.extra", "extra()", .instanceMethod, at: (21, 5), childOf: "s:e:Foo"),
-            def("s:Bar", "Bar", .struct, at: (30, 1)),
-            ref("s:Bar", at: (22, 9), containedBy: "s:Foo.extra"),
-        ]
-        let (graph, _) = build(records)
-        #expect(graph.outEdges["s:Foo"] == ["s:Bar"])
-    }
-
-    @Test("References to a member count toward the member's owning type")
-    func memberTargetResolution() {
-        // A.m references B.helper -> edge A -> B, not A -> helper.
-        let records = [
-            def("s:A", "A", .struct),
-            def("s:A.m", "m()", .instanceMethod, childOf: "s:A"),
-            def("s:B", "B", .struct, at: (10, 1)),
-            def("s:B.helper", "helper()", .instanceMethod, at: (11, 5), childOf: "s:B"),
-            ref("s:B.helper", kind: .instanceMethod, containedBy: "s:A.m"),
-        ]
-        let (graph, _) = build(records)
-        #expect(graph.outEdges["s:A"] == ["s:B"])
-    }
-
-    // MARK: - Aggregation
-
-    @Test("Fan counts aggregate distinct types over a small graph")
-    func fanAggregation() {
-        // A -> B, A -> C, C -> B
-        let records = [
-            def("s:A", "A", .struct),
-            def("s:A.m", "m()", .instanceMethod, childOf: "s:A"),
-            def("s:B", "B", .struct, at: (10, 1)),
-            def("s:C", "C", .struct, at: (20, 1)),
-            def("s:C.m", "m()", .instanceMethod, at: (21, 5), childOf: "s:C"),
-            ref("s:B", containedBy: "s:A.m"),
-            ref("s:C", containedBy: "s:A.m"),
-            ref("s:B", at: (60, 1), containedBy: "s:C.m"),
-        ]
-        let (graph, _) = build(records)
-        #expect(graph.fanOut(of: "s:A") == 2)
-        #expect(graph.fanIn(of: "s:A") == 0)
-        #expect(graph.fanOut(of: "s:B") == 0)
-        #expect(graph.fanIn(of: "s:B") == 2)
-        #expect(graph.fanOut(of: "s:C") == 1)
-        #expect(graph.fanIn(of: "s:C") == 1)
-    }
-
-    @Test("Repeated references to one type count once (distinct types)")
-    func distinctCounting() {
-        let records =
-            basicScenario + [
-                ref("s:B", at: (51, 1), containedBy: "s:A.m"),
-                ref("s:B", at: (52, 1), containedBy: "s:A.m"),
+        /// The standard two-type scenario: A.method references B.
+        private var basicScenario: [IndexOccurrenceRecord] {
+            [
+                def("s:A", "A", .struct),
+                def("s:A.m", "m()", .instanceMethod, childOf: "s:A"),
+                def("s:B", "B", .struct, at: (10, 1)),
+                ref("s:B", containedBy: "s:A.m"),
             ]
-        let (graph, _) = build(records)
-        #expect(graph.fanOut(of: "s:A") == 1)
-        #expect(graph.fanIn(of: "s:B") == 1)
-    }
+        }
 
-    @Test("Nested types are independent nodes; inner-outer references count")
-    func nestedTypesAreIndependent() {
-        let records = [
-            def("s:Outer", "Outer", .struct),
-            def("s:Outer.Inner", "Inner", .struct, at: (2, 5), childOf: "s:Outer"),
-            def("s:Outer.Inner.m", "m()", .instanceMethod, at: (3, 9), childOf: "s:Outer.Inner"),
-            ref("s:Outer", at: (3, 20), containedBy: "s:Outer.Inner.m"),
-        ]
-        let (graph, _) = build(records)
-        #expect(graph.outEdges["s:Outer.Inner"] == ["s:Outer"])
-        #expect(graph.nodes["s:Outer.Inner"] != nil)
-        #expect(graph.nodes["s:Outer"] != nil)
-    }
+        // MARK: - Core attribution
 
-    @Test("Mutual references stay directional")
-    func mutualReferences() {
-        let records = [
-            def("s:A", "A", .struct),
-            def("s:A.m", "m()", .instanceMethod, childOf: "s:A"),
-            def("s:B", "B", .struct, at: (10, 1)),
-            def("s:B.m", "m()", .instanceMethod, at: (11, 5), childOf: "s:B"),
-            ref("s:B", containedBy: "s:A.m"),
-            ref("s:A", at: (60, 1), containedBy: "s:B.m"),
-        ]
-        let (graph, _) = build(records)
-        #expect(graph.outEdges["s:A"] == ["s:B"])
-        #expect(graph.outEdges["s:B"] == ["s:A"])
-    }
+        @Test("Reference inside a method becomes an edge from the owning type")
+        func containedByAttribution() {
+            let (graph, diagnostics) = build(basicScenario)
+            #expect(graph.outEdges["s:A"] == ["s:B"])
+            #expect(graph.inEdges["s:B"] == ["s:A"])
+            #expect(diagnostics.attributedByContainedBy == 1)
+        }
 
-    // MARK: - Node metadata
-
-    @Test("Syntax ranges override the index kind (actor) and provide names")
-    func syntaxKindWins() {
-        let entry = TypeRangeEntry(
-            name: "MyActor", declKind: .nominal(.actor),
-            startLine: 1, startColumn: 1, endLine: 5, endColumn: 1,
-            suppressedMetrics: [.coupling])
-        let ranges = ["A.swift": TypeRangeIndex(entries: [entry])]
-        // The index reports actors as classes.
-        let records = [def("s:MyActor", "MyActor", .class, at: (1, 7))]
-
-        let (graph, _) = build(records, typeRanges: ranges)
-        #expect(graph.nodes["s:MyActor"]?.kind == .actor)
-        #expect(graph.nodes["s:MyActor"]?.suppressedMetrics == [.coupling])
-    }
-
-    @Test("Types without a syntax entry fall back to index metadata")
-    func fallbackToIndexMetadata() {
-        let (graph, _) = build([def("s:E", "E", .enum)])
-        #expect(graph.nodes["s:E"]?.kind == .enum)
-        #expect(graph.nodes["s:E"]?.name == "E")
-        #expect(graph.nodes["s:E"]?.suppressedMetrics == [])
-    }
-
-    // MARK: - Exclusions and robustness
-
-    @Test("Self references produce no edge but are accounted for")
-    func selfReferenceExcluded() {
-        let records = [
-            def("s:A", "A", .struct),
-            def("s:A.m", "m()", .instanceMethod, childOf: "s:A"),
-            def("s:A.other", "other()", .instanceMethod, at: (5, 5), childOf: "s:A"),
-            ref("s:A.other", kind: .instanceMethod, containedBy: "s:A.m"),
-        ]
-        let (graph, diagnostics) = build(records)
-        #expect(graph.outEdges["s:A"] == nil)
-        #expect(diagnostics.selfReferencesSkipped == 1)
-    }
-
-    @Test("References to symbols outside the analyzed files are dropped")
-    func nonProjectSymbolDropped() {
-        let records =
-            basicScenario + [
-                // No definition record exists for String: not a project symbol.
-                ref("s:Swift.String", at: (60, 1), containedBy: "s:A.m")
+        @Test("Multi-hop childOf chains resolve to the innermost owning type")
+        func childOfChainResolution() {
+            // A reference contained by an accessor-like symbol nested under a
+            // method nested under the type.
+            let records = [
+                def("s:A", "A", .struct),
+                def("s:A.m", "m()", .instanceMethod, childOf: "s:A"),
+                def("s:A.m.acc", "get", .function, childOf: "s:A.m"),
+                def("s:B", "B", .struct, at: (10, 1)),
+                ref("s:B", containedBy: "s:A.m.acc"),
             ]
-        let (graph, diagnostics) = build(records)
-        #expect(diagnostics.droppedNonProjectSymbol == 1)
-        #expect(graph.fanOut(of: "s:A") == 1)  // only the edge to B
+            let (graph, _) = build(records)
+            #expect(graph.outEdges["s:A"] == ["s:B"])
+        }
+
+        @Test("Members defined in extensions attribute to the extended type")
+        func extensionAttribution() {
+            let records = [
+                def("s:Foo", "Foo", .struct),
+                def("s:e:Foo", "Foo", .extension, at: (20, 1)),
+                // The `Foo` reference in `extension Foo` registers the mapping.
+                ref("s:Foo", at: (20, 11), extendedBy: "s:e:Foo"),
+                def("s:Foo.extra", "extra()", .instanceMethod, at: (21, 5), childOf: "s:e:Foo"),
+                def("s:Bar", "Bar", .struct, at: (30, 1)),
+                ref("s:Bar", at: (22, 9), containedBy: "s:Foo.extra"),
+            ]
+            let (graph, _) = build(records)
+            #expect(graph.outEdges["s:Foo"] == ["s:Bar"])
+        }
+
+        @Test("References to a member count toward the member's owning type")
+        func memberTargetResolution() {
+            // A.m references B.helper -> edge A -> B, not A -> helper.
+            let records = [
+                def("s:A", "A", .struct),
+                def("s:A.m", "m()", .instanceMethod, childOf: "s:A"),
+                def("s:B", "B", .struct, at: (10, 1)),
+                def("s:B.helper", "helper()", .instanceMethod, at: (11, 5), childOf: "s:B"),
+                ref("s:B.helper", kind: .instanceMethod, containedBy: "s:A.m"),
+            ]
+            let (graph, _) = build(records)
+            #expect(graph.outEdges["s:A"] == ["s:B"])
+        }
+
+        // MARK: - Aggregation
+
+        @Test("Fan counts aggregate distinct types over a small graph")
+        func fanAggregation() {
+            // A -> B, A -> C, C -> B
+            let records = [
+                def("s:A", "A", .struct),
+                def("s:A.m", "m()", .instanceMethod, childOf: "s:A"),
+                def("s:B", "B", .struct, at: (10, 1)),
+                def("s:C", "C", .struct, at: (20, 1)),
+                def("s:C.m", "m()", .instanceMethod, at: (21, 5), childOf: "s:C"),
+                ref("s:B", containedBy: "s:A.m"),
+                ref("s:C", containedBy: "s:A.m"),
+                ref("s:B", at: (60, 1), containedBy: "s:C.m"),
+            ]
+            let (graph, _) = build(records)
+            #expect(graph.fanOut(of: "s:A") == 2)
+            #expect(graph.fanIn(of: "s:A") == 0)
+            #expect(graph.fanOut(of: "s:B") == 0)
+            #expect(graph.fanIn(of: "s:B") == 2)
+            #expect(graph.fanOut(of: "s:C") == 1)
+            #expect(graph.fanIn(of: "s:C") == 1)
+        }
+
+        @Test("Repeated references to one type count once (distinct types)")
+        func distinctCounting() {
+            let records =
+                basicScenario + [
+                    ref("s:B", at: (51, 1), containedBy: "s:A.m"),
+                    ref("s:B", at: (52, 1), containedBy: "s:A.m"),
+                ]
+            let (graph, _) = build(records)
+            #expect(graph.fanOut(of: "s:A") == 1)
+            #expect(graph.fanIn(of: "s:B") == 1)
+        }
+
+        @Test("Nested types are independent nodes; inner-outer references count")
+        func nestedTypesAreIndependent() {
+            let records = [
+                def("s:Outer", "Outer", .struct),
+                def("s:Outer.Inner", "Inner", .struct, at: (2, 5), childOf: "s:Outer"),
+                def(
+                    "s:Outer.Inner.m", "m()", .instanceMethod, at: (3, 9), childOf: "s:Outer.Inner"),
+                ref("s:Outer", at: (3, 20), containedBy: "s:Outer.Inner.m"),
+            ]
+            let (graph, _) = build(records)
+            #expect(graph.outEdges["s:Outer.Inner"] == ["s:Outer"])
+            #expect(graph.nodes["s:Outer.Inner"] != nil)
+            #expect(graph.nodes["s:Outer"] != nil)
+        }
+
+        @Test("Mutual references stay directional")
+        func mutualReferences() {
+            let records = [
+                def("s:A", "A", .struct),
+                def("s:A.m", "m()", .instanceMethod, childOf: "s:A"),
+                def("s:B", "B", .struct, at: (10, 1)),
+                def("s:B.m", "m()", .instanceMethod, at: (11, 5), childOf: "s:B"),
+                ref("s:B", containedBy: "s:A.m"),
+                ref("s:A", at: (60, 1), containedBy: "s:B.m"),
+            ]
+            let (graph, _) = build(records)
+            #expect(graph.outEdges["s:A"] == ["s:B"])
+            #expect(graph.outEdges["s:B"] == ["s:A"])
+        }
+
+        // MARK: - Node metadata
+
+        @Test("Syntax ranges override the index kind (actor) and provide names")
+        func syntaxKindWins() {
+            let entry = TypeRangeEntry(
+                name: "MyActor", declKind: .nominal(.actor),
+                startLine: 1, startColumn: 1, endLine: 5, endColumn: 1,
+                suppressedMetrics: [.coupling])
+            let ranges = ["A.swift": TypeRangeIndex(entries: [entry])]
+            // The index reports actors as classes.
+            let records = [def("s:MyActor", "MyActor", .class, at: (1, 7))]
+
+            let (graph, _) = build(records, typeRanges: ranges)
+            #expect(graph.nodes["s:MyActor"]?.kind == .actor)
+            #expect(graph.nodes["s:MyActor"]?.suppressedMetrics == [.coupling])
+        }
+
+        @Test("Types without a syntax entry fall back to index metadata")
+        func fallbackToIndexMetadata() {
+            let (graph, _) = build([def("s:E", "E", .enum)])
+            #expect(graph.nodes["s:E"]?.kind == .enum)
+            #expect(graph.nodes["s:E"]?.name == "E")
+            #expect(graph.nodes["s:E"]?.suppressedMetrics == [])
+        }
+
+        // MARK: - Exclusions and robustness
+
+        @Test("Self references produce no edge but are accounted for")
+        func selfReferenceExcluded() {
+            let records = [
+                def("s:A", "A", .struct),
+                def("s:A.m", "m()", .instanceMethod, childOf: "s:A"),
+                def("s:A.other", "other()", .instanceMethod, at: (5, 5), childOf: "s:A"),
+                ref("s:A.other", kind: .instanceMethod, containedBy: "s:A.m"),
+            ]
+            let (graph, diagnostics) = build(records)
+            #expect(graph.outEdges["s:A"] == nil)
+            #expect(diagnostics.selfReferencesSkipped == 1)
+        }
+
+        @Test("References to symbols outside the analyzed files are dropped")
+        func nonProjectSymbolDropped() {
+            let records =
+                basicScenario + [
+                    // No definition record exists for String: not a project symbol.
+                    ref("s:Swift.String", at: (60, 1), containedBy: "s:A.m")
+                ]
+            let (graph, diagnostics) = build(records)
+            #expect(diagnostics.droppedNonProjectSymbol == 1)
+            #expect(graph.fanOut(of: "s:A") == 1)  // only the edge to B
+        }
+
+        @Test("Isolated types keep zero fan counts")
+        func isolatedType() {
+            let (graph, _) = build([def("s:Lonely", "Lonely", .struct)])
+            #expect(graph.nodes["s:Lonely"] != nil)
+            #expect(graph.fanIn(of: "s:Lonely") == 0)
+            #expect(graph.fanOut(of: "s:Lonely") == 0)
+        }
+
+        @Test("Corrupt parent cycles drop the reference instead of hanging")
+        func parentCycleGuard() {
+            let records = [
+                def("s:A", "A", .struct),
+                def("s:A.m", "m()", .instanceMethod, childOf: "s:A"),
+                // x and y form a childOf cycle and never reach a type.
+                def("s:x", "x", .function, at: (30, 1), childOf: "s:y"),
+                def("s:y", "y", .function, at: (31, 1), childOf: "s:x"),
+                def("s:B", "B", .struct, at: (10, 1)),
+                ref("s:B", containedBy: "s:x"),
+            ]
+            let (graph, diagnostics) = build(records)
+            #expect(graph.outEdges.isEmpty)
+            #expect(diagnostics.droppedUnattributable == 1)
+        }
+
+        @Test("Empty input builds an empty graph with zeroed diagnostics")
+        func emptyInput() {
+            let (graph, diagnostics) = build([])
+            #expect(graph.nodes.isEmpty)
+            #expect(graph.outEdges.isEmpty)
+            #expect(diagnostics == CouplingDiagnostics())
+        }
+
+        // MARK: - Fallback attribution
+
+        @Test("Conformance clauses recover edges through the baseOf relation")
+        func baseOfConformanceEdge() {
+            // `struct Foo: P` - the P reference has only a baseOf relation
+            // pointing at the conforming type.
+            let records = [
+                def("s:P", "P", .protocol),
+                def("s:Foo", "Foo", .struct, at: (10, 1)),
+                ref("s:P", kind: .protocol, at: (10, 13), baseOf: "s:Foo"),
+            ]
+            let (graph, diagnostics) = build(records)
+            #expect(graph.outEdges["s:Foo"] == ["s:P"])
+            #expect(diagnostics.attributedByBaseOf == 1)
+        }
+
+        @Test("Protocol fan-in counts every conformer")
+        func protocolFanIn() {
+            let records = [
+                def("s:P", "P", .protocol),
+                def("s:A", "A", .struct, at: (10, 1)),
+                def("s:B", "B", .class, at: (20, 1)),
+                def("s:C", "C", .enum, at: (30, 1)),
+                ref("s:P", kind: .protocol, at: (10, 11), baseOf: "s:A"),
+                ref("s:P", kind: .protocol, at: (20, 10), baseOf: "s:B"),
+                ref("s:P", kind: .protocol, at: (30, 10), baseOf: "s:C"),
+            ]
+            let (graph, _) = build(records)
+            #expect(graph.fanIn(of: "s:P") == 3)
+            #expect(graph.fanOut(of: "s:P") == 0)
+        }
+
+        @Test("Relation-free references attribute by source location")
+        func locationFallback() {
+            // `case wrapped(Outer)` - the Outer reference carries no relations;
+            // its position inside Payload's syntax range attributes it.
+            let records = [
+                def("s:Outer", "Outer", .struct, at: (1, 8)),
+                def("s:Payload", "Payload", .enum, at: (32, 6)),
+                ref("s:Outer", at: (33, 18)),
+            ]
+            let ranges = ["A.swift": rangeIndex("Payload", lines: 32...35)]
+            let (graph, diagnostics) = build(records, typeRanges: ranges)
+            #expect(graph.outEdges["s:Payload"] == ["s:Outer"])
+            #expect(diagnostics.attributedByLocation == 1)
+        }
+
+        @Test("Location fallback refuses ambiguous names without a same-file match")
+        func locationFallbackAmbiguity() {
+            // Two types named "Payload" in other files; the reference sits in a
+            // third file whose range says "Payload" - guessing would risk a wrong
+            // edge, so the reference is dropped.
+            let records = [
+                def("s:P1", "Payload", .enum, file: "B.swift"),
+                def("s:P2", "Payload", .enum, file: "C.swift"),
+                def("s:Outer", "Outer", .struct, at: (1, 8)),
+                ref("s:Outer", at: (33, 18)),
+            ]
+            let ranges = ["A.swift": rangeIndex("Payload", lines: 32...35)]
+            let (graph, diagnostics) = build(records, typeRanges: ranges)
+            #expect(graph.outEdges.isEmpty)
+            #expect(diagnostics.droppedUnattributable == 1)
+
+            // With one candidate in the same file, resolution succeeds.
+            let sameFile = [
+                def("s:P3", "Payload", .enum, at: (32, 6)),
+                def("s:P1", "Payload", .enum, file: "B.swift"),
+                def("s:Outer", "Outer", .struct, at: (1, 8)),
+                ref("s:Outer", at: (33, 18)),
+            ]
+            let (resolved, _) = build(sameFile, typeRanges: ranges)
+            #expect(resolved.outEdges["s:P3"] == ["s:Outer"])
+        }
+
+        @Test("Typealias references are excluded and counted")
+        func typealiasExcluded() {
+            let records = [
+                def("s:A", "A", .struct),
+                def("s:A.m", "m()", .instanceMethod, childOf: "s:A"),
+                def("s:Alias", "Alias", .typealias, at: (40, 1)),
+                ref("s:Alias", kind: .typealias, containedBy: "s:A.m"),
+            ]
+            let (graph, diagnostics) = build(records)
+            #expect(graph.outEdges.isEmpty)
+            #expect(diagnostics.droppedTypealias == 1)
+        }
+
+        @Test("References with no attribution evidence drop without throwing")
+        func unattributableDropped() {
+            let records = [
+                def("s:B", "B", .struct, at: (10, 1)),
+                // No relations, and no syntax range covers the location.
+                ref("s:B", at: (99, 1)),
+            ]
+            let (graph, diagnostics) = build(records)
+            #expect(graph.outEdges.isEmpty)
+            #expect(diagnostics.droppedUnattributable == 1)
+        }
+
+        @Test("containedBy wins over baseOf: one reference, one edge")
+        func containedByBeatsBaseOf() {
+            let records = [
+                def("s:P", "P", .protocol),
+                def("s:Foo", "Foo", .struct, at: (10, 1)),
+                def("s:Foo.m", "m()", .instanceMethod, at: (11, 5), childOf: "s:Foo"),
+                ref("s:P", kind: .protocol, containedBy: "s:Foo.m", baseOf: "s:Foo"),
+            ]
+            let (graph, diagnostics) = build(records)
+            #expect(graph.outEdges["s:Foo"] == ["s:P"])
+            #expect(diagnostics.attributedByContainedBy == 1)
+            #expect(diagnostics.attributedByBaseOf == 0)
+        }
+
+        @Test("Diagnostics buckets partition every reference")
+        func diagnosticsInvariant() {
+            let records = [
+                def("s:P", "P", .protocol),
+                def("s:A", "A", .struct, at: (10, 1)),
+                def("s:A.m", "m()", .instanceMethod, at: (11, 5), childOf: "s:A"),
+                def("s:B", "B", .struct, at: (20, 1)),
+                def("s:Alias", "Alias", .typealias, at: (40, 1)),
+                def("s:Payload", "Payload", .enum, at: (32, 6)),
+                ref("s:B", containedBy: "s:A.m"),  // containedBy
+                ref("s:P", kind: .protocol, at: (10, 11), baseOf: "s:A"),  // baseOf
+                ref("s:B", at: (33, 18)),  // location (inside Payload)
+                ref("s:Swift.Int", at: (51, 1), containedBy: "s:A.m"),  // non-project
+                ref("s:Alias", kind: .typealias, at: (52, 1), containedBy: "s:A.m"),  // typealias
+                ref("s:B", at: (99, 1)),  // unattributable
+                ref("s:A", at: (53, 1), containedBy: "s:A.m"),  // self reference
+            ]
+            let ranges = ["A.swift": rangeIndex("Payload", lines: 32...35)]
+            let (_, d) = build(records, typeRanges: ranges)
+
+            #expect(d.refsTotal == 7)
+            #expect(d.attributedByContainedBy == 2)  // edge to B + self reference
+            #expect(d.attributedByBaseOf == 1)
+            #expect(d.attributedByLocation == 1)
+            #expect(d.droppedNonProjectSymbol == 1)
+            #expect(d.droppedTypealias == 1)
+            #expect(d.droppedUnattributable == 1)
+            #expect(d.selfReferencesSkipped == 1)
+            // Cross-check the partition invariant documented on CouplingDiagnostics.
+            let attributed =
+                d.attributedByContainedBy + d.attributedByBaseOf + d.attributedByLocation
+            let dropped = d.droppedNonProjectSymbol + d.droppedTypealias + d.droppedUnattributable
+            #expect(d.refsTotal == attributed + dropped)
+        }
     }
-
-    @Test("Isolated types keep zero fan counts")
-    func isolatedType() {
-        let (graph, _) = build([def("s:Lonely", "Lonely", .struct)])
-        #expect(graph.nodes["s:Lonely"] != nil)
-        #expect(graph.fanIn(of: "s:Lonely") == 0)
-        #expect(graph.fanOut(of: "s:Lonely") == 0)
-    }
-
-    @Test("Corrupt parent cycles drop the reference instead of hanging")
-    func parentCycleGuard() {
-        let records = [
-            def("s:A", "A", .struct),
-            def("s:A.m", "m()", .instanceMethod, childOf: "s:A"),
-            // x and y form a childOf cycle and never reach a type.
-            def("s:x", "x", .function, at: (30, 1), childOf: "s:y"),
-            def("s:y", "y", .function, at: (31, 1), childOf: "s:x"),
-            def("s:B", "B", .struct, at: (10, 1)),
-            ref("s:B", containedBy: "s:x"),
-        ]
-        let (graph, diagnostics) = build(records)
-        #expect(graph.outEdges.isEmpty)
-        #expect(diagnostics.droppedUnattributable == 1)
-    }
-
-    @Test("Empty input builds an empty graph with zeroed diagnostics")
-    func emptyInput() {
-        let (graph, diagnostics) = build([])
-        #expect(graph.nodes.isEmpty)
-        #expect(graph.outEdges.isEmpty)
-        #expect(diagnostics == CouplingDiagnostics())
-    }
-
-    // MARK: - Fallback attribution
-
-    @Test("Conformance clauses recover edges through the baseOf relation")
-    func baseOfConformanceEdge() {
-        // `struct Foo: P` - the P reference has only a baseOf relation
-        // pointing at the conforming type.
-        let records = [
-            def("s:P", "P", .protocol),
-            def("s:Foo", "Foo", .struct, at: (10, 1)),
-            ref("s:P", kind: .protocol, at: (10, 13), baseOf: "s:Foo"),
-        ]
-        let (graph, diagnostics) = build(records)
-        #expect(graph.outEdges["s:Foo"] == ["s:P"])
-        #expect(diagnostics.attributedByBaseOf == 1)
-    }
-
-    @Test("Protocol fan-in counts every conformer")
-    func protocolFanIn() {
-        let records = [
-            def("s:P", "P", .protocol),
-            def("s:A", "A", .struct, at: (10, 1)),
-            def("s:B", "B", .class, at: (20, 1)),
-            def("s:C", "C", .enum, at: (30, 1)),
-            ref("s:P", kind: .protocol, at: (10, 11), baseOf: "s:A"),
-            ref("s:P", kind: .protocol, at: (20, 10), baseOf: "s:B"),
-            ref("s:P", kind: .protocol, at: (30, 10), baseOf: "s:C"),
-        ]
-        let (graph, _) = build(records)
-        #expect(graph.fanIn(of: "s:P") == 3)
-        #expect(graph.fanOut(of: "s:P") == 0)
-    }
-
-    @Test("Relation-free references attribute by source location")
-    func locationFallback() {
-        // `case wrapped(Outer)` - the Outer reference carries no relations;
-        // its position inside Payload's syntax range attributes it.
-        let records = [
-            def("s:Outer", "Outer", .struct, at: (1, 8)),
-            def("s:Payload", "Payload", .enum, at: (32, 6)),
-            ref("s:Outer", at: (33, 18)),
-        ]
-        let ranges = ["A.swift": rangeIndex("Payload", lines: 32...35)]
-        let (graph, diagnostics) = build(records, typeRanges: ranges)
-        #expect(graph.outEdges["s:Payload"] == ["s:Outer"])
-        #expect(diagnostics.attributedByLocation == 1)
-    }
-
-    @Test("Location fallback refuses ambiguous names without a same-file match")
-    func locationFallbackAmbiguity() {
-        // Two types named "Payload" in other files; the reference sits in a
-        // third file whose range says "Payload" - guessing would risk a wrong
-        // edge, so the reference is dropped.
-        let records = [
-            def("s:P1", "Payload", .enum, file: "B.swift"),
-            def("s:P2", "Payload", .enum, file: "C.swift"),
-            def("s:Outer", "Outer", .struct, at: (1, 8)),
-            ref("s:Outer", at: (33, 18)),
-        ]
-        let ranges = ["A.swift": rangeIndex("Payload", lines: 32...35)]
-        let (graph, diagnostics) = build(records, typeRanges: ranges)
-        #expect(graph.outEdges.isEmpty)
-        #expect(diagnostics.droppedUnattributable == 1)
-
-        // With one candidate in the same file, resolution succeeds.
-        let sameFile = [
-            def("s:P3", "Payload", .enum, at: (32, 6)),
-            def("s:P1", "Payload", .enum, file: "B.swift"),
-            def("s:Outer", "Outer", .struct, at: (1, 8)),
-            ref("s:Outer", at: (33, 18)),
-        ]
-        let (resolved, _) = build(sameFile, typeRanges: ranges)
-        #expect(resolved.outEdges["s:P3"] == ["s:Outer"])
-    }
-
-    @Test("Typealias references are excluded and counted")
-    func typealiasExcluded() {
-        let records = [
-            def("s:A", "A", .struct),
-            def("s:A.m", "m()", .instanceMethod, childOf: "s:A"),
-            def("s:Alias", "Alias", .typealias, at: (40, 1)),
-            ref("s:Alias", kind: .typealias, containedBy: "s:A.m"),
-        ]
-        let (graph, diagnostics) = build(records)
-        #expect(graph.outEdges.isEmpty)
-        #expect(diagnostics.droppedTypealias == 1)
-    }
-
-    @Test("References with no attribution evidence drop without throwing")
-    func unattributableDropped() {
-        let records = [
-            def("s:B", "B", .struct, at: (10, 1)),
-            // No relations, and no syntax range covers the location.
-            ref("s:B", at: (99, 1)),
-        ]
-        let (graph, diagnostics) = build(records)
-        #expect(graph.outEdges.isEmpty)
-        #expect(diagnostics.droppedUnattributable == 1)
-    }
-
-    @Test("containedBy wins over baseOf: one reference, one edge")
-    func containedByBeatsBaseOf() {
-        let records = [
-            def("s:P", "P", .protocol),
-            def("s:Foo", "Foo", .struct, at: (10, 1)),
-            def("s:Foo.m", "m()", .instanceMethod, at: (11, 5), childOf: "s:Foo"),
-            ref("s:P", kind: .protocol, containedBy: "s:Foo.m", baseOf: "s:Foo"),
-        ]
-        let (graph, diagnostics) = build(records)
-        #expect(graph.outEdges["s:Foo"] == ["s:P"])
-        #expect(diagnostics.attributedByContainedBy == 1)
-        #expect(diagnostics.attributedByBaseOf == 0)
-    }
-
-    @Test("Diagnostics buckets partition every reference")
-    func diagnosticsInvariant() {
-        let records = [
-            def("s:P", "P", .protocol),
-            def("s:A", "A", .struct, at: (10, 1)),
-            def("s:A.m", "m()", .instanceMethod, at: (11, 5), childOf: "s:A"),
-            def("s:B", "B", .struct, at: (20, 1)),
-            def("s:Alias", "Alias", .typealias, at: (40, 1)),
-            def("s:Payload", "Payload", .enum, at: (32, 6)),
-            ref("s:B", containedBy: "s:A.m"),  // containedBy
-            ref("s:P", kind: .protocol, at: (10, 11), baseOf: "s:A"),  // baseOf
-            ref("s:B", at: (33, 18)),  // location (inside Payload)
-            ref("s:Swift.Int", at: (51, 1), containedBy: "s:A.m"),  // non-project
-            ref("s:Alias", kind: .typealias, at: (52, 1), containedBy: "s:A.m"),  // typealias
-            ref("s:B", at: (99, 1)),  // unattributable
-            ref("s:A", at: (53, 1), containedBy: "s:A.m"),  // self reference
-        ]
-        let ranges = ["A.swift": rangeIndex("Payload", lines: 32...35)]
-        let (_, d) = build(records, typeRanges: ranges)
-
-        #expect(d.refsTotal == 7)
-        #expect(d.attributedByContainedBy == 2)  // edge to B + self reference
-        #expect(d.attributedByBaseOf == 1)
-        #expect(d.attributedByLocation == 1)
-        #expect(d.droppedNonProjectSymbol == 1)
-        #expect(d.droppedTypealias == 1)
-        #expect(d.droppedUnattributable == 1)
-        #expect(d.selfReferencesSkipped == 1)
-        // Cross-check the partition invariant documented on CouplingDiagnostics.
-        let attributed = d.attributedByContainedBy + d.attributedByBaseOf + d.attributedByLocation
-        let dropped = d.droppedNonProjectSymbol + d.droppedTypealias + d.droppedUnattributable
-        #expect(d.refsTotal == attributed + dropped)
-    }
-}
+#endif

--- a/docs/development/DEVELOPMENT.md
+++ b/docs/development/DEVELOPMENT.md
@@ -15,6 +15,20 @@ cd swift-complexity
 swift build
 ```
 
+A plain `swift build` is the default-trait build: every syntax-based metric,
+no `indexstore-db`. This is what Swift Package Index and consumers run, so keep
+it green. To work on LCOM4 or coupling, enable the `IndexStore` trait:
+
+```bash
+swift build --traits IndexStore
+swift test --traits IndexStore
+```
+
+Switching the trait recompiles the package (it changes compile flags), so
+stick to one mode per `.build` when iterating. Xcode's test action ignores
+traits and only runs the default-trait suites; run the index-backed tests from
+the command line.
+
 ### 2. Code Formatting
 
 This project uses `swift-format` for consistent code style via lefthook.
@@ -44,7 +58,8 @@ swift-format -ri Sources Tests
 ### 3. Running Tests
 
 ```bash
-swift test
+swift test                       # default traits (syntax-only)
+swift test --traits IndexStore   # adds the LCOM4 / coupling suites
 ```
 
 ### 4. Building and Running

--- a/docs/user-guide/ci-integration.md
+++ b/docs/user-guide/ci-integration.md
@@ -86,7 +86,9 @@ diff and in the repository's Security tab.
   build of your package produces, and the action runs on bare runners
   without building anything. To use them in CI, run the plain CLI in a job
   that executes `swift build` first (see below), passing
-  `--index-store-path .build/debug/index/store`.
+  `--index-store-path .build/debug/index/store`. The CLI itself must carry
+  the `IndexStore` trait: Homebrew and release binaries do; a from-source
+  build needs `swift build --traits IndexStore`.
 - Per-type thresholds and inline suppression comments work in CI exactly as
   they do locally — see the [Usage Guide](usage.md) for details.
 

--- a/docs/user-guide/coupling-metrics.md
+++ b/docs/user-guide/coupling-metrics.md
@@ -127,6 +127,10 @@ cannot contradict it.
 
 - Requires a **built index store** (`swift build` first). Index freshness is
   your responsibility: analyze after building, not after editing.
+- Requires a swift-complexity binary built with the `IndexStore` trait.
+  Homebrew and release binaries include it; when building from source, run
+  `swift build --traits IndexStore` (a default build exits with a rebuild
+  hint on `--coupling`).
 - Not available through the GitHub Action's zero-toolchain path (bare
   runners have no build). Run it in a job that builds your package — see
   [CI Integration](ci-integration.md).

--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -12,10 +12,16 @@
 ```bash
 git clone <repository-url>
 cd swift-complexity
-swift build --configuration release
+swift build --configuration release --traits IndexStore
 ```
 
 The executable will be available at `.build/release/swift-complexity`.
+
+`--traits IndexStore` enables the index-backed metrics (`--lcom4`, `--coupling`).
+It is off by default so the package builds on platforms where its
+`indexstore-db` dependency cannot; a build without it still provides every
+syntax-based metric and prints a rebuild hint if an index-backed flag is used.
+Homebrew and GitHub Releases binaries always include it.
 
 ### Option 2: Development Installation
 
@@ -24,7 +30,7 @@ For development or contributing:
 ```bash
 git clone <repository-url>
 cd swift-complexity
-swift build
+swift build --traits IndexStore
 ```
 
 Run with:


### PR DESCRIPTION
## Summary

Swift Package Index shows this package as **macOS-only** ([builds](https://swiftpackageindex.com/fummicc1/swift-complexity/builds)): every Linux/Wasm build fails inside `indexstore-db` with `fatal error: 'dispatch/dispatch.h' file not found`. Our CI only passes because it adds `-Xcxx -I<toolchain>/lib/swift{,/Block}` by hand; those flags target a dependency's C++ module and cannot be declared in `Package.swift`, and `.spi.yml` has no way to pass build flags or traits.

This PR moves `indexstore-db` behind a SwiftPM trait (SE-0450) named **`IndexStore`**, **off by default**:

- A plain `swift build` (what SPI and consumers run) no longer compiles IndexStoreDB at all, so the package builds wherever swift-syntax does.
- Public API and CLI flags are unchanged in every build. From a default build, `--lcom4` / `--coupling` exit 1 with a rebuild hint (`swift build --traits IndexStore` or install a release binary); `ComplexityAnalyzer(indexStorePath:)` throws `IndexStoreError.unavailableInThisBuild`.
- Release binaries, Homebrew (which downloads them), and the GitHub Action keep the trait enabled — prebuilt-binary users see no change.
- `CouplingDiagnostics` moves to `Models/` so the public type exists without the trait; `NominalTypeKind.symbolKind` moves next to its only user so `NominalTypeDetector` needs no IndexStoreDB import.

### CI

- Existing `test` job builds/tests with `--traits IndexStore` (including the debug build in the LCOM4 steps, since switching traits recompiles the package).
- New **Default traits (SPI parity)** job on macOS + Linux: `swift build` / `swift test` with no traits and no `-Xcxx`, then asserts the index-backed flags fail with the hint. This is the job that keeps the SPI badges from regressing.
- `release.yml` builds artifacts with `--traits IndexStore`; the release-notes "Build from Source" snippet includes the flag.
- `IndexStoreTraitTests` fails when `SWIFT_COMPLEXITY_EXPECT_INDEXSTORE_TRAIT` is set but the trait did not reach the test module (guards against index suites being silently compiled out).

### Not addressed here

- SwiftPM 6.2 does **not** prune trait-guarded dependencies by default (`--experimental-prune-unused-dependencies` is off), so `indexstore-db` is still resolved and `from:` requirements on this package remain rejected — #52 stays open.
- Swift 6.3 macOS (SPM) fails on `modelcontextprotocol/swift-sdk` 0.11.0 (`sending` diagnostics; fixed upstream in 0.12.1) and iOS fails because `MCP` requires iOS 16 while we declare 13. Both are separate PRs.
- Wasm may still fail on `SwiftComplexityMCP` / swift-sdk; this PR targets Linux. Will record the SPI result after merge.

Intended for **v1.5.0**: no API is removed, but the default from-source build behaviour changes; release notes should say so.

## Test plan

- [x] `swift build` / `swift test` (default traits, macOS): 171 tests pass; `Package.resolved` pins unchanged (only `originHash`)
- [x] Clean `swift build --scratch-path` with default traits: no `IndexStoreDB*`/`CLMDB` build products; `--lcom4` and `--coupling` exit 1 with the rebuild hint
- [x] `swift build --traits IndexStore` / `swift test --traits IndexStore`: 193 tests pass; `-DIndexStore` reaches all 6 modules (verified with `-v`)
- [x] ci.yml LCOM4 / coupling end-to-end commands (jq invariants, threshold gate exit 1/0) pass on macOS with the trait-enabled binary
- [x] CI: `Default traits (SPI parity)` green on ubuntu-22.04 (plain `swift build` + `swift test`, no `-Xcxx`) — all 11 checks pass
- [ ] After merge: SPI rebuilds `main`; Swift 6.2 Linux should turn green

https://claude.ai/code/session_01MXd4nnugT4HRYxMSVtSPiR
