### PR TITLE
Update modelcontextprotocol/swift-sdk to 0.12.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,9 +54,9 @@ jobs:
       - name: Cache Swift packages
         uses: actions/cache@v5
         with:
-          path: |
-            .build
-            Package.resolved
+          # Package.resolved is tracked in git and must not be restored from an
+          # older cache entry, or a dependency bump builds against the old pins.
+          path: .build
           key: ${{ runner.os }}-swift-${{ matrix.swift-version }}-${{ hashFiles('Package.swift', 'Package.resolved') }}
           restore-keys: |
             ${{ runner.os }}-swift-${{ matrix.swift-version }}-

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -115,9 +115,9 @@ jobs:
       - name: Cache Swift packages
         uses: actions/cache@v5
         with:
-          path: |
-            .build
-            Package.resolved
+          # Package.resolved is tracked in git and must not be restored from an
+          # older cache entry, or a dependency bump builds against the old pins.
+          path: .build
           key: ${{ runner.os }}-swift-pr-${{ hashFiles('Package.swift', 'Package.resolved') }}
 
       - name: Build PR changes

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "fdd42d36229efe69fb6daa073bf33703ba4b83319e29f64dd3de0ffe82feb48e",
+  "originHash" : "79e19fb8c20ec3ef32247b520a243130404443f8e7620d5f6ee1a144136ce066",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -26,15 +26,6 @@
       "state" : {
         "revision" : "309a47b2b1d9b5e991f36961c983ecec72275be3",
         "version" : "1.6.1"
-      }
-    },
-    {
-      "identity" : "swift-async-algorithms",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-async-algorithms.git",
-      "state" : {
-        "revision" : "9d349bcc328ac3c31ce40e746b5882742a0d1272",
-        "version" : "1.1.3"
       }
     },
     {
@@ -87,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/modelcontextprotocol/swift-sdk.git",
       "state" : {
-        "revision" : "6112a3995a992d159ad0e82c2d62a008ce932666",
-        "version" : "0.11.0"
+        "revision" : "a0ae212ebf6eab5f754c3129608bc5557637e605",
+        "version" : "0.12.1"
       }
     },
     {

--- a/Sources/SwiftComplexityMCP/Handlers/AnalyzeCodeStringHandler.swift
+++ b/Sources/SwiftComplexityMCP/Handlers/AnalyzeCodeStringHandler.swift
@@ -8,7 +8,9 @@ enum AnalyzeCodeStringHandler {
         // Extract required parameter
         guard let code = ParamExtractor.string("code", from: arguments) else {
             return .init(
-                content: [.text("Error: 'code' parameter is required")],
+                content: [
+                    .text(text: "Error: 'code' parameter is required", annotations: nil, _meta: nil)
+                ],
                 isError: true)
         }
 
@@ -28,10 +30,15 @@ enum AnalyzeCodeStringHandler {
             )
             let output = formatter.format(results: [result], format: .json, options: outputOptions)
 
-            return .init(content: [.text(output)], isError: false)
+            return .init(
+                content: [.text(text: output, annotations: nil, _meta: nil)], isError: false)
 
         } catch {
-            return .init(content: [.text("Error: \(error.localizedDescription)")], isError: true)
+            return .init(
+                content: [
+                    .text(
+                        text: "Error: \(error.localizedDescription)", annotations: nil, _meta: nil)
+                ], isError: true)
         }
     }
 }

--- a/Sources/SwiftComplexityMCP/Handlers/AnalyzeComplexityHandler.swift
+++ b/Sources/SwiftComplexityMCP/Handlers/AnalyzeComplexityHandler.swift
@@ -11,7 +11,9 @@ enum AnalyzeComplexityHandler {
         else {
             return .init(
                 content: [
-                    .text("Error: 'paths' parameter is required and must be a non-empty array")
+                    .text(
+                        text: "Error: 'paths' parameter is required and must be a non-empty array",
+                        annotations: nil, _meta: nil)
                 ],
                 isError: true)
         }
@@ -32,7 +34,10 @@ enum AnalyzeComplexityHandler {
         if cyclomaticOnly && cognitiveOnly {
             return .init(
                 content: [
-                    .text("Error: 'cyclomatic_only' and 'cognitive_only' are mutually exclusive")
+                    .text(
+                        text:
+                            "Error: 'cyclomatic_only' and 'cognitive_only' are mutually exclusive",
+                        annotations: nil, _meta: nil)
                 ],
                 isError: true)
         }
@@ -41,7 +46,9 @@ enum AnalyzeComplexityHandler {
         if lcom4 && indexStorePath == nil {
             return .init(
                 content: [
-                    .text("Error: 'index_store_path' is required when 'lcom4' is true")
+                    .text(
+                        text: "Error: 'index_store_path' is required when 'lcom4' is true",
+                        annotations: nil, _meta: nil)
                 ],
                 isError: true)
         }
@@ -53,7 +60,11 @@ enum AnalyzeComplexityHandler {
                 configuration = try ThresholdConfiguration.load(fromFileAtPath: configPath)
             } catch {
                 return .init(
-                    content: [.text("Error: \(error.localizedDescription)")], isError: true)
+                    content: [
+                        .text(
+                            text: "Error: \(error.localizedDescription)", annotations: nil,
+                            _meta: nil)
+                    ], isError: true)
             }
         } else {
             configuration = .empty
@@ -103,10 +114,15 @@ enum AnalyzeComplexityHandler {
             let formatter = OutputFormatter()
             let output = formatter.format(results: results, format: format, options: outputOptions)
 
-            return .init(content: [.text(output)], isError: false)
+            return .init(
+                content: [.text(text: output, annotations: nil, _meta: nil)], isError: false)
 
         } catch {
-            return .init(content: [.text("Error: \(error.localizedDescription)")], isError: true)
+            return .init(
+                content: [
+                    .text(
+                        text: "Error: \(error.localizedDescription)", annotations: nil, _meta: nil)
+                ], isError: true)
         }
     }
 

--- a/Sources/SwiftComplexityMCP/ToolRouter.swift
+++ b/Sources/SwiftComplexityMCP/ToolRouter.swift
@@ -9,7 +9,10 @@ enum ToolRouter {
         case "analyze_code_string":
             return await AnalyzeCodeStringHandler.handle(params.arguments)
         default:
-            return .init(content: [.text("Unknown tool: \(params.name)")], isError: true)
+            return .init(
+                content: [
+                    .text(text: "Unknown tool: \(params.name)", annotations: nil, _meta: nil)
+                ], isError: true)
         }
     }
 }

