### PR TITLE
chore: Bump version to 1.5.0

### DIFF
--- a/Sources/SwiftComplexityCore/Version.swift
+++ b/Sources/SwiftComplexityCore/Version.swift
@@ -3,5 +3,5 @@
 /// Referenced by the CLI (`--version`), the MCP server handshake, and the
 /// SARIF `tool.driver.version` field so a release bump happens in one place.
 public enum SwiftComplexityVersion {
-    public static let current = "1.4.0"
+    public static let current = "1.5.0"
 }


### PR DESCRIPTION
## Summary

Bumps `SwiftComplexityVersion.current` to 1.5.0 ahead of the release. The release workflow takes the version from its `workflow_dispatch` input and never checks `Version.swift`, so run 34718817708 (dispatched as 1.5.0 while `main` still said 1.4.0) was cancelled before it created the tag, the GitHub Release, or the Homebrew update; re-dispatch after this merges.

1.5.0 ships #54 (IndexStore trait; SPI Linux), #55 (swift-sdk 0.12.1; Swift 6.3), and #56 (iOS 16 floor).

## Test plan

- [x] One-line change; CI builds and tests it
- [ ] After merge: `workflow_dispatch` the Release workflow with `version: 1.5.0`

https://claude.ai/code/session_01MXd4nnugT4HRYxMSVtSPiR