### PR TITLE
Raise the iOS deployment target to 16

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
   name: "swift-complexity",
   platforms: [
     .macOS(.v14),
-    .iOS(.v13),
+    .iOS(.v16),
   ],
   products: [
     .library(

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A command-line tool to analyze Swift code complexity and quality metrics using s
 - **Multiple Output Formats**: Text, JSON, XML, Xcode diagnostics, and SARIF output for different use cases
 - **Flexible Analysis**: Single files, directories, or recursive directory analysis
 - **Swift Syntax Based**: Uses `swift-syntax` for accurate Swift code parsing
-- **Cross-Platform Support**: CLI works on macOS and Linux, library works on iOS 13+. Index-backed metrics (LCOM4, coupling) live behind the opt-in `IndexStore` SwiftPM trait, so the package itself builds wherever swift-syntax does; release binaries ship with the trait enabled.
+- **Cross-Platform Support**: CLI works on macOS and Linux, library works on iOS 16+. Index-backed metrics (LCOM4, coupling) live behind the opt-in `IndexStore` SwiftPM trait, so the package itself builds wherever swift-syntax does; release binaries ship with the trait enabled.
 - **MCP Server**: Expose complexity analysis as tools for LLM agents (Claude Code, etc.) via Model Context Protocol
 - **Claude Plugin**: Ready-to-use Claude Code plugin with MCP server and analysis skill
 - **Extensible Architecture**: Designed to support additional quality metrics in the future
@@ -214,7 +214,7 @@ Unified package with multiple components:
 
 ### Core Package
 
-- **SwiftComplexityCore**: Core analysis library (supports macOS 14+, iOS 13+). Add `traits: ["IndexStore"]` to your `.package(...)` declaration to include LCOM4 and coupling analysis
+- **SwiftComplexityCore**: Core analysis library (supports macOS 14+, iOS 16+). Add `traits: ["IndexStore"]` to your `.package(...)` declaration to include LCOM4 and coupling analysis
 - **SwiftComplexityCLI**: Command-line interface
 - **SwiftComplexityMCP**: MCP server for LLM agent integration
 - **SwiftComplexityPlugin**: Xcode Build Tool Plugin
@@ -449,7 +449,7 @@ and `lcom4_cohesion`) with `warning` level, escalating to `error` at twice the t
 ### Core Library
 
 - Swift 6.2+
-- macOS 14+, iOS 13+, or Linux
+- macOS 14+, iOS 16+, or Linux
 
 ### Index-Backed Metrics: LCOM4 and Coupling (Optional)
 


### PR DESCRIPTION
## Summary

Swift Package Index fails every iOS / tvOS / watchOS / visionOS build at build-description time ([log](https://swiftpackageindex.com/builds/815B5BB6-0D4E-4C49-A1C6-5E0B63932FD8)):

```
error: The package product 'MCP' requires minimum platform version 16.0 for the iOS platform,
but this target supports 13.0 (in target 'SwiftComplexityMCP' from project 'swift-complexity')
```

`platforms` is package-wide, so the executable's dependency floor applies to the whole scheme. Nothing in Core needs anything below iOS 16, so the declared floor moves from 13 to 16 and the README states it. Follow-up to #54.

Requires #55 (merged): with iOS 16 the platform error goes away, but the iOS compile then hits the same swift-sdk 0.11.0 `sending` diagnostics that broke Swift 6.3 on macOS, so this only turns green on top of the swift-sdk bump.

## Test plan

- [x] SPI's exact command locally on top of #55: `xcodebuild -skipMacroValidation -skipPackagePluginValidation build -scheme swift-complexity-Package -destination generic/platform=iOS` → **BUILD SUCCEEDED** (on `main` + this change alone it fails in swift-sdk 0.11.0's `NetworkTransport.swift`)
- [x] `swift build` on macOS still passes
- [ ] After merge: SPI iOS (and the other Apple platforms) turn green

https://claude.ai/code/session_01MXd4nnugT4HRYxMSVtSPiR