--- a/Tests/SwiftComplexityMCPTests/SwiftComplexityMCPTests.swift
+++ b/Tests/SwiftComplexityMCPTests/SwiftComplexityMCPTests.swift
@@ -82,7 +82,7 @@ struct AnalyzeCodeStringHandlerTests {
     /// Helper to extract text content from a CallTool.Result
     private func textContent(_ result: CallTool.Result) -> String? {
         result.content.first.flatMap {
-            if case .text(let t) = $0 { return t }
+            if case .text(let t, _, _) = $0 { return t }
             return nil
         }
     }
@@ -102,7 +102,7 @@ struct AnalyzeCodeStringHandlerTests {
 
         #expect(result.isError != true)
         let text = result.content.first.flatMap {
-            if case .text(let t) = $0 { return t }
+            if case .text(let t, _, _) = $0 { return t }
             return nil
         }
         #expect(text != nil)
@@ -120,7 +120,7 @@ struct AnalyzeCodeStringHandlerTests {
 
         #expect(result.isError != true)
         let text = result.content.first.flatMap {
-            if case .text(let t) = $0 { return t }
+            if case .text(let t, _, _) = $0 { return t }
             return nil
         }
         #expect(text?.contains("test.swift") == true)
@@ -169,7 +169,7 @@ struct AnalyzeComplexityHandlerValidationTests {
         #expect(result.isError == true)
 
         let text = result.content.first.flatMap {
-            if case .text(let t) = $0 { return t }
+            if case .text(let t, _, _) = $0 { return t }
             return nil
         }
         #expect(text?.contains("mutually exclusive") == true)
@@ -185,7 +185,7 @@ struct AnalyzeComplexityHandlerValidationTests {
         #expect(result.isError == true)
 
         let text = result.content.first.flatMap {
-            if case .text(let t) = $0 { return t }
+            if case .text(let t, _, _) = $0 { return t }
             return nil
         }
         #expect(text?.contains("index_store_path") == true)
@@ -330,7 +330,7 @@ struct ThresholdFilteringTests {
 struct AnalyzeComplexityConfigPathTests {
     private func textContent(_ result: CallTool.Result) -> String? {
         result.content.first.flatMap {
-            if case .text(let t) = $0 { return t }
+            if case .text(let t, _, _) = $0 { return t }
             return nil
         }
     }
@@ -416,7 +416,7 @@ struct ToolRouterTests {
         #expect(result.isError == true)
 
         let text = result.content.first.flatMap {
-            if case .text(let t) = $0 { return t }
+            if case .text(let t, _, _) = $0 { return t }
             return nil
         }
         #expect(text?.contains("Unknown tool") == true)


### PR DESCRIPTION
## Summary

Swift Package Index fails the **Swift 6.3 / macOS (SPM)** build inside `modelcontextprotocol/swift-sdk` 0.11.0 ([log](https://swiftpackageindex.com/builds/EE2F1059-BD4E-4F1A-B2DC-63470D027467)):

```
swift-sdk/Sources/MCP/Base/Transports/NetworkTransport.swift:532:33:
error: sending 'sendContinuationResumed' risks causing data races
```

0.12.1 (2026-05-07) fixes it by boxing the flags in `MainFlag`. Follow-up to #54.

- `Package.resolved`: swift-sdk 0.11.0 → 0.12.1; `swift-async-algorithms` is no longer in the graph. `indexstore-db` / `swift-lmdb` are kept on their previous `main` revisions (a plain `swift package update` moves them, so they were restored by hand — bumping them is a separate decision).
- API change in 0.12: `Tool.Content.text` is now `text(text:annotations:_meta:)`; the old `.text(_:)` / `.text(text:metadata:)` factories are deprecated. Handlers use the full case; tests destructure `.text(let t, _, _)`. No behaviour change.

- CI: `actions/cache` restored `Package.resolved` alongside `.build` (with a prefix `restore-keys`), so the first CI run compiled against the cached 0.11.0 pins and failed with `type 'Any' has no member 'text'`. `ci.yml` and `pr-validation.yml` now cache only `.build`; `Package.resolved` is tracked in git.

## Test plan

- [x] `swift build` / `swift test` (default traits): 171 tests pass, no deprecation warnings
- [x] `swift build --traits IndexStore` / `swift test --traits IndexStore`: 193 tests pass
- [ ] After merge: SPI Swift 6.3 macOS (SPM) turns green (cannot run 6.3 locally; fix verified in swift-sdk source)

https://claude.ai/code/session_01MXd4nnugT4HRYxMSVtSPiR
